### PR TITLE
Fix invalid parent problem

### DIFF
--- a/app/controllers/tasks/exports/coldp_controller.rb
+++ b/app/controllers/tasks/exports/coldp_controller.rb
@@ -9,9 +9,9 @@ class Tasks::Exports::ColdpController < ApplicationController
     @otu = Otu.where(project_id: sessions_current_project_id).find(params.require(:otu_id))
     if @otu.taxon_name
       if Rails.env == 'development'
-        download = ::Export::Coldp.download(@otu, request.url)
+        download = ::Export::Coldp.download(@otu, request.url, prefer_unlabelled_otus: !!params[:prefer_unlabelled_otus])
       else
-        download = ::Export::Coldp.download_async(@otu, request.url)
+        download = ::Export::Coldp.download_async(@otu, request.url, prefer_unlabelled_otus: !!params[:prefer_unlabelled_otus])
       end
       redirect_to file_download_path(download)
     else

--- a/app/jobs/coldp_create_download_job.rb
+++ b/app/jobs/coldp_create_download_job.rb
@@ -9,9 +9,9 @@ class ColdpCreateDownloadJob < ApplicationJob
     2
   end
 
-  def perform(otu, download)
+  def perform(otu, download, prefer_unlabelled_otus: false)
     begin
-      download.source_file_path = ::Export::Coldp.export(otu.id)
+      download.source_file_path = ::Export::Coldp.export(otu.id, prefer_unlabelled_otus: prefer_unlabelled_otus)
       download.save
     rescue => ex
       ExceptionNotifier.notify_exception(ex,

--- a/app/models/otu.rb
+++ b/app/models/otu.rb
@@ -158,7 +158,7 @@ class Otu < ApplicationRecord
   #  id - the (unambiguous) id of the nearest parent OTU attached to a valid taoxn name
   #
   #  Note this is used CoLDP export. Do not change without considerations there.
-  def parent_otu_id(skip_ranks: [], prefer_nameless_otu: false)
+  def parent_otu_id(skip_ranks: [], prefer_unlabelled_otus: false)
     return nil if taxon_name_id.nil?
 
     # TODO: Unify to a single query
@@ -174,7 +174,7 @@ class Otu < ApplicationRecord
 
     if candidates.size == 1
       otus = Otu.where(taxon_name_id: candidates.first).to_a
-      otus.select! { |o| o.name.nil? } if prefer_nameless_otu && otus.size > 1
+      otus.select! { |o| o.name.nil? } if prefer_unlabelled_otus && otus.size > 1
 
       if otus.size == 1
         return otus.first.id

--- a/app/models/otu.rb
+++ b/app/models/otu.rb
@@ -173,9 +173,8 @@ class Otu < ApplicationRecord
       .pluck(:id)
 
     if candidates.size == 1
-      otus = Otu.where(taxon_name_id: candidates.first)
-      otus = otus.where(name: nil) if prefer_nameless_otu
-      otus.load
+      otus = Otu.where(taxon_name_id: candidates.first).to_a
+      otus.select! { |o| o.name.nil? } if prefer_nameless_otu && otus.size > 1
 
       if otus.size == 1
         return otus.first.id

--- a/app/views/tasks/exports/coldp/index.html.erb
+++ b/app/views/tasks/exports/coldp/index.html.erb
@@ -13,6 +13,10 @@
         display: nil,
         size: 60} %>
     </div>
+    <div class="field">
+      <%= check_box_tag 'prefer_unlabelled_otus' %>
+      <%= label_tag 'prefer_unlabelled_otus', 'On taxon name with multiple OTUs conflict narrow selection to unlabelled ones.' %>
+    </div>
 
     <%= submit_tag :Download, class: ['normal-input', :button, 'button-default'] -%>
   <% end %>

--- a/lib/export/coldp/files/taxon.rb
+++ b/lib/export/coldp/files/taxon.rb
@@ -17,6 +17,11 @@ module Export::Coldp::Files::Taxon
     lifezone: 'https://api.catalogue.life/datapackage#Taxon.lifezone',                       # from https://api.catalogue.life/vocab/lifezone
   }
 
+  SKIPPED_RANKS = %w{
+    NomenclaturalRank::Iczn::SpeciesGroup::Superspecies
+    NomenclaturalRank::Iczn::SpeciesGroup::Supersuperspecies
+  }
+
   # @param predicate [:symbol]
   #   a key from IRI_MAP
   def self.predicate_value(otu, predicate)
@@ -156,7 +161,7 @@ module Export::Coldp::Files::Taxon
 
         parent_id = nil
         if root_otu_id != o.id
-          if pid = o.parent_otu_id
+          if pid = o.parent_otu_id(skip_ranks: SKIPPED_RANKS, prefer_nameless_otu: true)
             parent_id = pid
           else
             # there is no OTU parent for the hierarchy, at present we just flat skip this OTU

--- a/lib/export/coldp/files/taxon.rb
+++ b/lib/export/coldp/files/taxon.rb
@@ -102,7 +102,7 @@ module Export::Coldp::Files::Taxon
     nil
   end
 
-  def self.generate(otus, root_otu_id = nil, reference_csv = nil )
+  def self.generate(otus, root_otu_id = nil, reference_csv = nil, prefer_unlabelled_otus: false)
 
     # Until we have RC5 articulations we are temporarily glossing over the fact
     # that one taoxn name can be used for many OTUs.  Track to see that
@@ -161,7 +161,7 @@ module Export::Coldp::Files::Taxon
 
         parent_id = nil
         if root_otu_id != o.id
-          if pid = o.parent_otu_id(skip_ranks: SKIPPED_RANKS, prefer_nameless_otu: true)
+          if pid = o.parent_otu_id(skip_ranks: SKIPPED_RANKS, prefer_unlabelled_otus: prefer_unlabelled_otus)
             parent_id = pid
           else
             # there is no OTU parent for the hierarchy, at present we just flat skip this OTU


### PR DESCRIPTION
- Get the closest ancestor without superspecies and supersuperspecies ranks and assign as parent.
- When duplicate OTUs, pick the one with Otu.name=nil (if only one is nil).

https://github.com/CatalogueOfLife/testing/issues/87