### PR TITLE
Removed returning values from validation functions in global identifiers

### DIFF
--- a/app/models/identifier/global/isbn.rb
+++ b/app/models/identifier/global/isbn.rb
@@ -25,7 +25,6 @@ class Identifier::Global::Isbn < Identifier::Global
   validate :using_isbn_class
 
   def using_isbn_class
-    retval = true
     unless identifier.nil?
       isbn = identifier.upcase
       # 'ISBN-13: 978-0-596-52068-7'
@@ -50,7 +49,7 @@ class Identifier::Global::Isbn < Identifier::Global
       /[^\dX]/ =~ isbn
       unless $&.nil?
         errors.add(:identifier, "'#{identifier}' is an improperly formed ISBN.")
-        return false
+        return
       end
       # the final (checksum) digit has alreaqdy been identified, so we need 12 or 9 here
       /^(?<isbn_13>\d{12})\d$|^(?<isbn_10>\d{9}).$/ =~ isbn
@@ -59,7 +58,7 @@ class Identifier::Global::Isbn < Identifier::Global
           (isbn_10.nil? and isbn_13.nil?) or
           ((isbn_10.nil? and type == '10') or (isbn_13.nil? and type == '13'))
         errors.add(:identifier, "'#{identifier}' has the wrong number of digits.")
-        return false
+        return
       end
 
       data = isbn.slice(0, isbn.size - 1)
@@ -98,11 +97,9 @@ class Identifier::Global::Isbn < Identifier::Global
       # check_byte and/or last might be an 'X'
       if check_byte.to_s != last
         errors.add(:identifier, "'#{identifier}' has bad check digit.")
-        return false
+        return
       end
-
     end
-    retval
   end
 
   def ten_or_thirteen_digits?

--- a/app/models/identifier/global/issn.rb
+++ b/app/models/identifier/global/issn.rb
@@ -19,7 +19,6 @@ class Identifier::Global::Issn < Identifier::Global
   # @todo the validator for this identifier has been perverted so as to *NOT* require the preamble 'ISSN ', even though the ISSN spec is quite specific about its being there, because the Bibtex gem does not return it with the ISSN vslue as it should.
   def using_issn_class
     validate_preamble = false
-    retval = true
     unless identifier.nil?
       issn = identifier.upcase
 
@@ -28,7 +27,7 @@ class Identifier::Global::Issn < Identifier::Global
 
       if part_1.nil? or part_2.nil? or last.nil? or (preamble.nil? and validate_preamble)
         errors.add(:identifier, "'#{identifier}' is an improperly formed ISSN.")
-        return false
+        return
       end
 
       data = part_1 + part_2
@@ -47,9 +46,8 @@ class Identifier::Global::Issn < Identifier::Global
 
       if sum != 0
         errors.add(:identifier, "'#{identifier}' has bad check digit.")
-        return false
+        return
       end
     end
-    retval
   end
 end

--- a/app/models/identifier/global/lccn.rb
+++ b/app/models/identifier/global/lccn.rb
@@ -23,7 +23,6 @@ class Identifier::Global::Lccn < Identifier::Global
   validate :using_iccn_class
 
   def using_iccn_class
-    retval = true
     unless identifier.nil?
       lccn = identifier
 
@@ -53,28 +52,23 @@ class Identifier::Global::Lccn < Identifier::Global
             end
         end
         year = century + year_a
-        return true
+        return
       end
 
-      return retval unless (year_b.nil? or serial_b.nil?)
+      return unless (year_b.nil? or serial_b.nil?)
 
       unless year_b.nil?
         year = year_b.to_i
         if (year > Time.now.year) or (year < 2001)
           errors.add(:identifier, "'#{identifier}' is too far in the future, or before 2001.")
-          return false
+          return
         end
       else
         if serial_b.nil?
           errors.add(:identifier, "'#{identifier}' is an improperly formed LCCN.")
-          return false
+          return
         end
       end
-
-      # errors.add(:identifier, "'#{identifier}' is an improperly formed LCCN.")
-      # return false
-
     end
-    retval
   end
 end

--- a/app/models/identifier/global/lsid.rb
+++ b/app/models/identifier/global/lsid.rb
@@ -11,7 +11,6 @@ class Identifier::Global::Lsid < Identifier::Global
   validate :using_lsid_class
 
   def using_lsid_class
-    retval = true
     unless identifier.nil?
       lsid = identifier.split(':')
       # this is a test of http://rubular.com/regexes/13295
@@ -20,10 +19,8 @@ class Identifier::Global::Lsid < Identifier::Global
       unless lsid.length.between?(5, 6)
         unless lsid[0].upcase == 'URN' and lsid[1].upcase == 'LSID'
           errors.add(:identifier, "'#{identifier}' is not a valid LSID.")
-          retval = false
         end
       end
     end
-    return retval
   end
 end

--- a/app/models/identifier/global/occurrence_id.rb
+++ b/app/models/identifier/global/occurrence_id.rb
@@ -4,8 +4,6 @@ class Identifier::Global::OccurrenceId < Identifier::Global
   validate :using_occurrence_id_class
 
   def using_occurrence_id_class
-    retval = true
     # todo: decide exactly what rules to use to qualify this class as acceptable.
-    retval
   end
 end

--- a/app/models/identifier/global/orcid.rb
+++ b/app/models/identifier/global/orcid.rb
@@ -5,7 +5,6 @@ class Identifier::Global::Orcid < Identifier::Global
 
   # 'http://orcid.org/0000-0002-1825-0097'
   def using_orcid_class
-    retval = true
     unless identifier.nil?
       orcid = identifier.upcase
 
@@ -13,15 +12,14 @@ class Identifier::Global::Orcid < Identifier::Global
 
       if domain.nil? or part_1.nil? or part_2.nil? or part_3.nil? or part_4.nil? or last.nil?
         errors.add(:identifier, "'#{identifier}' is an improperly formed ORCID ID.")
-        return false
+        return
       end
 
       if last != generate_check_digit(part_1 + part_2 + part_3 + part_4)
         errors.add(:identifier, "'#{identifier}' has bad check digit.")
-        return false
+        return
       end
     end
-    retval
   end
 
   def generate_check_digit(base_digits)

--- a/app/models/identifier/global/uri.rb
+++ b/app/models/identifier/global/uri.rb
@@ -5,32 +5,25 @@ class Identifier::Global::Uri < Identifier::Global
   validate :using_uri_class
 
   def using_uri_class
-    retval = false
     unless identifier.nil?
-      retval = true
       uris = URI.extract(identifier)
       if uris.count == 0
         errors.add(:identifier, 'No URI detected.')
-        retval = false
       else
         unless (identifier.length == uris[0].length) and (uris.count == 1)
           errors.add(:identifier, 'More than a single URI present.')
-          retval = false
         else
           begin
             uri = URI(identifier)
             scheme = uri.scheme.upcase
             unless URI_SCHEMES.include?(scheme)
               errors.add(:identifier, "#{scheme} is not in the URI schemes list.")
-              retval = false
             end
           rescue
             errors.add(:identifier, "Badly formed URI #{identifier} detected.")
-            retval = false
           end
         end
       end
     end
-    retval
   end
 end

--- a/app/models/identifier/global/uuid.rb
+++ b/app/models/identifier/global/uuid.rb
@@ -7,13 +7,10 @@ class Identifier::Global::Uuid < Identifier::Global
 
   def using_uuid_class
     unless identifier.nil?
-      retval = true
       /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i =~ identifier
       if $&.nil?
         errors.add(:identifier, "#{identifier} is not a valid UUID.")
-        retval = false
       end
-      retval
     end
   end
 end


### PR DESCRIPTION
Removed `retval` and other returning values in the validation functions for most of the global identifiers since it doesn't matter what gets returned for validation functions.