### PR TITLE
Rename "sortable fields" checkbox to "reorder fields"

### DIFF
--- a/app/javascript/vue/tasks/collecting_events/new_collecting_event/app.vue
+++ b/app/javascript/vue/tasks/collecting_events/new_collecting_event/app.vue
@@ -12,7 +12,7 @@
             <input
               type="checkbox"
               v-model="settings.sortable">
-            Sortable fields
+            Reorder fields
           </label>
         </li>
         <li>

--- a/app/javascript/vue/tasks/digitize/app.vue
+++ b/app/javascript/vue/tasks/digitize/app.vue
@@ -11,7 +11,7 @@
             <input
               type="checkbox"
               v-model="settings.sortable">
-            Sortable fields
+            Reorder fields
           </label>
         </li>
       </ul>

--- a/app/javascript/vue/tasks/digitize/app.vue
+++ b/app/javascript/vue/tasks/digitize/app.vue
@@ -7,7 +7,7 @@
       <h1>Comprehensive specimen digitization</h1>
       <ul class="context-menu">
         <li>
-          <label>
+          <label v-help.sections.global.reorderFields>
             <input
               type="checkbox"
               v-model="settings.sortable">

--- a/app/javascript/vue/tasks/digitize/lang/help/en.js
+++ b/app/javascript/vue/tasks/digitize/lang/help/en.js
@@ -1,5 +1,8 @@
 export default {
   sections: {
+    global: {
+      reorderFields: 'When active, drag to reorder fields and cards on the page',
+    },
     collectionObject: {
       buffered: 'Complete here with the info the way you see it on the labels on the specimen.',
       identifier: 'Usually the number assigned to this particular specimen within the collection.'

--- a/app/javascript/vue/tasks/extracts/new_extract/app.vue
+++ b/app/javascript/vue/tasks/extracts/new_extract/app.vue
@@ -6,7 +6,7 @@
         <input
           type="checkbox"
           v-model="settings.sortable">
-        Sortable fields
+        Reorder fields
       </label>
     </div>
     <navbar-component

--- a/app/javascript/vue/tasks/sources/new_source/app.vue
+++ b/app/javascript/vue/tasks/sources/new_source/app.vue
@@ -17,7 +17,7 @@
             <input
               type="checkbox"
               v-model="settings.sortable">
-            Sortable fields
+            Reorder fields
           </label>
         </li>
         <li>


### PR DESCRIPTION
I'm not sure if you want to rename the setting in the components as well. There's some other references to `sortable` and it's not clear if they're related or not.