### PR TITLE
Make Browse CE edit button link to task

### DIFF
--- a/app/views/tasks/collecting_events/browse/index.html.erb
+++ b/app/views/tasks/collecting_events/browse/index.html.erb
@@ -43,7 +43,7 @@
         </div>
 
         <div class="navigation-controls">
-          <%= link_to('Edit', edit_collecting_event_path(  @collecting_event ), class: 'navigation-item') -%>
+          <%= link_to('Edit (Task)', new_collecting_event_task_path(collecting_event_id: @collecting_event.id), class: 'navigation-item') -%>
         </div>
 
         <div class="navigation-controls">


### PR DESCRIPTION
I'm not sure if the edit button is deprecated in favor of using the navigate radial, but I think it should be consistent between the Browse CE and CO tasks.

The Edit button in the navigation panel links to the old edit page instead of the new collecting event task.
