### PR TITLE
GenBankAccessionCode and MorphbankSpecimenNumber global identifiers

### DIFF
--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -56,20 +56,22 @@ class Identifier < ActiveRecord::Base
   # !! If there are inheritance issues with validation the position
   # !! of this constant is likely the problem
   SHORT_NAMES = {
-    doi:            Identifier::Global::Doi,
-    isbn:           Identifier::Global::Isbn,
-    issn:           Identifier::Global::Issn,
-    lccn:           Identifier::Global::Lccn,
-    occurrence_id:  Identifier::Global::OccurrenceId,
-    orcid:          Identifier::Global::Orcid,
-    uri:            Identifier::Global::Uri,
-    uuid:           Identifier::Global::Uuid,
-    catalog_number: Identifier::Local::CatalogNumber,
-    trip_code:      Identifier::Local::TripCode,
-    import:         Identifier::Local::Import,
-    otu_utility:    Identifier::Local::OtuUtility,
-    accession_code: Identifier::Local::AccessionCode,
-    unknown:        Identifier::Unknown
+    doi:                       Identifier::Global::Doi,
+    isbn:                      Identifier::Global::Isbn,
+    issn:                      Identifier::Global::Issn,
+    lccn:                      Identifier::Global::Lccn,
+    occurrence_id:             Identifier::Global::OccurrenceId,
+    orcid:                     Identifier::Global::Orcid,
+    uri:                       Identifier::Global::Uri,
+    uuid:                      Identifier::Global::Uuid,
+    gen_bank_accession_code:   Identifier::Global::GenBankAccessionCode,
+    morphbank_specimen_number: Identifier::Global::MorphbankSpecimenNumber,
+    catalog_number:            Identifier::Local::CatalogNumber,
+    trip_code:                 Identifier::Local::TripCode,
+    import:                    Identifier::Local::Import,
+    otu_utility:               Identifier::Local::OtuUtility,
+    accession_code:            Identifier::Local::AccessionCode,
+    unknown:                   Identifier::Unknown
   }
 
   # Please DO NOT include the following:

--- a/app/models/identifier/global/gen_bank_accession_code.rb
+++ b/app/models/identifier/global/gen_bank_accession_code.rb
@@ -1,0 +1,27 @@
+# From NCBI-GenBank Flat File Release 220.0 at ftp://ftp.ncbi.nih.gov/genbank/gbrel.txt 
+# section 3.4.6 ACCESSION format
+# There are 2 formats, one format with 1 upper case letter followed by 5 numbers 
+# and another format with 2 upper case letters followed by 6 numbers
+# Format 1: A12345
+# Format 2: AB123456
+# For use with GenBank sequences
+
+class Identifier::Global::GenBankAccessionCode < Identifier::Global
+  validate :valid_gen_bank_accession_code
+
+  def valid_gen_bank_accession_code
+    if identifier.present?
+      matched = false
+
+      if /\A[A-Z][A-Z][0-9]{6}\Z/.match(identifier)
+        matched = true
+      elsif /\A[A-Z][0-9]{5}\Z/.match(identifier)
+        matched = true
+      end
+
+      if !matched
+        errors.add(:identifier, "invalid format")
+      end
+    end
+  end
+end

--- a/app/models/identifier/global/morphbank_specimen_number.rb
+++ b/app/models/identifier/global/morphbank_specimen_number.rb
@@ -1,0 +1,15 @@
+# For use with Morphbank specimens, currently just a number
+# e.g. 855664
+
+class Identifier::Global::MorphbankSpecimenNumber < Identifier::Global
+  validate :is_number
+
+  def is_number
+    if identifier.present?
+      # If non-number characters are in the string, invalid format
+      if /\D/.match(identifier)
+        errors.add(:identifier, "invalid format, only numbers allowed")
+      end
+    end
+  end
+end

--- a/spec/factories/identifier/global/gen_bank_accession_code_factory.rb
+++ b/spec/factories/identifier/global/gen_bank_accession_code_factory.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :identifier_global_gen_bank_accession_code, class: "Identifier::Global::GenBankAccessionCode", traits: [:housekeeping] do
+  end
+end

--- a/spec/factories/identifier/global/morphbank_specimen_number_factory.rb
+++ b/spec/factories/identifier/global/morphbank_specimen_number_factory.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :identifier_global_morphbank_specimen_number, class: "Identifier::Global::MorphbankSpecimenNumber", traits: [:housekeeping] do
+  end
+end

--- a/spec/models/identifier/global/gen_bank_accession_code_spec.rb
+++ b/spec/models/identifier/global/gen_bank_accession_code_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe Identifier::Global::GenBankAccessionCode, type: :model, group: :identifiers do
+  context "GenBankAccessionCode" do
+    let(:id) { FactoryGirl.build(:identifier_global_gen_bank_accession_code) }
+
+    context "#identifier is invalid format" do
+      specify "empty" do
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("can't be blank")
+      end
+
+      specify "too few characters" do
+        id.identifier = "A1"
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("invalid format")
+      end
+
+      specify "too many characters" do
+        id.identifier = "ABC1234567"
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("invalid format")
+      end
+
+      specify "lowercase 6 character version" do
+        id.identifier = "a12345"
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("invalid format")
+      end
+
+      specify "lowercase 8 character version" do
+        id.identifier = "ab123456"
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("invalid format")
+      end
+
+      context "valid identifier surrounded by other characters" do
+        specify "6 character version" do
+          id.identifier = "AB1234567"
+          expect(id.valid?).to be_falsey
+          expect(id.errors.messages[:identifier][0]).to eq("invalid format")
+        end
+
+        specify "8 character version" do
+          id.identifier = "AAB1234567"
+          expect(id.valid?).to be_falsey
+          expect(id.errors.messages[:identifier][0]).to eq("invalid format")
+        end
+      end
+    end
+
+    context "#identifier is valid format" do
+      specify "6 character version" do
+        id.identifier = "A12345"
+        expect(id.valid?).to be_truthy
+      end
+
+      specify "8 character version" do
+        id.identifier = "AB123456"
+        expect(id.valid?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/models/identifier/global/morphbank_specimen_number_spec.rb
+++ b/spec/models/identifier/global/morphbank_specimen_number_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe Identifier::Global::MorphbankSpecimenNumber, type: :model, group: :identifiers do
+  context "MorphbankSpecimenNumber" do
+    let(:id) { FactoryGirl.build(:identifier_global_morphbank_specimen_number) }
+
+    context "#identifier is invalid format" do
+      specify "empty" do
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("can't be blank")
+      end
+
+      specify "non-numbers" do
+        id.identifier = "asdfSJFoi-ASD_sfs"
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("invalid format, only numbers allowed")
+      end
+
+      specify "mixed" do
+        id.identifier = "2asdfS234JFoi-ASD_sfs333"
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("invalid format, only numbers allowed")
+      end
+    end
+
+    context "#identifier is valid format" do
+      specify "numbers" do
+        id.identifier = "123456"
+        expect(id.valid?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds GenBankAccessionCode and MorphbankSpecimenNumber as global identifiers. Constraints for GenBankAccessionCode were found ftp://ftp.ncbi.nih.gov/genbank/gbrel.txt in section 3.4.6 ACCESSION Format while constraints for MorphbankSpecimenNumber were found through analysis of multiple specimens on their online database.