### PR TITLE
Strip namespace delimiter when parsing catalogNumber from DwC import

### DIFF
--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -73,7 +73,7 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
 
         if attributes[:catalog_number]
           namespace = attributes.dig(:catalog_number, :namespace)
-          attributes.dig(:catalog_number, :identifier)&.delete_prefix!(namespace.verbatim_short_name || namespace.short_name) if namespace
+          attributes.dig(:catalog_number, :identifier)&.delete_prefix!(namespace.verbatim_short_name || namespace.short_name)&.delete_prefix!(namespace.delimiter) if namespace
 
           identifier = Identifier::Local::CatalogNumber
                       .create_with(identifier_object: specimen)


### PR DESCRIPTION
When extracting the identifier from the catalogNumber in the DwC import, the prefix isn't removed. As a result, a catalogNumber like `MCZ.14376w` is parsed into an identifier of `.14376w` and displayed as `MCZ..14376w`.

I recognize there may be an edge case when the delimiter is set to `NONE`, but I don't think it'll be a problem.