### PR TITLE
Gene compress logic regex

### DIFF
--- a/app/models/descriptor/gene.rb
+++ b/app/models/descriptor/gene.rb
@@ -200,7 +200,11 @@ class Descriptor::Gene < Descriptor
     b = gene_attribute_term_index
 
     b.each do |k, v|
-      a.gsub!(/#{k}/, v)
+      # Match whole words, ABC should only match ABC NOT AB.
+      # Uses lookahead to acomplish this by checking if the
+      # next character is a space, closing parentheses, or
+      # is the end of the string
+      a.gsub!(/#{k}(?=[\s)]|$)/, v)
     end
     a.gsub!(/\s+OR\s+/, '+')
     a.gsub!(/\s+AND\s+/, '.')

--- a/spec/models/descriptor/gene/logic_spec.rb
+++ b/spec/models/descriptor/gene/logic_spec.rb
@@ -94,6 +94,11 @@ RSpec.describe Descriptor::Gene, type: :model, group: [:descriptor, :matrix, :dn
 
     specify '#compress_logic' do
       expect(descriptor.compress_logic).to eq('(a+b).(c+d)')
+
+      # Make sure the compress logic replaces whole words and not just partial words
+      # e.g A.10 matches only A.10 and NOT A.1
+      descriptor.gene_attribute_logic = '(A.1 OR B.2) AND (A.10 OR B.20)'
+      expect(descriptor.compress_logic).to eq('(a+b).(c+d)')
     end
 
     specify '#attributes_from_or_queries' do


### PR DESCRIPTION
These changes to the regex expression in the `compress_logic` function for `Descriptor::Gene` makes it so that it correctly replaces the sequence relationships to their symbol equivalents. Before, given `(A.1 OR B.2) AND (A.10 OR B.20)` as a `gene_attribute_logic`, the result from `compress_logic` would be `(a+b).(a0+b0)` instead of `(a+b).(c+d)` as `A.10` matched with `A.1` and `B.20` matched with `B.2`.