### PR TITLE
Fix extra semicolon in CE label when locality is blank

### DIFF
--- a/app/helpers/collecting_events_helper.rb
+++ b/app/helpers/collecting_events_helper.rb
@@ -100,7 +100,7 @@ module CollectingEventsHelper
   end
 
   def collecting_event_verbatim_locality_tag(collecting_event)
-    return nil unless !(collecting_event&.verbatim_locality&.blank?)
+    return nil unless collecting_event&.verbatim_locality&.present?
     content_tag(:span, collecting_event.verbatim_locality)
   end
 

--- a/spec/factories/collecting_event_factory.rb
+++ b/spec/factories/collecting_event_factory.rb
@@ -59,5 +59,11 @@ FactoryBot.define do
       verbatim_longitude { '-88.204517' }
     end
 
+    factory :collecting_event_without_verbatim_locality do
+      verbatim_latitude { '40.116402' }
+      verbatim_longitude { '-88.243386' }
+      verbatim_elevation { '735' }
+    end
+
   end
 end

--- a/spec/helpers/collecting_event_spec.rb
+++ b/spec/helpers/collecting_event_spec.rb
@@ -4,7 +4,7 @@ describe CollectingEventsHelper, type: :helper do
   context 'a collecting event needs some helpers' do
     let(:verbatim_label) { "USA: IL: Champaign Co.\nUrbana ii.2.14 YPT\nYoder" }
     let(:collecting_event) {FactoryBot.create(:valid_collecting_event, verbatim_label: verbatim_label ) }
-  
+
 
     specify '.collecting_event_tag' do
       expect(helper.collecting_event_tag(collecting_event)).to eq(verbatim_label)
@@ -12,6 +12,15 @@ describe CollectingEventsHelper, type: :helper do
 
     specify '#collecting_event_tag' do
       expect(helper.collecting_event_tag(collecting_event)).to eq(verbatim_label)
+    end
+
+    specify "#collecting_event_verbatim_locality_tag" do
+      expect(helper.collecting_event_verbatim_locality_tag(collecting_event)).to match(/Locality \d+ for testing\.\.\./)
+    end
+
+    specify "#collecting_event_verbatim_locality_tag without verbatim locality" do
+      sans_locality_ce = FactoryBot.create(:collecting_event_without_verbatim_locality)
+      expect(helper.collecting_event_verbatim_locality_tag(sans_locality_ce)).to be_nil
     end
 
     specify '#collecting_event_link' do


### PR DESCRIPTION
`!(collecting_event&.verbatim_locality&.blank?)` returns false if verbatim_locality is `nil`, so it creates an empty `<span></span>` element. This change fixes it so that it returns `nil` if `verbatim_locality` is `nil`
