### PR TITLE
Extract namespace prefix deletion to method

### DIFF
--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -102,7 +102,7 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
 
         if attributes[:catalog_number]
           namespace = attributes.dig(:catalog_number, :namespace)
-          attributes.dig(:catalog_number, :identifier)&.delete_prefix!(namespace.verbatim_short_name || namespace.short_name)&.delete_prefix!(namespace.delimiter || '') if namespace
+          delete_namespace_prefix(attributes.dig(:catalog_number, :identifier))
 
           identifier = Identifier::Local::CatalogNumber
                       .create_with(identifier_object: specimen)
@@ -153,7 +153,7 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
 
             identifier_attributes[:namespace] = namespace
 
-            event_id&.delete_prefix!(namespace.verbatim_short_name || namespace.short_name)&.delete_prefix!(namespace.delimiter)
+            delete_namespace_prefix(event_id)
           end
 
           collecting_event = identifier_type.find_by(identifier_attributes)&.identifier_object
@@ -296,6 +296,11 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
       hsh.delete(key) if hsh[key].nil? || hsh[key] == {}
     end
     hsh
+  end
+
+  # @param [String] identifier_id
+  def delete_namespace_prefix(identifier_id)
+    identifier_id&.delete_prefix!(namespace.verbatim_short_name || namespace.short_name)&.delete_prefix!(namespace.delimiter || '') if namespace
   end
 
   def parse_record_level_class


### PR DESCRIPTION
We're removing the prefix from an identifier in two separate places, so I think we should convert it to a method