### PR TITLE
Dates validations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
       - dna
       - eyelet
       - batch_file_load
+      - dates-validations
 addons:
   postgresql: "9.4"
   firefox: "46.0"

--- a/app/helpers/validators_helper.rb
+++ b/app/helpers/validators_helper.rb
@@ -1,0 +1,29 @@
+# Base validation class for validator specs, follows the style described at http://devblog.orgsync.com/2013/10/29/building-custom-rails-attribute-validators/
+
+module ValidatorsHelper
+  class ValidationTester
+    extend ActiveModel::Naming
+    include ActiveModel::Conversion
+    include ActiveModel::Validations
+
+    def new_record?
+      true
+    end
+
+    def persisted?
+      false
+    end
+
+    def self.name
+      'Validator'
+    end
+
+    def [](key)
+      send(key)
+    end
+
+    def []=(key, value)
+      send("#{key}=", value)
+    end
+  end
+end

--- a/app/models/collecting_event.rb
+++ b/app/models/collecting_event.rb
@@ -229,8 +229,8 @@ class CollectingEvent < ActiveRecord::Base
   validates_presence_of :time_end_minute, if: '!self.time_end_second.blank?'
   validates_presence_of :time_end_hour, if: '!self.time_end_minute.blank?'
 
-  validates :start_date_year, date_year: true
-  validates :end_date_year, date_year: true
+  validates :start_date_year, date_year: { min_year: 1000, max_year: Time.now.year + 5}
+  validates :end_date_year, date_year: { min_year: 1000, max_year: Time.now.year + 5}
   
   validates :start_date_month, date_month: true
   validates :end_date_month, date_month: true
@@ -241,21 +241,11 @@ class CollectingEvent < ActiveRecord::Base
   validates_presence_of :end_date_month,
                         if: '!end_date_day.nil?'
 
-  validates_numericality_of :end_date_day,
-                            allow_nil:             true,
-                            only_integer:          true,
-                            greater_than:          0,
-                            less_than_or_equal_to: Proc.new { |a| Time.utc(a.end_date_year, a.end_date_month).end_of_month.day },
-                            unless:                'end_date_year.nil? || end_date_month.nil?',
-                            message:               '%{value} is not a valid end_date_day for the month provided'
+  validates :end_date_day, date_day: { year_sym: :end_date_year, month_sym: :end_date_month },
+            unless: 'end_date_year.nil? || end_date_month.nil?'
 
-  validates_numericality_of :start_date_day,
-                            allow_nil:             true,
-                            only_integer:          true,
-                            greater_than:          0,
-                            less_than_or_equal_to: Proc.new { |a| Time.utc(a.start_date_year, a.start_date_month).end_of_month.day },
-                            unless:                'start_date_year.nil? || start_date_month.nil?',
-                            message:               '%{value} is not a valid start_date_day for the month provided'
+  validates :start_date_day, date_day: { year_sym: :start_date_year, month_sym: :start_date_month },
+            unless: 'start_date_year.nil? || start_date_month.nil?'
 
 
   soft_validate(:sv_minimally_check_for_a_label)

--- a/app/models/collecting_event.rb
+++ b/app/models/collecting_event.rb
@@ -215,82 +215,25 @@ class CollectingEvent < ActiveRecord::Base
 
   validates :geographic_area, presence: true, allow_nil: true
 
-  validates :time_start_hour,
-            allow_nil:    true,
-            numericality: {
-              only_integer: true,
-              greater_than: -1, less_than: 24,
-              message:      'start time hour must be 0-23'
-            }
-
-  validates :time_start_minute,
-            allow_nil:    true,
-            numericality: {
-              only_integer: true,
-              greater_than: -1, less_than: 60,
-              message:      'start time minute must be 0-59'
-            }
-
-  validates :time_start_second,
-            allow_nil:    true,
-            numericality: {
-              only_integer: true,
-              greater_than: -1, less_than: 60,
-              message:      'start time second must be 0-59'
-            }
+  validates :time_start_hour, time_hour: true
+  validates :time_start_minute, time_minute: true
+  validates :time_start_second, time_second: true
 
   validates_presence_of :time_start_minute, if: '!self.time_start_second.blank?'
   validates_presence_of :time_start_hour, if: '!self.time_start_minute.blank?'
 
-  validates :time_end_hour,
-            allow_nil:    true,
-            numericality: {
-              only_integer: true,
-              in:           (0..23),
-              message:      'end time hour must be 0-23'}
-
-  validates :time_end_minute,
-            allow_nil:    true,
-            numericality: {
-              only_integer: true,
-              in:           (0..59),
-              message:      'end time minute must be 0-59'}
-
-  validates :time_end_second,
-            allow_nil:    true,
-            numericality: {
-              only_integer: true,
-              in:           (0..59),
-              message:      'end time second must be 0-59'}
+  validates :time_end_hour, time_hour: true
+  validates :time_end_minute, time_minute: true
+  validates :time_end_second, time_second: true
 
   validates_presence_of :time_end_minute, if: '!self.time_end_second.blank?'
   validates_presence_of :time_end_hour, if: '!self.time_end_minute.blank?'
 
-  # @todo factor these out (see also TaxonDetermination, Source::Bibtex)
-  validates :start_date_year,
-            numericality: {only_integer: true,
-                           greater_than: 1000,
-                           less_than:    (Time.now.year + 5),
-                           message:      'start date year must be an integer greater than 1500, and no more than 5 years in the future'},
-            length:       {is: 4},
-            allow_nil:    true
-
-  validates :end_date_year,
-            numericality: {only_integer: true,
-                           greater_than: 1000,
-                           less_than:    (Time.now.year + 5),
-                           message:      'end date year must be an integer greater than 1500, and no more than 5 years int he future'},
-            length:       {is: 4},
-            allow_nil:    true
-
-  # @todo these are just simple integer validations now, fix!
-  validates :start_date_month,
-            numericality: {only_integer: true, greater_than: 0, less_than: 13},
-            unless:       'start_date_month.blank?'
-
-  validates :end_date_month,
-            numericality: {only_integer: true, greater_than: 0, less_than: 13},
-            unless:       'end_date_month.blank?'
+  validates :start_date_year, date_year: true
+  validates :end_date_year, date_year: true
+  
+  validates :start_date_month, date_month: true
+  validates :end_date_month, date_month: true
 
   validates_presence_of :start_date_month,
                         if: '!start_date_day.nil?'

--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -6,30 +6,8 @@ class Extract < ActiveRecord::Base
 
   validates_presence_of :quantity_value 
   validates_presence_of :quantity_unit
-  validates_presence_of :verbatim_anatomical_origin 
-  validates :year_made,
-            allow_nil: false,
-            numericality: {
-              only_integer: true,
-              greater_than: 1000,
-              less_than: Time.now.year + 5,
-              message: 'must be an integer greater than 1000, and no more than 5 years in the future'
-            }
-                  
-  validates :month_made,
-            allow_nil: false,
-            numericality: {
-              only_integer: true,
-              greater_than: 0,
-              less_than: 13,
-              message: 'must be an integer greater than 0 and less than 13'
-            }
-  validates :day_made,
-           allow_nil: false,
-           numericality: {
-             only_integer: true,
-             greater_than: 0,
-             less_than: 32,
-             message: 'must be an integer greater than 0 and less than 32'
-           }
+  validates_presence_of :verbatim_anatomical_origin
+  validates :year_made, date_year: { allow_blank: false }
+  validates :month_made, date_month: { allow_blank: false }
+  validates :day_made, date_day: { allow_blank: false }
 end

--- a/app/models/source/bibtex.rb
+++ b/app/models/source/bibtex.rb
@@ -353,11 +353,7 @@ class Source::Bibtex < Source
                         message: 'year is required when month or stated_year is provided'
 
   # @todo refactor out date validation methods so that they can be unified (TaxonDetermination, CollectingEvent)
-  validates_numericality_of :year,
-                            only_integer:          true, greater_than: 999,
-                            less_than_or_equal_to: Time.now.year + 2,
-                            allow_blank:           true,
-                            message:               'year must be an integer greater than 999 and no more than 2 years in the future'
+  validates :year, date_year: { min_year: 1000, max_year: Time.now.year + 2, message: "year must be an integer greater than 999 and no more than 2 years in the future" }
 
   validates_presence_of :month,
                         if:      '!day.nil?',
@@ -368,13 +364,8 @@ class Source::Bibtex < Source
                          allow_blank: true,
                          message:     ' month'
 
-  validates_numericality_of :day,
-                            allow_blank:           true,
-                            only_integer:          true,
-                            greater_than:          0,
-                            less_than_or_equal_to: Proc.new { |a| Time.utc(a.year, a.month).end_of_month.day },
-                            :unless                => 'year.nil? || month.nil?',
-                            message:               '%{value} is not a valid day for the month provided'
+  validates :day, date_day: { year_sym: :year, month_sym: :month },
+            unless: 'year.nil? || month.nil?'
 
   validates :url, :format => {:with    => URI::regexp(%w(http https ftp)),
                               message: "[%{value}] is not a valid URL"}, allow_blank: true

--- a/app/models/taxon_determination.rb
+++ b/app/models/taxon_determination.rb
@@ -59,24 +59,10 @@ class TaxonDetermination < ActiveRecord::Base
   validates :otu, presence: true # TODO - probably bad, and preventing nested determinations, should just use DB validation
 
   # @todo factor these out (see also TaxonDetermination, Source::Bibtex)
-  validates_numericality_of :year_made,
-                            only_integer:          true,
-                            greater_than:          1757,
-                            less_than_or_equal_to: Time.now.year,
-                            allow_nil:             true,
-                            message:               ' must be a 4 digit integer greater than 1757'
-  validates_inclusion_of :month_made,
-                         in:        1..12,
-                         allow_nil: true,
-                         message:   ' is not an integer from 1-12'
-  validates_numericality_of :day_made,
-                            unless:                'year_made.nil? || month_made.nil? || ![*(1..12)].include?(month_made)',
-                            allow_nil:             true,
-                            only_integer:          true,
-                            greater_than:          0,
-                            less_than:             32,
-                            less_than_or_equal_to: Proc.new { |a| Time.utc(a.year_made, a.month_made).end_of_month.day },
-                            message:               '%{value} is not valid for the month provided'
+  validates :year_made, date_year: { min_year: 1757, max_year: Time.now.year }
+  validates :month_made, date_month: true
+  validates :day_made, date_day: { year_sym: :year_made, month_sym: :month_made },
+            unless: 'year_made.nil? || month_made.nil?'
 
   before_save :set_made_fields_if_not_provided
   after_create :sort_to_top

--- a/app/models/taxon_determination.rb
+++ b/app/models/taxon_determination.rb
@@ -58,7 +58,6 @@ class TaxonDetermination < ActiveRecord::Base
   validates :biological_collection_object, presence: true
   validates :otu, presence: true # TODO - probably bad, and preventing nested determinations, should just use DB validation
 
-  # @todo factor these out (see also TaxonDetermination, Source::Bibtex)
   validates :year_made, date_year: { min_year: 1757, max_year: Time.now.year }
   validates :month_made, date_month: true
   validates :day_made, date_day: { year_sym: :year_made, month_sym: :month_made },

--- a/app/validators/date_day_validator.rb
+++ b/app/validators/date_day_validator.rb
@@ -1,3 +1,39 @@
+=begin
+  Child class of DateTimeValidator class
+
+  Example on how to use this class:
+    In the model file call
+      validates :model_attribute, date_day: true
+
+    To pass parameters to have custom min/max values
+      validates :model_attribute, date_day: { min_day: 3, max_day: 29 }
+
+  Description:
+    This class is a custom validators for date day related attributes.
+    Checks if the model_attribute is empty, an integer, and within min_day and max_day inclusive
+    If BOTH year_sym and month_sym are passed in, the validity of the day within a specific year
+    and month will be checked as well
+
+  Optional parameters:
+    allow_blank, default true
+      If true, allows the model attribute to be empty, aka not set, from base class
+
+    message, default "must be an integer between #{@min_value} and #{@max_value}" 
+      Error message to be added to the model_attribute if an error occurs
+
+    min_day, default 1
+      Minimum day value for the model_attribute
+
+    max_day, default 31
+      Maximum day value for the model_attribute
+
+    year_sym
+      Symbol of a model attribute containing the year value
+
+    month_sym
+      Symbol of a model attribute containing the month value
+=end
+
 class DateDayValidator < DateTimeValidator
   def validate_each(record, attribute, value)
     @min_value = options.fetch(:min_day, 1)

--- a/app/validators/date_day_validator.rb
+++ b/app/validators/date_day_validator.rb
@@ -1,0 +1,21 @@
+class DateDayValidator < DateTimeValidator
+  def validate_each(record, attribute, value)
+    @min_value = options.fetch(:min_day, 1)
+    @max_value = options.fetch(:max_day, 31)
+
+    if options.key?(:year_sym) && options.key?(:month_sym)
+      year = record[options[:year_sym]]
+      month = record[options[:month_sym]]
+
+      begin
+        @max_value = Time.utc(year, month).end_of_month.day
+        @message = "#{value} is not a valid day for the month provided"
+        
+      rescue ArgumentError
+        record.errors.add(options[:month_sym], "#{month} is not a valid month")
+      end
+    end
+
+    super
+  end
+end

--- a/app/validators/date_month_validator.rb
+++ b/app/validators/date_month_validator.rb
@@ -1,0 +1,7 @@
+class DateMonthValidator < DateTimeValidator
+  def validate_each(record, attribute, value)
+    @min_value = options.fetch(:min_month, 1)
+    @max_value = options.fetch(:max_month, 12)
+    super
+  end
+end

--- a/app/validators/date_month_validator.rb
+++ b/app/validators/date_month_validator.rb
@@ -1,3 +1,31 @@
+=begin
+  Child class of DateTimeValidator class
+
+  Example on how to use this class:
+    In the model file call
+      validates :model_attribute, date_month: true
+
+    To pass parameters to have custom min/max values
+      validates :model_attribute, date_month: { min_month: 3, max_month: 29 }
+
+  Description:
+    This class is a custom validators for date month related attributes.
+    Checks if the model_attribute is empty, an integer, and within min_month and max_month inclusive
+
+  Optional parameters:
+    allow_blank, default true, from base class
+      If true, allows the model attribute to be empty, aka not set
+
+    message, default "must be an integer between #{@min_value} and #{@max_value}", from base class
+      Error message to be added to the model_attribute if an error occurs
+
+    min_month, default 1
+      Minimum month value for the model_attribute
+
+    max_month, default 12
+      Maximum month value for the model_attribute
+=end
+
 class DateMonthValidator < DateTimeValidator
   def validate_each(record, attribute, value)
     @min_value = options.fetch(:min_month, 1)

--- a/app/validators/date_time_validator.rb
+++ b/app/validators/date_time_validator.rb
@@ -1,3 +1,42 @@
+=begin
+  Base validator class for the following validators:
+    DateDayValidator
+    DateMonthValidator
+    DateYearValidator
+    TimeSecondValidator
+    TimeMinuteValidator
+    TImeHourValidator
+
+  This class should NOT be used directly for validating attribtues in models,
+  instead you should be using one of the child classes listed above
+
+  Child classes MUST create an instance variable named "min_value" and "max_value"
+
+  Example on how to use one of the child classes:
+    In the model file call
+      validates :model_attribute, date_day: true
+
+    To pass parameters to have custom min/max values
+      validates :model_attribute, date_day: { min_day: 3, max_day: 29 }
+
+  Description:
+    This class and its children are custom validators for dates/times related attributes.
+    Checks if the model_attribute is empty, an integer, and within min_value and max_value inclusive
+
+  Optional parameters:
+    allow_blank, default true
+      If true, allows the model attribute to be empty, aka not set
+
+    message, default "must be an integer between #{@min_value} and #{@max_value}" 
+      Error message to be added to the model_attribute if an error occurs
+
+    min_value, set in child class
+      Minimum value for the model_attribute
+
+    max_value, set in child class
+      Maximum value for the model_attribute
+=end
+
 class DateTimeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     @message ||= options.fetch(:message, "must be an integer between #{@min_value} and #{@max_value}")

--- a/app/validators/date_time_validator.rb
+++ b/app/validators/date_time_validator.rb
@@ -1,0 +1,18 @@
+class DateTimeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    @message ||= options.fetch(:message, "must be an integer between #{@min_value} and #{@max_value}")
+    @allow_blank ||= options.fetch(:allow_blank, true)
+
+    if !@allow_blank && value.nil?
+      record.errors.add(attribute, "can't be blank")
+    elsif !value.blank?
+      if !value.is_a? Integer 
+        record.errors.add(attribute, "is not an integer")
+      elsif value < @min_value || value > @max_value
+        record.errors.add(attribute, "not in range")
+      end
+    end
+
+    record.errors.add(attribute, @message) if record.errors.key?(attribute)
+  end
+end

--- a/app/validators/date_year_validator.rb
+++ b/app/validators/date_year_validator.rb
@@ -1,0 +1,7 @@
+class DateYearValidator < DateTimeValidator
+  def validate_each(record, attribute, value)
+    @min_value = options.fetch(:min_year, 1000)
+    @max_value = options.fetch(:max_year, Time.now.year + 5)
+    super
+  end
+end

--- a/app/validators/date_year_validator.rb
+++ b/app/validators/date_year_validator.rb
@@ -1,3 +1,31 @@
+=begin
+  Child class of DateTimeValidator class
+
+  Example on how to use this class:
+    In the model file call
+      validates :model_attribute, date_year: true
+
+    To pass parameters to have custom min/max values
+      validates :model_attribute, date_year: { min_year: 3, max_year: 29 }
+
+  Description:
+    This class is a custom validators for date year related attributes.
+    Checks if the model_attribute is empty, an integer, and within min_year and max_year inclusive
+
+  Optional parameters:
+    allow_blank, default true, from base class
+      If true, allows the model attribute to be empty, aka not set
+
+    message, default "must be an integer between #{@min_value} and #{@max_value}", from base class
+      Error message to be added to the model_attribute if an error occurs
+
+    min_year, default 1000
+      Minimum year value for the model_attribute
+
+    max_year, default Time.now.year + 5
+      Maximum year value for the model_attribute
+=end
+
 class DateYearValidator < DateTimeValidator
   def validate_each(record, attribute, value)
     @min_value = options.fetch(:min_year, 1000)

--- a/app/validators/time_hour_validator.rb
+++ b/app/validators/time_hour_validator.rb
@@ -1,0 +1,7 @@
+class TimeHourValidator < DateTimeValidator
+  def validate_each(record, attribute, value)
+    @min_value = options.fetch(:min_hour, 0)
+    @max_value = options.fetch(:max_hour, 23)
+    super
+  end
+end

--- a/app/validators/time_hour_validator.rb
+++ b/app/validators/time_hour_validator.rb
@@ -1,3 +1,31 @@
+=begin
+  Child class of DateTimeValidator class
+
+  Example on how to use this class:
+    In the model file call
+      validates :model_attribute, time_hour: true
+
+    To pass parameters to have custom min/max values
+      validates :model_attribute, time_hour: { min_hour: 3, max_hour: 29 }
+
+  Description:
+    This class is a custom validators for date hour related attributes.
+    Checks if the model_attribute is empty, an integer, and within min_hour and max_hour inclusive
+
+  Optional parameters:
+    allow_blank, default true, from base class
+      If true, allows the model attribute to be empty, aka not set
+
+    message, default "must be an integer between #{@min_value} and #{@max_value}", from base class
+      Error message to be added to the model_attribute if an error occurs
+
+    min_hour, default 0
+      Minimum hour value for the model_attribute
+
+    max_hour, default 23
+      Maximum hour value for the model_attribute
+=end
+
 class TimeHourValidator < DateTimeValidator
   def validate_each(record, attribute, value)
     @min_value = options.fetch(:min_hour, 0)

--- a/app/validators/time_minute_validator.rb
+++ b/app/validators/time_minute_validator.rb
@@ -1,3 +1,31 @@
+=begin
+  Child class of DateTimeValidator class
+
+  Example on how to use this class:
+    In the model file call
+      validates :model_attribute, time_minute: true
+
+    To pass parameters to have custom min/max values
+      validates :model_attribute, time_minute: { min_minute: 3, max_minute: 29 }
+
+  Description:
+    This class is a custom validators for date minute related attributes.
+    Checks if the model_attribute is empty, an integer, and within min_minute and max_minute inclusive
+
+  Optional parameters:
+    allow_blank, default true, from base class
+      If true, allows the model attribute to be empty, aka not set
+
+    message, default "must be an integer between #{@min_value} and #{@max_value}", from base class
+      Error message to be added to the model_attribute if an error occurs
+
+    min_minute, default 0
+      Minimum minute value for the model_attribute
+
+    max_minute, default 59
+      Maximum minute value for the model_attribute
+=end
+
 class TimeMinuteValidator < DateTimeValidator
   def validate_each(record, attribute, value)
     @min_value = options.fetch(:min_minute, 0)

--- a/app/validators/time_minute_validator.rb
+++ b/app/validators/time_minute_validator.rb
@@ -1,0 +1,7 @@
+class TimeMinuteValidator < DateTimeValidator
+  def validate_each(record, attribute, value)
+    @min_value = options.fetch(:min_minute, 0)
+    @max_value = options.fetch(:max_minute, 59)
+    super
+  end
+end

--- a/app/validators/time_second_validator.rb
+++ b/app/validators/time_second_validator.rb
@@ -1,3 +1,31 @@
+=begin
+  Child class of DateTimeValidator class
+
+  Example on how to use this class:
+    In the model file call
+      validates :model_attribute, time_second: true
+
+    To pass parameters to have custom min/max values
+      validates :model_attribute, time_second: { min_second: 3, max_second: 29 }
+
+  Description:
+    This class is a custom validators for date second related attributes.
+    Checks if the model_attribute is empty, an integer, and within min_second and max_second inclusive
+
+  Optional parameters:
+    allow_blank, default true, from base class
+      If true, allows the model attribute to be empty, aka not set
+
+    message, default "must be an integer between #{@min_value} and #{@max_value}", from base class
+      Error message to be added to the model_attribute if an error occurs
+
+    min_second, default 0
+      Minimum second value for the model_attribute
+
+    max_second, default 59
+      Maximum second value for the model_attribute
+=end
+
 class TimeSecondValidator < DateTimeValidator
   def validate_each(record, attribute, value)
     @min_value = options.fetch(:min_second, 0)

--- a/app/validators/time_second_validator.rb
+++ b/app/validators/time_second_validator.rb
@@ -1,0 +1,7 @@
+class TimeSecondValidator < DateTimeValidator
+  def validate_each(record, attribute, value)
+    @min_value = options.fetch(:min_second, 0)
+    @max_value = options.fetch(:max_second, 59)
+    super
+  end
+end

--- a/spec/models/extract_spec.rb
+++ b/spec/models/extract_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Extract, type: :model, group: :extract do
 
       context 'year_made' do
         specify '< 1000' do 
-          valid_extract.year_made = 1000
+          valid_extract.year_made = 999
         end
 
         specify '> Time.now.year + 5' do 

--- a/spec/validators/date_day_validator_spec.rb
+++ b/spec/validators/date_day_validator_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe DateDayValidator, type: :validator, group: :validator do
+  context 'validations' do
+    context 'no parameters given for validator' do
+      let(:test_model) {
+        date_day_validator_class(true).new
+      }
+
+      specify 'empty day is valid' do
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default min day is 1' do
+        test_model.day = 0
+        expect(test_model.valid?).to be_falsey
+
+        test_model.day = 1
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default max day is 31' do
+        test_model.day = 32
+        expect(test_model.valid?).to be_falsey
+
+        test_model.day = 31
+        expect(test_model.valid?).to be_truthy
+      end
+    end 
+
+    context 'parameters given for validator' do
+      context 'min_day' do
+        let(:test_model) {
+          date_day_validator_class({ min_day: 20 }).new
+        }
+
+        specify 'min_day now 20' do
+          test_model.day = 19
+          expect(test_model.valid?).to be_falsey
+
+          test_model.day = 20
+          expect(test_model.valid?).to be_truthy
+        end
+
+        specify 'max_day still 31' do
+          test_model.day = 32
+          expect(test_model.valid?).to be_falsey
+
+          test_model.day = 31
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+
+      context 'max_day' do
+        let(:test_model) {
+          date_day_validator_class({ max_day: 20 }).new
+        }
+
+        specify 'max_day now 20' do
+          test_model.day = 20
+          expect(test_model.valid?).to be_truthy
+
+          test_model.day = 21
+          expect(test_model.valid?).to be_falsey
+        end
+
+        specify 'min_day still 1' do
+          test_model.day = 0
+          expect(test_model.valid?).to be_falsey
+
+          test_model.day = 1
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+
+      context 'year_sym and month_sym' do
+        let(:test_model) {
+          date_day_validator_class({ year_sym: :year, month_sym: :month }).new
+        }
+
+        specify 'invalid month adds error message' do
+          test_model.year = Time.now.year
+          test_model.month = 45
+          test_model.day = 3
+          expect(test_model.valid?).to be_falsey
+          expect(test_model.errors.messages[:month].include?("45 is not a valid month")).to be true
+        end
+
+        specify 'invalid day adds error message' do
+          test_model.year = Time.now.year
+          test_model.month = 12
+          test_model.day = 45
+          expect(test_model.valid?).to be_falsey
+          expect(test_model.errors.messages[:day].include?("45 is not a valid day for the month provided")).to be true
+        end
+
+        specify 'calculates correct max_day' do
+          test_model.year = 2015
+          test_model.month = 2    # Feb
+          test_model.day = 28
+          expect(test_model.valid?).to be_truthy
+
+          test_model.day = 30
+          expect(test_model.valid?).to be_falsey
+        end
+      end
+    end
+  end
+end
+
+def date_day_validator_class(options)
+  Class.new(ValidatorsHelper::ValidationTester) do
+    attr_accessor :day
+    attr_accessor :year
+    attr_accessor :month
+
+    validates :day, date_day: options
+  end
+end

--- a/spec/validators/date_month_validator_spec.rb
+++ b/spec/validators/date_month_validator_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe DateMonthValidator, type: :validator, group: :validator do
+  context 'validations' do
+    context 'no parameters given for validator' do
+      let(:test_model) {
+        date_month_validator_class(true).new
+      }
+
+      specify 'empty month is valid' do
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default min month is 1' do
+        test_model.month = 0
+        expect(test_model.valid?).to be_falsey
+
+        test_model.month = 1
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default max month is 12' do
+        test_model.month = 13
+        expect(test_model.valid?).to be_falsey
+
+        test_model.month = 12
+        expect(test_model.valid?).to be_truthy
+      end
+    end 
+
+    context 'parameters given for validator' do
+      context 'min_month' do
+        let(:test_model) {
+          date_month_validator_class({ min_month: 2 }).new
+        }
+
+        specify 'min_month now 2' do
+          test_model.month = 1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.month = 2
+          expect(test_model.valid?).to be_truthy
+        end
+
+        specify 'max_month still 12' do
+          test_model.month = 13
+          expect(test_model.valid?).to be_falsey
+
+          test_model.month = 12
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+
+      context 'max_month' do
+        let(:test_model) {
+          date_month_validator_class({ max_month: 20 }).new
+        }
+
+        specify 'max_month now 20' do
+          test_model.month = 20
+          expect(test_model.valid?).to be_truthy
+
+          test_model.month = 21
+          expect(test_model.valid?).to be_falsey
+        end
+
+        specify 'min_month still 1' do
+          test_model.month = 0
+          expect(test_model.valid?).to be_falsey
+
+          test_model.month = 1
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+    end
+  end
+end
+
+def date_month_validator_class(options)
+  Class.new(ValidatorsHelper::ValidationTester) do
+    attr_accessor :month
+
+    validates :month, date_month: options
+  end
+end

--- a/spec/validators/date_time_validator_spec.rb
+++ b/spec/validators/date_time_validator_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe DateTimeValidator, type: :validator, group: :validator do
+  specify 'testing' do
+    expect(true).to be true
+    test_model = date_time_base_validator_class(true).new
+    expect(test_model.valid?).to be_truthy
+  end
+
+  context 'validations' do
+    context 'no parameters given for validator' do
+      specify 'empty attribute is valid' do
+        test_model = date_time_base_validator_class(true).new
+        expect(test_model.valid?).to be_truthy
+      end
+
+      context 'default error messages occur' do
+        let(:test_model) {
+          date_time_base_validator_class({ allow_blank: false }).new
+        }
+
+        after(:each) {
+          expect(test_model.errors.messages[:attribute].include?("must be an integer between 1 and 100")).to be true
+        }
+
+        specify "can't be blank and default error message" do
+          test_model.valid?
+          expect(test_model.errors.messages[:attribute].include?("can't be blank")).to be true
+        end
+
+        specify 'is not an integer and default error message' do
+          test_model.attribute = "4"
+          test_model.valid?
+          expect(test_model.errors.messages[:attribute].include?("is not an integer")).to be true
+        end
+
+        specify 'not in range and default error message' do
+          test_model.attribute = 101
+          test_model.valid?
+          expect(test_model.errors.messages[:attribute].include?("not in range")).to be true
+        end
+      end
+    end
+
+    context 'parameters given for validator' do
+      context 'allow_blank' do
+        context 'true' do
+          let(:test_model) {
+            date_time_base_validator_class({ allow_blank: true }).new
+          }
+
+          specify 'empty attribute, model valid' do
+            expect(test_model.valid?).to be_truthy
+          end
+
+          specify 'valid attribute, model valid' do
+            test_model.attribute = 15
+            expect(test_model.valid?).to be_truthy
+          end
+        end
+
+        context 'false' do
+          let(:test_model) {
+            date_time_base_validator_class({ allow_blank: false }).new
+          }
+
+          specify 'empty attribute, model invalid' do
+            expect(test_model.valid?).to be_falsey
+          end
+
+          specify 'valid attribute, model valid' do
+            test_model.attribute = 15
+            expect(test_model.valid?).to be_truthy
+          end
+        end
+      end
+    end
+
+    context 'message' do
+      specify 'custom message occurs' do
+        custom_message = "this is a custom message"
+        test_model = date_time_base_validator_class({ allow_blank: false, message: custom_message}).new
+        test_model.valid?
+        expect(test_model.errors.messages[:attribute].include?(custom_message)).to be true
+      end
+    end
+  end
+end
+
+class DateTimeBaseValidator < DateTimeValidator
+  def validate_each(record, attribute, value)
+    @min_value = options.fetch(:min_value, 1)
+    @max_value = options.fetch(:max_value, 100)
+    super
+  end
+end
+
+def date_time_base_validator_class(options)
+  Class.new(ValidatorsHelper::ValidationTester) do
+    attr_accessor :attribute
+
+    validates :attribute, date_time_base: options
+  end
+end

--- a/spec/validators/date_year_validator_spec.rb
+++ b/spec/validators/date_year_validator_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe DateYearValidator, type: :validator, group: :validator do
+  context 'validations' do
+    context 'no parameters given for validator' do
+      let(:test_model) {
+        date_year_validator_class(true).new
+      }
+
+      specify 'empty year is valid' do
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default min year is 1000' do
+        test_model.year = 999
+        expect(test_model.valid?).to be_falsey
+
+        test_model.year = 1000
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default max year is Time.now.year + 5' do
+        test_model.year = Time.now.year + 6
+        expect(test_model.valid?).to be_falsey
+
+        test_model.year = Time.now.year + 5
+        expect(test_model.valid?).to be_truthy
+      end
+    end 
+
+    context 'parameters given for validator' do
+      context 'min_year' do
+        let(:test_model) {
+          date_year_validator_class({ min_year: 2 }).new
+        }
+
+        specify 'min_year now 2' do
+          test_model.year = 1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.year = 2
+          expect(test_model.valid?).to be_truthy
+        end
+
+        specify 'max_year still 12' do
+          test_model.year = Time.now.year + 6
+          expect(test_model.valid?).to be_falsey
+
+          test_model.year = Time.now.year + 5
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+
+      context 'max_year' do
+        let(:test_model) {
+          date_year_validator_class({ max_year: 2000 }).new
+        }
+
+        specify 'max_year now 2000' do
+          test_model.year = 2000
+          expect(test_model.valid?).to be_truthy
+
+          test_model.year = 2001
+          expect(test_model.valid?).to be_falsey
+        end
+
+        specify 'min_year still 1000' do
+          test_model.year = 999
+          expect(test_model.valid?).to be_falsey
+
+          test_model.year = 1000
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+    end
+  end
+end
+
+def date_year_validator_class(options)
+  Class.new(ValidatorsHelper::ValidationTester) do
+    attr_accessor :year
+
+    validates :year, date_year: options
+  end
+end

--- a/spec/validators/time_hour_validator_spec.rb
+++ b/spec/validators/time_hour_validator_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe TimeHourValidator, type: :validator, group: :validator do
+  context 'validations' do
+    context 'no parameters given for validator' do
+      let(:test_model) {
+        time_hour_validator_class(true).new
+      }
+
+      specify 'empty hour is valid' do
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default min hour is 0' do
+        test_model.hour = -1
+        expect(test_model.valid?).to be_falsey
+
+        test_model.hour = 0
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default max hour is 23' do
+        test_model.hour = 24
+        expect(test_model.valid?).to be_falsey
+
+        test_model.hour = 23
+        expect(test_model.valid?).to be_truthy
+      end
+    end 
+
+    context 'parameters given for validator' do
+      context 'min_hour' do
+        let(:test_model) {
+          time_hour_validator_class({ min_hour: 2 }).new
+        }
+
+        specify 'min_hour now 2' do
+          test_model.hour = 1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.hour = 2
+          expect(test_model.valid?).to be_truthy
+        end
+
+        specify 'max_hour still 23' do
+          test_model.hour = 24
+          expect(test_model.valid?).to be_falsey
+
+          test_model.hour = 23
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+
+      context 'max_hour' do
+        let(:test_model) {
+          time_hour_validator_class({ max_hour: 2000 }).new
+        }
+
+        specify 'max_hour now 2000' do
+          test_model.hour = 2000
+          expect(test_model.valid?).to be_truthy
+
+          test_model.hour = 2001
+          expect(test_model.valid?).to be_falsey
+        end
+
+        specify 'min_hour still 0' do
+          test_model.hour = -1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.hour = 0
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+    end
+  end
+end
+
+def time_hour_validator_class(options)
+  Class.new(ValidatorsHelper::ValidationTester) do
+    attr_accessor :hour
+
+    validates :hour, time_hour: options
+  end
+end

--- a/spec/validators/time_minute_validator_spec.rb
+++ b/spec/validators/time_minute_validator_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe TimeMinuteValidator, type: :validator, group: :validator do
+  context 'validations' do
+    context 'no parameters given for validator' do
+      let(:test_model) {
+        time_minute_validator_class(true).new
+      }
+
+      specify 'empty minute is valid' do
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default min minute is 0' do
+        test_model.minute = -1
+        expect(test_model.valid?).to be_falsey
+
+        test_model.minute = 0
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default max minute is 59' do
+        test_model.minute = 60
+        expect(test_model.valid?).to be_falsey
+
+        test_model.minute = 59
+        expect(test_model.valid?).to be_truthy
+      end
+    end 
+
+    context 'parameters given for validator' do
+      context 'min_minute' do
+        let(:test_model) {
+          time_minute_validator_class({ min_minute: 2 }).new
+        }
+
+        specify 'min_minute now 2' do
+          test_model.minute = 1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.minute = 2
+          expect(test_model.valid?).to be_truthy
+        end
+
+        specify 'max_minute still 59' do
+          test_model.minute = 60
+          expect(test_model.valid?).to be_falsey
+
+          test_model.minute = 59
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+
+      context 'max_minute' do
+        let(:test_model) {
+          time_minute_validator_class({ max_minute: 2000 }).new
+        }
+
+        specify 'max_minute now 2000' do
+          test_model.minute = 2000
+          expect(test_model.valid?).to be_truthy
+
+          test_model.minute = 2001
+          expect(test_model.valid?).to be_falsey
+        end
+
+        specify 'min_minute still 0' do
+          test_model.minute = -1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.minute = 0
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+    end
+  end
+end
+
+def time_minute_validator_class(options)
+  Class.new(ValidatorsHelper::ValidationTester) do
+    attr_accessor :minute
+
+    validates :minute, time_minute: options
+  end
+end

--- a/spec/validators/time_second_validator_spec.rb
+++ b/spec/validators/time_second_validator_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe TimeSecondValidator, type: :validator, group: :validator do
+  context 'validations' do
+    context 'no parameters given for validator' do
+      let(:test_model) {
+        time_second_validator_class(true).new
+      }
+
+      specify 'empty second is valid' do
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default min second is 0' do
+        test_model.second = -1
+        expect(test_model.valid?).to be_falsey
+
+        test_model.second = 0
+        expect(test_model.valid?).to be_truthy
+      end
+
+      specify 'default max second is 59' do
+        test_model.second = 60
+        expect(test_model.valid?).to be_falsey
+
+        test_model.second = 59
+        expect(test_model.valid?).to be_truthy
+      end
+    end 
+
+    context 'parameters given for validator' do
+      context 'min_second' do
+        let(:test_model) {
+          time_second_validator_class({ min_second: 2 }).new
+        }
+
+        specify 'min_second now 2' do
+          test_model.second = 1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.second = 2
+          expect(test_model.valid?).to be_truthy
+        end
+
+        specify 'max_second still 59' do
+          test_model.second = 60
+          expect(test_model.valid?).to be_falsey
+
+          test_model.second = 59
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+
+      context 'max_second' do
+        let(:test_model) {
+          time_second_validator_class({ max_second: 2000 }).new
+        }
+
+        specify 'max_second now 2000' do
+          test_model.second = 2000
+          expect(test_model.valid?).to be_truthy
+
+          test_model.second = 2001
+          expect(test_model.valid?).to be_falsey
+        end
+
+        specify 'min_second still 0' do
+          test_model.second = -1
+          expect(test_model.valid?).to be_falsey
+
+          test_model.second = 0
+          expect(test_model.valid?).to be_truthy
+        end
+      end
+    end
+  end
+end
+
+def time_second_validator_class(options)
+  Class.new(ValidatorsHelper::ValidationTester) do
+    attr_accessor :second
+
+    validates :second, time_second: options
+  end
+end


### PR DESCRIPTION
Added 6 custom validators to use on model attributes

* DateDayValidator
* DateMonthValidator
* DateYearValidator
* TimeSecondValidator
* TimeMinuteValidator
* TImeHourValidator

The validators check if a model attribute is empty, of an integer value, and within range.

To use a custom validator on a model attribute, in the model file write
`validates :model_attribute, date_day: true`

To pass in parameters to the custom validator for customization
`validates :model_attribute, date_day: { min_day: 2, max_day: 28 }`

Optional parameters
* `allow_blank`: if true allows model attribute to be empty, defaults to true
* `message`: error message to be attached to model attribute if validation fails
* `min_day/month/year/etc`: minimum value of  model attribute
* `max_day/month/year/etc`: maximum value of  model attribute

Optional parameters unique to DateDayValidator
* 'year_sym`: the symbol of the model attribute containing the year value for the model
* 'month_sym`: the symbol of the model attribute containing the month value for the model

`validates :model_attribute, date_day: { year_sym: :year, month_sym: :month }`

If both `year_sym` and `month_sym` are given to a DateDayValidator then the `max_day` value will be the amount of days that exists of the month and year specified