### PR TITLE
Accept .tsv extension for DwC-A file

### DIFF
--- a/app/javascript/vue/tasks/dwca_import/components/NewImport.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/NewImport.vue
@@ -64,7 +64,7 @@ export default {
           'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
         },
         dictDefaultMessage: 'Drop import file here',
-        acceptedFiles: '.zip,.txt,.xls,.xlsx,.ods'
+        acceptedFiles: '.zip,.txt,.tsv,.xls,.xlsx,.ods'
       }
     }
   },

--- a/app/javascript/vue/tasks/dwca_import/lang/help/en.js
+++ b/app/javascript/vue/tasks/dwca_import/lang/help/en.js
@@ -30,7 +30,7 @@ const helpData = {
       <span>Supported formats:</span>
       <ul>
         <li>Darwin Core Archive (DwC-A) ZIP file with meta.xml and data files inside (preferred)</li>
-        <li>Tab-separated values text file (TXT)</li>
+        <li>Tab-separated values text file (TXT, TSV)</li>
         <li>Spreadsheet (XLS, XLSX and ODS supported)</li>
       </ul>
       `

--- a/app/models/import_dataset/darwin_core.rb
+++ b/app/models/import_dataset/darwin_core.rb
@@ -228,8 +228,8 @@ class ImportDataset::DarwinCore < ImportDataset
         records[:extensions][type] = get_dwc_records(extension)
         headers[:extensions][type] = get_dwc_headers(extension)
       end
-    elsif source.path =~ /\.(txt|xlsx?|ods)\z/i
-      if source.path =~ /\.(txt)\z/i
+    elsif source.path =~ /\.(txt|tsv|xlsx?|ods)\z/i
+      if source.path =~ /\.(txt|tsv)\z/i
         records[:core] = CSV.read(source.path, headers: true, col_sep: "\t", quote_char: nil, encoding: 'bom|utf-8')
       else
         records[:core] = CSV.parse(Roo::Spreadsheet.open(source.path).to_csv, headers: true)


### PR DESCRIPTION
Briefly discussed in #2291, it is counter-intuitive that it accepts a `tab-separated values text file` but only if the extension is `.txt` and not `.tsv`.