### PR TITLE
Fix TypeMaterial legal_type_type validation for ICN

### DIFF
--- a/app/models/type_material.rb
+++ b/app/models/type_material.rb
@@ -36,7 +36,7 @@ class TypeMaterial < ApplicationRecord
   include SoftValidation
 
   # Keys are valid values for type_type, values are
-  # required Class for BiologicalCollectionObject 
+  # required Class for BiologicalCollectionObject
   ICZN_TYPES = {
     'holotype' =>  Specimen,
     'paratype' => Specimen,
@@ -98,7 +98,7 @@ class TypeMaterial < ApplicationRecord
     when :iczn
       ICZN_TYPES.keys.include?(type_type)
     when :icn
-      ICZN_TYPES.keys.include?(type_type)
+      ICN_TYPES.keys.include?(type_type)
     else
       false
     end


### PR DESCRIPTION
`legal_type_type` was validating against the ICZN types, even when the code was set to ICN.