### PR TITLE
Using deprecation warning fix from official closure_tree repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'exception_notification', '~> 4.4'
 
 # Models
 gem 'bcrypt', '~> 3.1.11'
-gem 'closure_tree', github: 'ClosureTree/closure_tree', ref: '9b5245e' # '~> 7.0'  
+gem 'closure_tree', github: 'ClosureTree/closure_tree', ref: '15b253e' # '~> 7.0'
 
 gem 'delayed_job_active_record', '~> 4.1.3'
 gem 'validates_timeliness', '~> 4.1', '>= 4.1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,8 @@ gem 'exception_notification', '~> 4.4'
 
 # Models
 gem 'bcrypt', '~> 3.1.11'
-gem 'closure_tree', '~> 7.0'
+gem 'closure_tree', github: 'ClosureTree/closure_tree', ref: '9b5245e' # '~> 7.0'  
+
 gem 'delayed_job_active_record', '~> 4.1.3'
 gem 'validates_timeliness', '~> 4.1', '>= 4.1.1'
 gem 'paper_trail', '~> 10.3', '>= 10.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/ClosureTree/closure_tree.git
+  revision: 9b5245e77914a219e1faa769c0704612155699fa
+  ref: 9b5245e
+  specs:
+    closure_tree (7.1.0)
+      activerecord (>= 4.2.10)
+      with_advisory_lock (>= 4.0.0)
+
+GIT
   remote: https://github.com/james2m/seedbank
   revision: 58d19b0c5c2afd139b3d395f2a516dd399eef57b
   specs:
@@ -116,9 +125,6 @@ GEM
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 1.5)
     climate_control (0.2.0)
-    closure_tree (7.1.0)
-      activerecord (>= 4.2.10)
-      with_advisory_lock (>= 4.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -566,7 +572,7 @@ DEPENDENCIES
   chronic (~> 0.10.2)
   chunky_png (~> 1.3.11)
   citeproc-ruby (~> 1.1.10)
-  closure_tree (~> 7.0)
+  closure_tree!
   coveralls (~> 0.8.22)
   csl (~> 1.5.0)
   csl-styles (~> 1.0.1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ClosureTree/closure_tree.git
-  revision: 9b5245e77914a219e1faa769c0704612155699fa
-  ref: 9b5245e
+  revision: 15b253eab350321ac83668ab2228276eea450db8
+  ref: 15b253e
   specs:
     closure_tree (7.1.0)
       activerecord (>= 4.2.10)


### PR DESCRIPTION
Using code from official closure_tree repo at the commit where the deprecation warning is fixed. DO NOT MERGE before tests pass at Travis CI.