### PR TITLE
[WIP] Browse sequences task

### DIFF
--- a/app/controllers/tasks/sequences/browse_controller.rb
+++ b/app/controllers/tasks/sequences/browse_controller.rb
@@ -7,15 +7,11 @@ class Tasks::Sequences::BrowseController < ApplicationController
 
   # POST
   def sequences
-    sequences = []
     gene_id = params[:gene_id]
     gene = Descriptor.find_by(id: gene_id)
-
-    if gene
-      sequences = gene.sequences
-      puts gene
-    end
-
+    sequences = []
+    sequences = gene.sequences if gene
+    
     render :json => sequences
   end
 end

--- a/app/controllers/tasks/sequences/browse_controller.rb
+++ b/app/controllers/tasks/sequences/browse_controller.rb
@@ -1,0 +1,21 @@
+class Tasks::Sequences::BrowseController < ApplicationController
+  include TaskControllerConfiguration
+
+  # GET
+  def index
+  end
+
+  # POST
+  def sequences
+    sequences = []
+    gene_id = params[:gene_id]
+    gene = Descriptor.find_by(id: gene_id)
+
+    if gene
+      sequences = gene.sequences
+      puts gene
+    end
+
+    render :json => sequences
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@
 require('./vue/citations/otus/main.js');
 require('./vue/content/editor/main.js');
 require('./vue/nomenclature/new_taxon_name/main.js');
+require('./vue/sequences/browse/main.js');
 require('./vue/loan/main.js');
 require('./vue/matrix_row_coder/main.js');
 require('./vue/annotator_init/main.js');

--- a/app/javascript/packs/vue/sequences/browse/app.vue
+++ b/app/javascript/packs/vue/sequences/browse/app.vue
@@ -1,10 +1,12 @@
-<<template>
+<template>
     <div id="browse_sequences">
-        <autocomplete 
+        <autocomplete
+            id="gene_autocomplete"
             url="/descriptors/autocomplete" 
             param="term" 
             min="1" 
             label="label"
+            placeholder="Enter Gene name"
             @getItem="loadGene">
         </autocomplete>
         <paged-table-header :maxItems="list.length" :perPage="itemsPerPage" @newPage="newPage"></paged-table-header>
@@ -13,7 +15,7 @@
     </div>
 </template>
 
-<<script>
+<script>
     import tableList from "../../components/table_list.vue";
     import autocomplete from "../../components/autocomplete.vue";
     import pagedTableHeader from "./components/pagedTableHeader.vue";
@@ -59,3 +61,9 @@
         }
     }
 </script>
+
+<style scoped>
+    #gene_autocomplete {
+        margin-bottom: 5px;
+    }
+</style>

--- a/app/javascript/packs/vue/sequences/browse/app.vue
+++ b/app/javascript/packs/vue/sequences/browse/app.vue
@@ -9,27 +9,29 @@
             placeholder="Enter Gene name"
             @getItem="loadGene">
         </autocomplete>
-        <paged-table-header title="Displaying sequences" :maxItems="list.length" :perPage="itemsPerPage" @newPage="newPage"></paged-table-header>
-        <table-list :list="slicedList" :header="header" :attributes="attributes" :edit="true" :destroy="false" @edit="editSequence">
-        </table-list> 
+        <paged-table
+            title="Displaying sequences"
+            :list="list"
+            :header="header"
+            :attributes="attributes"
+            :edit="true"
+            :destroy="false"
+            @edit="editSequence">
+        </paged-table>
     </div>
 </template>
 
 <script>
-    import tableList from "../../components/table_list.vue";
     import autocomplete from "../../components/autocomplete.vue";
-    import pagedTableHeader from "./components/pagedTableHeader.vue";
+    import pagedTable from "./components/pagedTable.vue";
 
     export default {
         components: {
-            tableList,
             autocomplete,
-            pagedTableHeader
+            pagedTable
         },
         data: function() {
             return {
-                itemsPerPage: 25,
-                currentPage: 1,
                 list: [],
                 header: [
                     "Name"
@@ -47,16 +49,6 @@
             },
             editSequence: (sequence) => {
                 window.location.href = "/sequences/" + sequence.id;
-            },
-            newPage: function(newPage) {
-                this.currentPage = newPage;
-            }
-        },
-        computed: {
-            slicedList: function() {
-                const begIndex = this.itemsPerPage * (this.currentPage - 1);
-
-                return this.list.slice(begIndex, begIndex + this.itemsPerPage);
             }
         }
     }

--- a/app/javascript/packs/vue/sequences/browse/app.vue
+++ b/app/javascript/packs/vue/sequences/browse/app.vue
@@ -9,7 +9,7 @@
             placeholder="Enter Gene name"
             @getItem="loadGene">
         </autocomplete>
-        <paged-table-header :maxItems="list.length" :perPage="itemsPerPage" @newPage="newPage"></paged-table-header>
+        <paged-table-header title="Displaying sequences" :maxItems="list.length" :perPage="itemsPerPage" @newPage="newPage"></paged-table-header>
         <table-list :list="slicedList" :header="header" :attributes="attributes" :edit="true" :destroy="false" @edit="editSequence">
         </table-list> 
     </div>

--- a/app/javascript/packs/vue/sequences/browse/app.vue
+++ b/app/javascript/packs/vue/sequences/browse/app.vue
@@ -1,0 +1,61 @@
+<<template>
+    <div id="browse_sequences">
+        <autocomplete 
+            url="/descriptors/autocomplete" 
+            param="term" 
+            min="1" 
+            label="label"
+            @getItem="loadGene">
+        </autocomplete>
+        <paged-table-header :maxItems="list.length" :perPage="itemsPerPage" @newPage="newPage"></paged-table-header>
+        <table-list :list="slicedList" :header="header" :attributes="attributes" :edit="true" :destroy="false" @edit="editSequence">
+        </table-list> 
+    </div>
+</template>
+
+<<script>
+    import tableList from "../../components/table_list.vue";
+    import autocomplete from "../../components/autocomplete.vue";
+    import pagedTableHeader from "./components/pagedTableHeader.vue";
+
+    export default {
+        components: {
+            tableList,
+            autocomplete,
+            pagedTableHeader
+        },
+        data: function() {
+            return {
+                itemsPerPage: 25,
+                currentPage: 1,
+                list: [],
+                header: [
+                    "Name"
+                ],
+                attributes: [
+                    "name"
+                ]
+            }
+        },
+        methods: {
+            loadGene: function (gene) {
+                this.$http.get("/tasks/sequence/browse/sequences?gene_id=" + gene.id).then(res => {
+                    this.list = res.body;
+                });
+            },
+            editSequence: (sequence) => {
+                window.location.href = "/sequences/" + sequence.id;
+            },
+            newPage: function(newPage) {
+                this.currentPage = newPage;
+            }
+        },
+        computed: {
+            slicedList: function() {
+                const begIndex = this.itemsPerPage * (this.currentPage - 1);
+
+                return this.list.slice(begIndex, begIndex + this.itemsPerPage);
+            }
+        }
+    }
+</script>

--- a/app/javascript/packs/vue/sequences/browse/components/pagedTable.vue
+++ b/app/javascript/packs/vue/sequences/browse/components/pagedTable.vue
@@ -6,7 +6,8 @@
             :perPage="perPage"
             :pagesDisplayed="pagesDisplayed"
             :title="title"
-            @newPage="newPage">
+            @newPage="newPage"
+            @showAll="showAll">
         </paged-table-header>
         <table-list
             :list="pagedList"
@@ -27,7 +28,8 @@
     export default {
         data: function() {
             return {
-                currentPage: this.initialPage
+                currentPage: this.initialPage,
+                paginating: true
             }
         },
         props: {
@@ -79,6 +81,10 @@
         methods: {
             newPage: function(newPage) {
                 this.currentPage = newPage;
+                this.paginating = true;
+            },
+            showAll: function() {
+                this.paginating = false;
             },
             deleteCallback: function(item) {
                 this.$emit("delete", item);
@@ -89,8 +95,13 @@
         },
         computed: {
             pagedList: function() {
-                const begIndex = this.perPage * (this.currentPage - 1);
-                return this.list.slice(begIndex, begIndex + this.perPage);
+                if(this.paginating) {
+                    const begIndex = this.perPage * (this.currentPage - 1);
+                    return this.list.slice(begIndex, begIndex + this.perPage);
+                }
+
+                else
+                    return this.list;
             }
         }
     }

--- a/app/javascript/packs/vue/sequences/browse/components/pagedTable.vue
+++ b/app/javascript/packs/vue/sequences/browse/components/pagedTable.vue
@@ -1,0 +1,97 @@
+<template>
+    <div>
+        <paged-table-header
+            :maxItems="list.length"
+            :initialPage="initialPage"
+            :perPage="perPage"
+            :pagesDisplayed="pagesDisplayed"
+            :title="title"
+            @newPage="newPage">
+        </paged-table-header>
+        <table-list
+            :list="pagedList"
+            :attributes="attributes"
+            :header="header"
+            :destroy="destroy"
+            :edit="edit"
+            @delete="deleteCallback"
+            @edit="editCallback">
+        </table-list>
+    </div>
+</template>
+
+<script>
+    import pagedTableHeader from "./pagedTableHeader.vue";
+    import tableList from "../../../components/table_list.vue";
+
+    export default {
+        data: function() {
+            return {
+                currentPage: this.initialPage
+            }
+        },
+        props: {
+            initialPage: {
+                type: Number,
+                default: 1
+            },
+            perPage: {
+                type: Number,
+                default: 25
+            },
+            pagesDisplayed: {
+                type: Number,
+                default: 9
+            },
+            title: {
+                type: String,
+                default: "Displaying"
+            },
+            list: {
+				type: Array,
+				default: () => { 
+					return []
+				}
+			},
+			attributes: {
+				type: Array,
+				required: true
+			},
+			header: {
+				type: Array,
+				default: () => {
+					return []
+				}
+			},
+			destroy: {
+				type: Boolean,
+				default: true
+			},
+			edit: {
+				type: Boolean,
+				default: false
+			}
+        },
+        components: {
+            pagedTableHeader,
+            tableList
+        },
+        methods: {
+            newPage: function(newPage) {
+                this.currentPage = newPage;
+            },
+            deleteCallback: function(item) {
+                this.$emit("delete", item);
+            },
+            editCallback: function(item) {
+                this.$emit("edit", item);
+            }
+        },
+        computed: {
+            pagedList: function() {
+                const begIndex = this.perPage * (this.currentPage - 1);
+                return this.list.slice(begIndex, begIndex + this.perPage);
+            }
+        }
+    }
+</script>

--- a/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
+++ b/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
@@ -1,48 +1,46 @@
 <template>
-	<div>
-        <div class="panel column-big separate-right" data-help="Use the left and right buttoms to hide or show columns groups">
-            <div class="title nav-line ">
-                <span>{{ title }}<b> {{ getBegItemCount() }}&nbsp;-&nbsp;{{ getEndItemCount() }}</b> of <b>{{ this.maxItems }}</b></span>
-            </div>      
-            <div class="navigation-controls"> 
-                <div class="navigation-bar-left">
-                    <div class="page-navigator">
-                        <span>
-                            <a v-if="currentPage > 1" href="#" @click.prevent="prevPage">
-                                ‹ Back
-                            </a>
-                            <template v-else>
-                                ‹ Back
-                            </template>
-                        </span>
-                        <span>
-                            <a v-if="currentPage < totalPages" href="#" @click.prevent="nextPage">
-                                Next ›
-                            </a>
-                            <template v-else>
-                                Next ›
-                            </template>
-                        </span> 
-                    </div>
-                    <nav class="pagination" role="navigation" aria-label="pager">
-                        <span v-if="begPage > 1" class="page gap">...</span>
-                        <span v-for="i in range(begPage, endPage + 1)" :key="i" class="page" :class="{ current: i === currentPage }">
-                            <template v-if="i === currentPage">
-                                {{ i }}
-                            </template>
-                            <a v-else href="#" @click.prevent="selectPage(i)">{{ i }}</a>
-                        </span>
-                        <span v-if="endPage < totalPages" class="page gap">...</span>
-                        <span v-if="currentPage > 1" class="first">
-                            <a href="#" @click.prevent="selectPage(1)">« First</a>
-                        </span>
-                        <span v-if="currentPage < totalPages" class="last">
-                            <a href="#" @click.prevent="selectPage(totalPages)">Last »</a>
-                        </span>
-                    </nav>
+    <div class="panel column-big separate-right" data-help="Use the left and right buttoms to hide or show columns groups">
+        <div class="title nav-line ">
+            <span>{{ title }}<b> {{ getBegItemCount() }}&nbsp;-&nbsp;{{ getEndItemCount() }}</b> of <b>{{ this.maxItems }}</b></span>
+        </div>      
+        <div class="navigation-controls"> 
+            <div class="navigation-bar-left">
+                <div class="page-navigator">
+                    <span>
+                        <a v-if="currentPage > 1" href="#" @click.prevent="prevPage">
+                            ‹ Back
+                        </a>
+                        <template v-else>
+                            ‹ Back
+                        </template>
+                    </span>
+                    <span>
+                        <a v-if="currentPage < totalPages" href="#" @click.prevent="nextPage">
+                            Next ›
+                        </a>
+                        <template v-else>
+                            Next ›
+                        </template>
+                    </span> 
                 </div>
-            </div>       
-        </div>
+                <nav class="pagination" role="navigation" aria-label="pager">
+                    <span v-if="begPage > 1" class="page gap">...</span>
+                    <span v-for="i in range(begPage, endPage + 1)" :key="i" class="page" :class="{ current: i === currentPage }">
+                        <template v-if="i === currentPage">
+                            {{ i }}
+                        </template>
+                        <a v-else href="#" @click.prevent="selectPage(i)">{{ i }}</a>
+                    </span>
+                    <span v-if="endPage < totalPages" class="page gap">...</span>
+                    <span v-if="currentPage > 1" class="first">
+                        <a href="#" @click.prevent="selectPage(1)">« First</a>
+                    </span>
+                    <span v-if="currentPage < totalPages" class="last">
+                        <a href="#" @click.prevent="selectPage(totalPages)">Last »</a>
+                    </span>
+                </nav>
+            </div>
+        </div>       
     </div>
 </template>
 
@@ -59,7 +57,7 @@
             },
             perPage: {
                 type: Number,
-                default: 1
+                default: 25
             },
             pagesDisplayed: {
                 type: Number,

--- a/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
+++ b/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
@@ -1,0 +1,140 @@
+<template>
+	<div>
+        <div class="panel column-big separate-right" data-help="Use the left and right buttoms to hide or show columns groups">
+            <div class="title nav-line ">
+                <span>{{ title }}<b> {{ getBegItemCount() }}&nbsp;-&nbsp;{{ getEndItemCount() }}</b> of <b>{{ this.maxItems }}</b></span>
+            </div>      
+            <div class="navigation-controls"> 
+                <div class="navigation-bar-left">
+                    <div class="page-navigator">
+                        <span>
+                            <a v-if="currentPage > 1" href="#" @click.prevent="prevPage">
+                                ‹ Back
+                            </a>
+                            <template v-else>
+                                ‹ Back
+                            </template>
+                        </span>
+                        <span>
+                            <a v-if="currentPage < totalPages" href="#" @click.prevent="nextPage">
+                                Next ›
+                            </a>
+                            <template v-else>
+                                Next ›
+                            </template>
+                        </span> 
+                    </div>
+                    <nav class="pagination" role="navigation" aria-label="pager">
+                        <span v-if="begPage > 1" class="page gap">...</span>
+                        <span v-for="i in range(begPage, endPage + 1)" :key="i" class="page" :class="{ current: i === currentPage }">
+                            <template v-if="i === currentPage">
+                                {{ i }}
+                            </template>
+                            <a v-else href="#" @click.prevent="selectPage(i)">{{ i }}</a>
+                        </span>
+                        <span v-if="endPage < totalPages" class="page gap">...</span>
+                        <span v-if="currentPage > 1" class="first">
+                            <a href="#" @click.prevent="selectPage(1)">« First</a>
+                        </span>
+                        <span v-if="currentPage < totalPages" class="last">
+                            <a href="#" @click.prevent="selectPage(totalPages)">Last »</a>
+                        </span>
+                    </nav>
+                </div>
+            </div>       
+        </div>
+    </div>
+</template>
+<script>
+    export default {
+        props: {
+            maxItems: {
+                type: Number,
+                required: true
+            },
+            initialPage: {
+                type: Number,
+                default: 1
+            },
+            perPage: {
+                type: Number,
+                default: 1
+            },
+            pagesDisplayed: {
+                type: Number,
+                default: 9
+            },
+            title: {
+                type: String,
+                default: "Displaying"
+            }
+        },
+        data: function() {
+            return {
+                currentPage: this.initialPage,
+                totalPages: Math.ceil(this.maxItems / this.perPage),
+                begPage: 0,
+                endPage: 0
+            }
+        },
+        mounted: function() {
+            this.updatePageBoundaries();
+        },
+        methods: {
+            prevPage: function() {
+                this.$emit("newPage", --this.currentPage);
+            },
+            nextPage: function() {
+                this.$emit("newPage", ++this.currentPage)
+            },
+            selectPage: function(newPage) {
+                this.currentPage = newPage;
+                this.$emit("newPage", this.currentPage);
+            },
+            getBegItemCount: function() {
+                let begItemCount = (this.currentPage * this.perPage) - (this.perPage - 1);
+
+                if(this.maxItems <= 0)
+                    begItemCount = 0;
+                
+                return begItemCount;
+            },
+            getEndItemCount: function() {
+                let endItemCount = this.currentPage * this.perPage;
+
+                if(endItemCount > this.maxItems)
+                    endItemCount = this.maxItems;
+
+                return endItemCount;
+            },
+            range: function(beg, end) {
+                let arr = [];
+
+                for(let i = beg; i < end; i++)
+                    arr.push(i);
+
+                return arr;
+            },
+            updatePageBoundaries: function() {
+                const half = Math.floor(this.pagesDisplayed / 2);
+                this.begPage = this.currentPage - half
+                this.endPage = this.currentPage + half;
+
+                if(this.begPage < 1)
+                    this.begPage = 1
+
+                if(this.endPage > this.totalPages)
+                    this.endPage = this.totalPages;
+            }
+        },
+        watch: {
+            currentPage: function() {
+                this.updatePageBoundaries();
+            },
+            maxItems: function() {
+                this.totalPages = Math.ceil(this.maxItems / this.perPage);
+                this.updatePageBoundaries();
+            }
+        }
+    }
+</script>

--- a/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
+++ b/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
@@ -5,42 +5,48 @@
         </div>      
         <div class="navigation-controls"> 
             <div class="navigation-bar-left">
-                <div class="page-navigator">
-                    <span>
-                        <a v-if="currentPage > 1" href="#" @click.prevent="prevPage">
-                            ‹ Back
-                        </a>
-                        <template v-else>
-                            ‹ Back
-                        </template>
-                    </span>
-                    <span>
-                        <a v-if="currentPage < totalPages" href="#" @click.prevent="nextPage">
-                            Next ›
-                        </a>
-                        <template v-else>
-                            Next ›
-                        </template>
-                    </span> 
-                </div>
-                <nav class="pagination" role="navigation" aria-label="pager">
-                    <span v-if="begPage > 1" class="page gap">...</span>
-                    <span v-for="i in range(begPage, endPage + 1)" :key="i" class="page" :class="{ current: i === currentPage }">
-                        <template v-if="i === currentPage">
-                            {{ i }}
-                        </template>
-                        <a v-else href="#" @click.prevent="selectPage(i)">{{ i }}</a>
-                    </span>
-                    <span v-if="endPage < totalPages" class="page gap">...</span>
-                    <span v-if="currentPage > 1" class="first">
-                        <a href="#" @click.prevent="selectPage(1)">« First</a>
-                    </span>
-                    <span v-if="currentPage < totalPages" class="last">
-                        <a href="#" @click.prevent="selectPage(totalPages)">Last »</a>
-                    </span>
-                </nav>
+                <template v-if="paginating">
+                    <div class="page-navigator">
+                        <span>
+                            <a v-if="currentPage > 1" href="#" @click.prevent="prevPage">
+                                ‹ Back
+                            </a>
+                            <template v-else>
+                                ‹ Back
+                            </template>
+                        </span>
+                        <span>
+                            <a v-if="currentPage < totalPages" href="#" @click.prevent="nextPage">
+                                Next ›
+                            </a>
+                            <template v-else>
+                                Next ›
+                            </template>
+                        </span> 
+                    </div>
+                    <nav class="pagination" role="navigation" aria-label="pager">
+                        <span v-if="begPage > 1" class="page gap">...</span>
+                        <span v-for="i in range(begPage, endPage + 1)" :key="i" class="page" :class="{ current: i === currentPage }">
+                            <template v-if="i === currentPage">
+                                {{ i }}
+                            </template>
+                            <a v-else href="#" @click.prevent="selectPage(i)">{{ i }}</a>
+                        </span>
+                        <span v-if="endPage < totalPages" class="page gap">...</span>
+                        <span v-if="currentPage > 1" class="first">
+                            <a href="#" @click.prevent="selectPage(1)">« First</a>
+                        </span>
+                        <span v-if="currentPage < totalPages" class="last">
+                            <a href="#" @click.prevent="selectPage(totalPages)">Last »</a>
+                        </span>
+                    </nav>
+                </template>
+                <span class="paginating">
+                    <a v-if="paginating" href="#" @click.prevent="showAll">Show all</a>
+                    <a v-else href="#" @click.prevent="paginate">Paginate</a>
+                </span>
             </div>
-        </div>       
+        </div>
     </div>
 </template>
 
@@ -73,11 +79,12 @@
                 currentPage: this.initialPage,
                 totalPages: Math.ceil(this.maxItems / this.perPage),
                 begPage: 0,
-                endPage: 0
+                endPage: 0,
+                paginating: true
             }
         },
         mounted: function() {
-            this.updatePageBoundaries();
+            this.calculateBoundaries();
         },
         methods: {
             prevPage: function() {
@@ -90,7 +97,22 @@
                 this.currentPage = newPage;
                 this.$emit("newPage", this.currentPage);
             },
+            showAll: function() {
+                this.paginating = false;
+                this.$emit("showAll");
+            },
+            paginate: function() {
+                this.paginating = true;
+                this.$emit("newPage", this.currentPage);
+            },
             getBegItemCount: function() {
+                if(!this.paginating) {
+                    if(this.maxItems > 0)
+                        return 1;
+
+                    return 0;
+                }
+                
                 let begItemCount = (this.currentPage * this.perPage) - (this.perPage - 1);
 
                 if(this.maxItems <= 0)
@@ -99,6 +121,9 @@
                 return begItemCount;
             },
             getEndItemCount: function() {
+                if(!this.paginating)
+                    return this.maxItems;
+
                 let endItemCount = this.currentPage * this.perPage;
 
                 if(endItemCount > this.maxItems)
@@ -114,7 +139,9 @@
 
                 return arr;
             },
-            updatePageBoundaries: function() {
+            calculateBoundaries: function() {
+                this.totalPages = Math.ceil(this.maxItems / this.perPage);
+
                 const half = Math.floor(this.pagesDisplayed / 2);
                 this.begPage = this.currentPage - half
                 this.endPage = this.currentPage + half;
@@ -128,12 +155,22 @@
         },
         watch: {
             currentPage: function() {
-                this.updatePageBoundaries();
+                this.calculateBoundaries();
             },
             maxItems: function() {
-                this.totalPages = Math.ceil(this.maxItems / this.perPage);
-                this.updatePageBoundaries();
-            }
+                this.calculateBoundaries();
+            },
+            perPage: function() {
+                this.calculateBoundaries();
+            },
+            pagesDisplayed: function() {
+                this.calculateBoundaries();
+            },
         }
     }
 </script>
+<style scoped>
+    .paginating {
+        margin-left: 5px;
+    }
+</style>

--- a/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
+++ b/app/javascript/packs/vue/sequences/browse/components/pagedTableHeader.vue
@@ -45,6 +45,7 @@
         </div>
     </div>
 </template>
+
 <script>
     export default {
         props: {

--- a/app/javascript/packs/vue/sequences/browse/main.js
+++ b/app/javascript/packs/vue/sequences/browse/main.js
@@ -1,0 +1,30 @@
+var TW = TW || {};
+TW.views = TW.views || {};
+TW.views.tasks = TW.views.tasks || {};
+TW.views.tasks.sequences = TW.views.tasks.sequences || {};
+TW.views.tasks.sequences.browse = TW.views.tasks.sequences.browse || {};
+
+import Vue from 'vue';
+import VueResource from 'vue-resource';
+
+Object.assign(TW.views.tasks.sequences.browse, {
+    init: function() {
+        Vue.use(VueResource);
+        var App = require('./app.vue').default;
+        var token = $('[name="csrf-token"]').attr('content');
+        Vue.http.headers.common['X-CSRF-Token'] = token;
+
+        new Vue({
+            el: '#browse_sequences',
+            render: function(createElement) {
+                return createElement(App);
+            }
+        })
+    }
+});
+
+$(document).on('turbolinks:load', function() {
+    if($("#browse_sequences").length) {
+        TW.views.tasks.sequences.browse.init();
+    }
+});

--- a/app/views/tasks/sequences/browse/index.html.erb
+++ b/app/views/tasks/sequences/browse/index.html.erb
@@ -1,0 +1,4 @@
+<h1>Browse Sequences</h1>
+
+<div id="browse_sequences">
+</div>

--- a/config/interface/hub/user_tasks.yml
+++ b/config/interface/hub/user_tasks.yml
@@ -275,3 +275,10 @@ edit_loan_task:
     - collection_object
   status: prototype
   description: 'Create and edit loans.'
+browse_sequences_task:
+  hub: true
+  name: 'Browse sequences'
+  related:
+  categories:
+  status: prototype
+  description: 'Report everything known about a sequence'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -574,6 +574,13 @@ TaxonWorks::Application.routes.draw do
   ### End of data resources ###
 
   scope :tasks do
+    scope :sequence do
+      scope :browse, controller: 'tasks/sequences/browse' do
+        get 'index', as: 'browse_sequences_task'
+        get 'sequences'
+      end
+    end
+
     scope :observation_matrices do
       scope :row_coder, controller: 'tasks/observation_matrices/row_coder' do
         get 'index', as: 'index_row_coder_task'


### PR DESCRIPTION
This pull request is mainly to just get feedback to make sure the pattern is correct for developing tasks using VueJS. This task is to retrieve all sequences that are associated with a Gene Descriptor and display them in a table. It uses the `autocomplete` and `tableList` component for querying Gene Descriptors and displaying the sequences. A `pagedTableHeader` component was also made to add paging capabilities similar to how the list view works for data models e.g. Taxon Names.

Couple of questions I have
1) Currently when searching for sequences it creates an ajax call behind the scenes for the sequences, this leaves the url unchanged making it impossible to share the current page. Should I pursue modifying the url on each request so that sharing a link is possible?
2) I considered making a `pagedTable` component that encapsulated the `tableList` component in it with the `pagedTableHeader` component but ditched the idea as that would mean I would have to pass all the props from the `pagedTable` component to its child `tableList` component which would require a bunch of code just for passing those props. Should I have continued with the idea anyways?