### PR TITLE
Added batch load for namespaces

### DIFF
--- a/app/views/namespaces/batch_load.html.erb
+++ b/app/views/namespaces/batch_load.html.erb
@@ -1,0 +1,2 @@
+<%= render 'namespaces/batch_load/simple/batch_load' -%>
+

--- a/app/views/namespaces/batch_load/simple/_batch_load.html.erb
+++ b/app/views/namespaces/batch_load/simple/_batch_load.html.erb
@@ -1,0 +1,36 @@
+<div>
+  <h2> Simple batch load </h2>
+
+  <div class="flexbox full_viewport_whitespace">
+    <div class="item item1 one_third_width">
+      <h3> Description and requirements  </h3>
+
+      <p> Creates namespaces. </p>
+      <ul>
+        <li>A tab-delimited, UTF-8 compatible text file is required.</li>
+        <li>Name column cannot be blank and must be unique among all namespaces.</li>
+        <li>Short name cannot be blank and must be unique among all namespaces.</li>
+        <li>Column headers are <%= link_to('here', asset_path('batch_load_templates/namespaces/namespaces_simple_batch_load.tab'), target: '_blank') -%>.</li>
+        <li>Multiple uploads of the same data will fail the duplicated data.</li>
+        <li>There is currently some|no size limit to the file being loaded but this may change in the future.</li>
+      </ul>
+    </div>
+
+    <div class="item item2 one_third_width">
+      <h3> Example file </h3>
+
+      <p> A tab delimited formatted file
+          In the example whitespace is a tab. View sample file template.</p>
+
+      <pre class="fixed_width_font">
+        institution name short_name verbatim_short_name
+        institution_a name_a short_name_a verbatim_short_name_a
+      </pre>
+    </div>
+
+    <div class="item item3">
+      <h3> Go! </h3>
+      <%= render partial: '/namespaces/batch_load/simple/form', locals: {url: preview_simple_batch_load_namespaces_path, submit: :preview} -%>
+    </div>
+  </div>
+</div>

--- a/app/views/namespaces/batch_load/simple/_form.html.erb
+++ b/app/views/namespaces/batch_load/simple/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_tag url, multipart: true do -%>
+
+    <div class="field">
+      <%= label_tag :file, 'Select a file' -%>
+      <br>
+      <%= file_field_tag :file -%>
+    </div>
+
+
+    <% if @result -%>
+
+      <p> TODO: ADD OTHER METADATA INPUT OPTIONS HERE </p>
+
+    <% end %>
+
+    <%= content_for :warn_level -%>
+
+    <%= submit_tag submit -%>
+<% end %>

--- a/app/views/namespaces/batch_load/simple/create.html.erb
+++ b/app/views/namespaces/batch_load/simple/create.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: '/shared/data/all/batch_load/create' -%>

--- a/app/views/namespaces/batch_load/simple/preview.html.erb
+++ b/app/views/namespaces/batch_load/simple/preview.html.erb
@@ -1,0 +1,48 @@
+<% content_for :warn_level do -%>
+    <%= warn_level_input(@result) -%>
+<% end %>
+
+<%= content_for :batch_form do -%>
+  <%= render partial: '/namespaces/batch_load/simple/form', locals: {url: create_simple_batch_load_namespaces_path, submit: :create} -%>
+<% end %>
+
+<%= content_for :line_breakdown do -%>
+  <table class="top_align_text"> 
+    <tr>
+      <th class="">line</th>
+      <th class="">data count</th>
+      <th class="">institution</th>
+      <th class="">name</th>
+      <th class="">short_name</th>
+      <th class="">verbatim_short_name</th>
+      <th class="">data errors*</th>
+    </tr>
+
+    <% @result.sorted_processed_rows.each do |i, rp| -%>
+      <tr>
+        <%= batch_line_link_td(i) -%> 
+        <%= batch_all_objects_count_td(rp) -%>
+        <td>
+          <%= rp.objects[:namespaces].collect{|n| n.institution }.join('<br>').html_safe -%>
+        </td> 
+        <td>
+          <%= rp.objects[:namespaces].collect{|n| n.name }.join('<br>').html_safe -%>
+        </td> 
+        <td>
+          <%= rp.objects[:namespaces].collect{|n| n.short_name }.join('<br>').html_safe -%>
+        </td>
+        <td>
+          <%= rp.objects[:namespaces].collect{|n| n.verbatim_short_name }.join('<br>').html_safe -%>
+        </td> 
+        <td>
+          <%= rp.objects[:namespaces].collect{|n| n.errors.full_messages }.join('<br>').html_safe -%>
+        </td> 
+
+      </tr>
+    <% end -%> 
+  </table>
+<% end %>
+
+
+<%= render partial: '/shared/data/all/batch_load/preview' -%>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,6 +244,11 @@ TaxonWorks::Application.routes.draw do
 
   resources :namespaces do
     concerns [:data_routes]
+
+    collection do
+      post :preview_simple_batch_load
+      post :create_simple_batch_load
+    end
   end
 
   resources :notes, except: [:show] do

--- a/lib/batch_load/import/namespaces/simple_interpreter.rb
+++ b/lib/batch_load/import/namespaces/simple_interpreter.rb
@@ -1,0 +1,47 @@
+module BatchLoad
+  class Import::Namespaces::SimpleInterpreter < BatchLoad::Import
+
+    def initialize(**args)
+      super(args)
+    end
+
+    def build_namespaces
+      i = 1
+
+      namespaces = {};
+
+      # loop throw rows
+      csv.each do |row|
+
+        parse_result = BatchLoad::RowParse.new
+        parse_result.objects[:namespaces] = []
+
+        @processed_rows[i] = parse_result
+
+        begin
+          namespace_attributes = {
+            institution: row["institution"],
+            name: row["name"],
+            short_name: row["short_name"],
+            verbatim_short_name: row["verbatim_short_name"]
+          };
+
+          namespace = Namespace.new(namespace_attributes)
+          parse_result.objects[:namespaces].push namespace
+        # rescue TODO: THIS IS A GENERATED STUB, it does not function
+        end
+        i += 1
+      end
+
+      @total_lines = i - 1
+    end
+
+    def build
+      if valid?
+        build_namespaces
+        @processed = true
+      end
+    end
+
+  end
+end

--- a/public/batch_load_templates/namespaces/namespaces_simple_batch_load.tab
+++ b/public/batch_load_templates/namespaces/namespaces_simple_batch_load.tab
@@ -1,0 +1,2 @@
+institution name short_name verbatim_short_name
+institution_a name_a short_name_a verbatim_short_name_a   


### PR DESCRIPTION
Adds batch load functionality for Namespaces to allow creating Namespaces by uploading a csv file with the headers of `institution name short_name verbatim_short_name` where each space is a tab.

institution: name of the institution, optional
name: name of the namespace, required and must be unique among all namespaces
short_name: short name of the namespace, required and must be unique among all namespaces
verbatim_short_name: verbatim short name of the namespace, optional
