### PR TITLE
Documentation Rake Task

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -48,7 +48,7 @@ class Document < ActiveRecord::Base
   has_attached_file :document_file,
                     filename_cleaner:  Utilities::CleanseFilename
 
-  validates_attachment_content_type :document_file, content_type: ['application/pdf', 'text/plain', 'text/xml']
+  validates_attachment_content_type :document_file, content_type: ['application/octet-stream', 'application/pdf', 'text/plain', 'text/xml']
   validates_attachment_presence :document_file
   validates_attachment_size :document_file, greater_than: 1.bytes
 

--- a/config/initializers/vendor/paperclip.rb
+++ b/config/initializers/vendor/paperclip.rb
@@ -1,4 +1,6 @@
   # paperclip requires information on where ImageMagick is installed.
   Paperclip.options[:command_path] = "/usr/local/bin/"
 
-
+  Paperclip.options[:content_type_mappings] = {
+    ab1: %w(application/octet-stream)
+  }

--- a/db/migrate/20170721210127_add_document_file_fingerprint.rb
+++ b/db/migrate/20170721210127_add_document_file_fingerprint.rb
@@ -1,0 +1,5 @@
+class AddDocumentFileFingerprint < ActiveRecord::Migration
+  def change
+    add_column :documents, :document_file_fingerprint, :string
+  end
+end

--- a/lib/tasks/batch_load/documentations.rake
+++ b/lib/tasks/batch_load/documentations.rake
@@ -25,7 +25,7 @@ namespace :tw do
 
         csv = CSV.parse(File.read(meta_data_file_path), { headers: true, col_sep: "\t" })
 
-        puts "Processing files".yellow
+        puts Rainbow("Processing files").yellow
         documents_created = 0
         documentations_created = 0
         rows_processed = 0
@@ -40,7 +40,7 @@ namespace :tw do
                 identifier = Identifier.find_by(cached: identifier_text)
 
                 if identifier.nil?
-                  puts "Object with identifier \"#{identifier_text}\" not found on row #{rows_processed}".yellow
+                  puts Rainbow("Object with identifier \"#{identifier_text}\" not found on row #{rows_processed}").yellow
                 else
                   identifier_object = identifier.identifier_object
 
@@ -59,10 +59,10 @@ namespace :tw do
                           document.save!
                           documents_created += 1
                         else
-                          puts "Document invalid on row #{rows_processed} - #{document.errors.full_messages.join("; ")}".red
+                          puts Rainbow("Document invalid on row #{rows_processed} - #{document.errors.full_messages.join("; ")}").red
                         end
                       else
-                          puts "Document already exists on row #{rows_processed}".yellow                        
+                          puts Rainbow("Document already exists on row #{rows_processed}").yellow                        
                       end
 
                       # If document exists and has been saved, create documentation with it
@@ -78,14 +78,14 @@ namespace :tw do
                             documentation.save!
                             documentations_created += 1
                           else
-                            puts "Documentation invalid on row #{rows_processed} - #{documentation.errors.full_messages.join("; ")}".red
+                            puts Rainbow("Documentation invalid on row #{rows_processed} - #{documentation.errors.full_messages.join("; ")}").red
                           end
                         else
-                          puts "Documentation already exists with this document/identifier_object pair on row #{rows_processed}".yellow
+                          puts Rainbow("Documentation already exists with this document/identifier_object pair on row #{rows_processed}").yellow
                         end
                       end
                     else
-                      puts "File \"#{filename}\" not found on row #{rows_processed}".yellow
+                      puts Rainbow("File \"#{filename}\" not found on row #{rows_processed}").yellow
                     end
                   end
                 end
@@ -96,8 +96,8 @@ namespace :tw do
           end
         end
 
-        puts "Finished processing files".yellow
-        puts "Created #{documentations_created} documentations and #{documents_created} documents".green
+        puts Rainbow("Finished processing files").yellow
+        puts Rainbow("Created #{documentations_created} documentations and #{documents_created} documents").green
       end
     end
   end

--- a/lib/tasks/batch_load/documentations.rake
+++ b/lib/tasks/batch_load/documentations.rake
@@ -5,9 +5,8 @@ namespace :tw do
       # Format
       #   rake tw:batch_load:documentations data_directory="/chromatograms/" meta_data_file="/chromatograms.csv project_id=1 user_id=2"
       # 
-      # The expected format for the meta data file is to be tab delimitted with 3 columns of "namespace_short_name", "identifier", and "filenames"
-      # namespace_short_name contains the short name of the namespace
-      # identifier contains the text of the identifier
+      # The expected format for the meta data file is to be tab delimitted with 2 columns of "identifier" and "filenames"
+      # identifier contains the namespace short name and text of the identifier e.g. "DRM 12345"
       # filenames contains the filenames of the files to be attached, multiple files can be in this field if separated by a ", "
       desc '
         Imports files in the filenames column as documents and attaches 
@@ -29,11 +28,10 @@ namespace :tw do
         documentations_created = 0
 
         csv.each do |row|
-          namespace_short_name = row["namespace_short_name"]
           identifier = row["identifier"]
           filenames = row["filenames"].split(", ")
-          
-          identifier_objects = Identifier.where(cached: "#{namespace_short_name} #{identifier}")
+
+          identifier_objects = Identifier.where(cached: identifier)
           identifier_object = nil
           identifier_object = identifier_objects.first.identifier_object if identifier_objects.any?
 
@@ -49,9 +47,11 @@ namespace :tw do
                 documentation.save!
                 documentations_created += 1
               else
-                puts "File #{file_path} does not exist".green
+                puts "File \"#{file_path}\" does not exist".yellow
               end
             end
+          else
+            puts "Object with identifier \"#{identifier}\" not found".yellow
           end
         end
 

--- a/lib/tasks/batch_load/documentations.rake
+++ b/lib/tasks/batch_load/documentations.rake
@@ -1,0 +1,63 @@
+namespace :tw do
+  namespace :batch_load do
+    namespace :documentations do
+      
+      # Format
+      #   rake tw:batch_load:documentations data_directory="/chromatograms/" meta_data_file="/chromatograms.csv project_id=1 user_id=2"
+      # 
+      # The expected format for the meta data file is to be tab delimitted with 3 columns of "namespace_short_name", "identifier", and "filenames"
+      # namespace_short_name contains the short name of the namespace
+      # identifier contains the text of the identifier
+      # filenames contains the filenames of the files to be attached, multiple files can be in this field if separated by a ", "
+      desc '
+        Imports files in the filenames column as documents and attaches 
+        them to the first object identified by the namespace_short_name 
+        and identifer column via documentations 
+      '
+      task :import => [:environment, :project_id, :user_id] do
+        data_directory_path = ENV["data_directory"]
+        meta_data_file_path = ENV["meta_data_file"]
+
+        raise "Path to data directory not provided".red if data_directory_path.nil?
+        raise "Data directory does not exist at #{data_directory_path}".red unless File.directory?(data_directory_path)
+        raise "Path to meta data file not provided".red if meta_data_file_path.nil?
+        raise "Meta data file does not exist at #{meta_data_file_path}".red unless File.exists?(meta_data_file_path)
+
+        csv = CSV.parse(File.read(meta_data_file_path), { headers: true, col_sep: "\t" })
+
+        puts "Processing files".yellow
+        documentations_created = 0
+
+        csv.each do |row|
+          namespace_short_name = row["namespace_short_name"]
+          identifier = row["identifier"]
+          filenames = row["filenames"].split(", ")
+          
+          identifier_objects = Identifier.where(cached: "#{namespace_short_name} #{identifier}")
+          identifier_object = nil
+          identifier_object = identifier_objects.first.identifier_object if identifier_objects.any?
+
+          if !identifier_object.nil?
+            filenames.each do |filename|
+              file_path = File.join(data_directory_path, filename)
+
+              if File.exists?(file_path)
+                document = Document.new(document_file: File.open(file_path))
+                document.save!
+
+                documentation = Documentation.new(document: document, documentation_object: identifier_object)
+                documentation.save!
+                documentations_created += 1
+              else
+                puts "File #{file_path} does not exist".green
+              end
+            end
+          end
+        end
+
+        puts "Finished processing files".yellow
+        puts "Created #{documentations_created} documentations".green
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds rake task to create Documents and attaches them to object identified by an identifier via Documentations. Task requires a directory of files to create as Documents and a specifying which object to attach the document to and which file to create as a document. The file format is with columns of 
"namespace_short_name", "identifier", "filenames". Filenames can contain multiple filenames when separated with a ", " (comma and space). Adds 'application/octet-stream' as a valid content_type for Documents and adds 'ab1' as a valid file extension for ''application/octet-stream' files.