### PR TITLE
TableList Component Transition

### DIFF
--- a/app/javascript/packs/vue/components/table_list.vue
+++ b/app/javascript/packs/vue/components/table_list.vue
@@ -82,15 +82,10 @@
 		justify-content: space-between;
 		transition: all 0.5s, opacity 0.2s;
 	}
-	.list-complete-enter, .list-complete-leave-to
+	.list-complete-enter-active, .list-complete-leave-active
 	{
 		opacity: 0;
 		font-size: 0px;
 		border:none;
-		transform: scale(0.0);
-	}
-	.list-complete-leave-active {
-		width: 100%;
-		position: absolute;
 	}
 </style>


### PR DESCRIPTION
Changes the transition for elements in the `table_list` Vue component to be a fade in/out transition. Previously the transition would cause elements to be shifted up and layering on top of each other.

Before:
![defaulttransition](https://user-images.githubusercontent.com/2141272/34064056-225950fe-e1ab-11e7-9b1a-bd13600ee2f8.gif)

Now:
![newtransition](https://user-images.githubusercontent.com/2141272/34064062-28550b1a-e1ab-11e7-80e4-9f4a9269b061.gif)
