### PR TITLE
Task generator

### DIFF
--- a/lib/generators/tw_task/USAGE
+++ b/lib/generators/tw_task/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Explain the generator
+
+Example:
+    rails generate tw_task Thing
+
+    This will create:
+        what/will/it/create

--- a/lib/generators/tw_task/USAGE
+++ b/lib/generators/tw_task/USAGE
@@ -1,8 +1,86 @@
 Description:
-    Explain the generator
+    Stubs out the basic needed files for creating a TaxonWorks task
 
 Example:
-    rails generate tw_task Thing
+    rails generate tw_task fasta_load "sequence/" index:get:get_fast_load verify:post:verify_task_name replace:put
 
-    This will create:
-        what/will/it/create
+    controller_base_name = fasta_load
+
+    path_to_controller = "sequence/"
+    
+    methods_actions_names = index:get:get_fast_load verify:post:verify_task_name replace:put
+        format: method_name:action:route_name
+            method_name: 
+                verify
+            action: 
+                get
+                put
+                post
+                patch 
+                etc
+            route_name OPTIONAL note- '_task' will automatically be appended: 
+                task_name
+    
+    The result of this command will be
+        insert  config/routes.rb
+        append  config/interface/hub/user_tasks.yml
+        create  app/controllers/tasks/sequence/fasta_load_controller.rb
+        create  app/views/tasks/sequence/fasta_load/index.html.erb
+        create  app/views/tasks/sequence/fasta_load/verify.html.erb
+        create  app/views/tasks/sequence/fasta_load/replace.html.erb
+
+        This assumes the "task" scope has already been declared in the routes.rb file.
+        Any parent scopes that don't exist for the controller besides the 'task' scope
+        will otherwise be procedurally generated. If the scope for the controller already
+        exists then the generate will quit. Below is what will be in the following files,
+        the view files will be empty.
+
+        insert config/routes.rb:
+            scope :sequence do
+                scope :fasta_load, controller: 'tasks/sequence/fasta_load' do
+                    get 'index', as: 'get_fast_load_task'
+                    post 'verify', as: 'verify_task_name_task'
+                    put 'replace', as: 'put_fasta_load_task'
+                end
+            end
+
+        append  config/interface/hub/user_tasks.yml:
+            fasta_load_index_task:
+                hub: true
+                name: 'TODO'
+                related:
+                categories:
+                status: prototype
+                description: 'FILL ME IN'
+            fasta_load_verify_task:
+                hub: true
+                name: 'TODO'
+                related:
+                categories:
+                status: prototype
+                description: 'FILL ME IN'
+            fasta_load_replace_task:
+                hub: true
+                name: 'TODO'
+                related:
+                categories:
+                status: prototype
+                description: 'FILL ME IN'
+
+        create  app/controllers/tasks/sequence/fasta_load_controller.rb:
+            class Tasks::Sequence::FastaLoadController < ApplicationController
+                include TaskControllerConfigration
+
+                # GET
+                def index
+                end
+
+                # POST
+                def verify
+                end
+
+                # PUT
+                def replace
+                end
+
+            end

--- a/lib/generators/tw_task/USAGE
+++ b/lib/generators/tw_task/USAGE
@@ -18,7 +18,8 @@ Example:
                 post
                 patch 
                 etc
-            route_name OPTIONAL note- '_task' will automatically be appended: 
+            route_name OPTIONAL, if none is provided one will be made in the format of method_name + controller_base_name + '_task
+                otherwise '_task' will be appended to route_name: 
                 task_name
     
     The result of this command will be
@@ -40,36 +41,36 @@ Example:
                 scope :fasta_load, controller: 'tasks/sequence/fasta_load' do
                     get 'index', as: 'get_fast_load_task'
                     post 'verify', as: 'verify_task_name_task'
-                    put 'replace', as: 'put_fasta_load_task'
+                    put 'replace', as: 'replace_fasta_load_task'
                 end
             end
 
         append  config/interface/hub/user_tasks.yml:
             fasta_load_index_task:
                 hub: true
-                name: 'TODO'
+                name: 'TODO: Task name'
                 related:
                 categories:
                 status: prototype
-                description: 'FILL ME IN'
+                description: 'TODO: Task description'
             fasta_load_verify_task:
                 hub: true
-                name: 'TODO'
+                name: 'TODO: Task name'
                 related:
                 categories:
                 status: prototype
-                description: 'FILL ME IN'
+                description: 'TODO: Task description'
             fasta_load_replace_task:
                 hub: true
-                name: 'TODO'
+                name: 'TODO: Task name'
                 related:
                 categories:
                 status: prototype
-                description: 'FILL ME IN'
+                description: 'TODO: Task description'
 
         create  app/controllers/tasks/sequence/fasta_load_controller.rb:
             class Tasks::Sequence::FastaLoadController < ApplicationController
-                include TaskControllerConfigration
+                include TaskControllerConfiguration
 
                 # GET
                 def index

--- a/lib/generators/tw_task/templates/controller.tt
+++ b/lib/generators/tw_task/templates/controller.tt
@@ -1,7 +1,7 @@
 class <%= full_controller_class_name %> < ApplicationController
   include TaskControllerConfigration
-  
-<% @route_methods.each do |method_name| %>
+<% @route_methods.each_with_index do |method_name, index| %>
+  # <%= @route_actions[index].upcase %>
   def <%= method_name %>
   end
 <% end %>

--- a/lib/generators/tw_task/templates/controller.tt
+++ b/lib/generators/tw_task/templates/controller.tt
@@ -1,5 +1,5 @@
 class <%= full_controller_class_name %> < ApplicationController
-  include TaskControllerConfigration
+  include TaskControllerConfiguration
 <% @route_methods.each_with_index do |method_name, index| %>
   # <%= @route_actions[index].upcase %>
   def <%= method_name %>

--- a/lib/generators/tw_task/templates/controller.tt
+++ b/lib/generators/tw_task/templates/controller.tt
@@ -1,0 +1,8 @@
+class <%= full_controller_class_name %> < ApplicationController
+  include TaskControllerConfigration
+  
+<% @route_methods.each do |method_name| %>
+  def <%= method_name %>
+  end
+<% end %>
+end

--- a/lib/generators/tw_task/tw_task_generator.rb
+++ b/lib/generators/tw_task/tw_task_generator.rb
@@ -17,7 +17,7 @@ class TwTaskGenerator < Rails::Generators::Base
         split_str = str.split(":")
         method = split_str[0]
         action = split_str[1]
-        name = split_str[2] || action + "_" + controller_base_name
+        name = split_str[2] || "#{method}_#{controller_base_name}"
 
         @route_methods.push(method)
         @route_actions.push(action)
@@ -80,14 +80,16 @@ class TwTaskGenerator < Rails::Generators::Base
   def add_to_user_task
     user_tasks_str = "\n"
 
-    @route_methods.each do |method|
-      user_tasks_str += "#{controller_base_name}_#{method}_task:\n"
+    @route_names.each_with_index do |name, index|
+      next if @route_actions[index] != "get"
+      
+      user_tasks_str += "#{name}:\n"
       user_tasks_str += "  hub: true\n"
-      user_tasks_str += "  name: 'TODO'\n"
+      user_tasks_str += "  name: 'TODO: Task name'\n"
       user_tasks_str += "  related:\n"
       user_tasks_str += "  categories:\n"
       user_tasks_str += "  status: prototype\n"
-      user_tasks_str += "  description: 'FILL ME IN'\n"
+      user_tasks_str += "  description: 'TODO: Task description'\n"
     end
 
     append_to_file "config/interface/hub/user_tasks.yml", user_tasks_str

--- a/lib/generators/tw_task/tw_task_generator.rb
+++ b/lib/generators/tw_task/tw_task_generator.rb
@@ -88,8 +88,8 @@ class TwTaskGenerator < Rails::Generators::Base
   def add_to_user_task
     user_tasks_str = "\n"
 
-    @route_actions.each do |action|
-      user_tasks_str += "#{controller_base_name}_#{action}_task:\n"
+    @route_methods.each do |method|
+      user_tasks_str += "#{controller_base_name}_#{method}_task:\n"
       user_tasks_str += "  hub: true\n"
       user_tasks_str += "  name: 'TODO'\n"
       user_tasks_str += "  related:\n"
@@ -115,20 +115,37 @@ class TwTaskGenerator < Rails::Generators::Base
     template "controller", "app/controllers/tasks/#{@paths.join('/')}/#{controller_base_name}_controller.rb"
   end
 
+  def create_view_folders
+    directory_name = "app/views/tasks"
+
+    @paths.each do |path|
+      directory_name += "/#{path}"
+      Dir.mkdir(directory_name) unless File.directory?(directory_name)
+    end
+
+    Dir.mkdir(directory_name += "/#{controller_base_name}") unless File.directory?(directory_name)
+  end
+
+  def create_views
+    @route_methods.each do |method|
+      create_file "app/views/tasks/#{@paths.join('/')}/#{controller_base_name}/#{method}.html.rb"
+    end
+  end
+
   private
   
   def controller_class_name
-    controller_base_name.tr('_', '').titleize
+    controller_base_name.titleize.tr(' ', '')
   end
 
   def full_controller_class_name
     controller_name = "Tasks::"
     controller_name += @paths.inject("") do |str, elem|
-      str += "#{elem.tr('_', '').titleize}::" 
+      str += "#{elem.titleize.tr(' ', '')}::" 
     end
 
     controller_name += controller_class_name
-    "#{controller_name[0...controller_name.length - 2]}Controller"
+    "#{controller_name.chomp("::")}Controller"
   end
 
 end 

--- a/lib/generators/tw_task/tw_task_generator.rb
+++ b/lib/generators/tw_task/tw_task_generator.rb
@@ -1,0 +1,134 @@
+class TwTaskGenerator < Rails::Generators::Base
+  source_root File.expand_path('../templates', __FILE__)
+
+  desc 'Used to stub out a task'
+
+  argument :controller_base_name, type: 'string', required: true
+  argument :path_to_controller, type: 'string', required: true
+  argument :methods_actions_names, type: 'array', required: true
+
+  def setup_args
+    @paths = path_to_controller.split("/")
+    @route_methods = Array.new
+    @route_actions = Array.new
+    @route_names = Array.new
+
+    methods_actions_names.each do |str|
+        split_str = str.split(":")
+        method = split_str[0]
+        action = split_str[1]
+        name = split_str[2] || action + "_" + controller_base_name
+
+        @route_methods.push(method)
+        @route_actions.push(action)
+        @route_names.push(name + "_task")
+    end
+
+    # ap controller_base_name
+    # ap path_to_controller
+    # ap methods_actions_names
+
+    # ap @paths
+    # ap @route_methods
+    # ap @route_actions
+    # ap @route_names
+  end
+
+  def add_scopes_to_routes
+    scopes = ["scope :tasks"]
+    scope_index = 0
+
+    @paths.each do |path|
+      scopes.push("scope :#{path}")
+    end
+
+    File.read("config/routes.rb").split("\n").each do |line|
+      if line.include?(scopes[scope_index])
+        scope_index += 1
+
+        if scope_index >= scopes.length
+          puts "WARNING: '#{scopes[scope_index - 1]}' already exists!"
+          break
+        end
+      end
+    end
+
+    if scope_index == 0
+      puts "WARNING: Couldn't find 'task' scope!"
+    end
+
+    route_str = ""
+    indent_str = "  "
+
+    scopes.each_with_index do |scope, index|
+      if index >= scope_index
+        route_str += "#{indent_str}#{scope} do\n" 
+      end
+
+      indent_str += "  "
+    end
+
+    route_str += "#{indent_str}scope :#{controller_base_name}, controller: 'tasks/#{path_to_controller}#{controller_base_name}' do\n"
+    
+    @route_actions.each_with_index do |action, index|
+      route_str += "#{indent_str}  #{action} '#{@route_methods[index]}', as: '#{@route_names[index]}'\n"
+    end
+
+    route_str += "#{indent_str}end\n"
+
+    scopes.length.downto(scope_index + 1) do
+      indent_str.chomp!("  ")
+      route_str += "#{indent_str}end\n"
+    end
+
+    route_str += "\n"
+    insert_into_file("config/routes.rb", route_str, after: "#{scopes[scope_index - 1]} do\n")
+  end
+
+  def add_to_user_task
+    user_tasks_str = "\n"
+
+    @route_actions.each do |action|
+      user_tasks_str += "#{controller_base_name}_#{action}_task:\n"
+      user_tasks_str += "  hub: true\n"
+      user_tasks_str += "  name: 'TODO'\n"
+      user_tasks_str += "  related:\n"
+      user_tasks_str += "  categories:\n"
+      user_tasks_str += "  status: prototype\n"
+      user_tasks_str += "  description: 'FILL ME IN'\n"
+    end
+
+    append_to_file "config/interface/hub/user_tasks.yml", user_tasks_str
+    ap full_controller_class_name
+  end
+
+  def create_controller_folders
+    directory_name = "app/controllers/tasks"
+
+    @paths.each do |path|
+      directory_name += "/#{path}"
+      Dir.mkdir(directory_name) unless File.directory?(directory_name)
+    end
+  end
+
+  def create_controller
+    template "controller", "app/controllers/tasks/#{@paths.join('/')}/#{controller_base_name}_controller.rb"
+  end
+
+  private
+  
+  def controller_class_name
+    controller_base_name.tr('_', '').titleize
+  end
+
+  def full_controller_class_name
+    controller_name = "Tasks::"
+    controller_name += @paths.inject("") do |str, elem|
+      str += "#{elem.tr('_', '').titleize}::" 
+    end
+
+    controller_name += controller_class_name
+    "#{controller_name[0...controller_name.length - 2]}Controller"
+  end
+
+end 

--- a/lib/generators/tw_task/tw_task_generator.rb
+++ b/lib/generators/tw_task/tw_task_generator.rb
@@ -1,11 +1,11 @@
 class TwTaskGenerator < Rails::Generators::Base
   source_root File.expand_path('../templates', __FILE__)
 
-  desc 'Used to stub out a task'
+  desc 'Used to stub out a TaxonWorks task'
 
-  argument :controller_base_name, type: 'string', required: true
-  argument :path_to_controller, type: 'string', required: true
-  argument :methods_actions_names, type: 'array', required: true
+  argument :controller_base_name, type: 'string', required: true, banner: '<controller_base_name>'
+  argument :path_to_controller, type: 'string', required: true, banner: '<"path/to/controller_folder/">'
+  argument :methods_actions_names, type: 'array', required: true, banner: '<method_name:action:route_name>'
 
   def setup_args
     @paths = path_to_controller.split("/")
@@ -23,15 +23,6 @@ class TwTaskGenerator < Rails::Generators::Base
         @route_actions.push(action)
         @route_names.push(name + "_task")
     end
-
-    # ap controller_base_name
-    # ap path_to_controller
-    # ap methods_actions_names
-
-    # ap @paths
-    # ap @route_methods
-    # ap @route_actions
-    # ap @route_names
   end
 
   def add_scopes_to_routes
@@ -47,14 +38,15 @@ class TwTaskGenerator < Rails::Generators::Base
         scope_index += 1
 
         if scope_index >= scopes.length
-          puts "WARNING: '#{scopes[scope_index - 1]}' already exists!"
-          break
+          puts "ERROR: scope '#{controller_base_name}' for controller '#{controller_base_name}' already exists!"
+          abort
         end
       end
     end
 
     if scope_index == 0
-      puts "WARNING: Couldn't find 'task' scope!"
+      puts "ERROR: Couldn't find 'task' scope!"
+      abort
     end
 
     route_str = ""
@@ -99,7 +91,6 @@ class TwTaskGenerator < Rails::Generators::Base
     end
 
     append_to_file "config/interface/hub/user_tasks.yml", user_tasks_str
-    ap full_controller_class_name
   end
 
   def create_controller_folders
@@ -112,7 +103,7 @@ class TwTaskGenerator < Rails::Generators::Base
   end
 
   def create_controller
-    template "controller", "app/controllers/tasks/#{@paths.join('/')}/#{controller_base_name}_controller.rb"
+    template "controller", "app/controllers/tasks/#{path_to_controller}#{controller_base_name}_controller.rb"
   end
 
   def create_view_folders
@@ -128,7 +119,7 @@ class TwTaskGenerator < Rails::Generators::Base
 
   def create_views
     @route_methods.each do |method|
-      create_file "app/views/tasks/#{@paths.join('/')}/#{controller_base_name}/#{method}.html.rb"
+      create_file "app/views/tasks/#{path_to_controller}#{controller_base_name}/#{method}.html.erb"
     end
   end
 

--- a/lib/user_tasks.rb
+++ b/lib/user_tasks.rb
@@ -65,6 +65,10 @@ module UserTasks
      #@defaults.merge!(verb: route.verb)
     end
 
+    def categories
+      @categories.nil? ? [] : @categories
+    end
+    
     def status
       @status.nil? ? 'unknown' : @status
     end


### PR DESCRIPTION
Added tw_task generator that creates/modifies all the necessary files to make a bare-bones TaxonWorks task which includes adding task routes to the routes.rb file, adding task entries to the user_tasks.yml file, creating a controller for the task in the app/controllers/tasks directory, and adding views for each action in the app/views/tasks/ directory.

Example use of the generator: `rails generate tw_task fasta_load "sequence/" index:get:get_fast_load verify:post:verify_task_name replace:put`

This would result in the following commands to be executed
* insert  config/routes.rb
* append  config/interface/hub/user_tasks.yml
* create  app/controllers/tasks/sequence/fasta_load_controller.rb
* create  app/views/tasks/sequence/fasta_load/index.html.erb
* create  app/views/tasks/sequence/fasta_load/verify.html.erb
* create  app/views/tasks/sequence/fasta_load/replace.html.erb

A more detailed explanation can be found in this generators USAGE file