### PR TITLE
Add taxonomic hierarchy specs for Browse Nomenclature task

### DIFF
--- a/spec/features/tasks/nomeclature/browse_spec.rb
+++ b/spec/features/tasks/nomeclature/browse_spec.rb
@@ -8,8 +8,6 @@ describe 'Browse nomenclature task', type: :feature, group: :nomenclature do
     context 'when I visit the task page', js: true do
       let!(:root) { @project.send(:create_root_taxon_name) }
       let!(:genus) { Protonym.create!(by: @user, project: @project, parent: root, name: 'Aus', rank_class: Ranks.lookup(:iczn, :genus)) }
-      let!(:genus_synonym) { Protonym.create!(by: @user, project: @project, parent: root, name: 'Bus', rank_class: Ranks.lookup(:iczn, :genus)) }
-      let!(:tnr1) { TaxonNameRelationship.create!({by: @user, project: @project, subject_taxon_name: genus_synonym, object_taxon_name: genus, type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym'}) }
 
       before { visit browse_nomenclature_task_path(taxon_name_id: genus.id) }
 
@@ -25,6 +23,8 @@ describe 'Browse nomenclature task', type: :feature, group: :nomenclature do
       end
 
       context 'inside the taxon name hierarchy list' do
+        let!(:genus_synonym) { Protonym.create!(by: @user, project: @project, parent: root, name: 'Bus', rank_class: Ranks.lookup(:iczn, :genus)) }
+        let!(:tnr1) { TaxonNameRelationship.create!({by: @user, project: @project, subject_taxon_name: genus_synonym, object_taxon_name: genus, type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym'}) }
 
         before(:each) do
           @hierarchy = page.find_by_id('show_taxon_name_hierarchy')

--- a/spec/features/tasks/nomeclature/browse_spec.rb
+++ b/spec/features/tasks/nomeclature/browse_spec.rb
@@ -6,8 +6,10 @@ describe 'Browse nomenclature task', type: :feature, group: :nomenclature do
     before { sign_in_user_and_select_project}
 
     context 'when I visit the task page', js: true do
-      let!(:root) { @project.send(:create_root_taxon_name) } 
+      let!(:root) { @project.send(:create_root_taxon_name) }
       let!(:genus) { Protonym.create!(by: @user, project: @project, parent: root, name: 'Aus', rank_class: Ranks.lookup(:iczn, :genus)) }
+      let!(:genus_synonym) { Protonym.create!(by: @user, project: @project, parent: root, name: 'Bus', rank_class: Ranks.lookup(:iczn, :genus)) }
+      let!(:tnr1) { TaxonNameRelationship.create!({by: @user, project: @project, subject_taxon_name: genus_synonym, object_taxon_name: genus, type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym'}) }
 
       before { visit browse_nomenclature_task_path(taxon_name_id: genus.id) }
 
@@ -20,6 +22,31 @@ describe 'Browse nomenclature task', type: :feature, group: :nomenclature do
       specify 'edit icon navigates to New taxon name task' do
         page.find('a.edit-taxon-name').click
         expect(page).to have_text('Edit taxon name')
+      end
+
+      context 'inside the taxon name hierarchy list' do
+
+        before(:each) do
+          @hierarchy = page.find_by_id('show_taxon_name_hierarchy')
+        end
+
+        specify 'should have a link to the root name' do
+          expect(@hierarchy).to have_link('Root', href: browse_nomenclature_task_path(taxon_name_id: TaxonName.first.id))
+        end
+
+        specify 'displaying invalid should only show invalid names' do
+          visit browse_nomenclature_task_path(taxon_name_id: root.id)
+          @hierarchy.find('label[for=display_herarchy_invalid]').click
+          expect(@hierarchy).to have_link('Bus', href: browse_nomenclature_task_path(taxon_name_id: genus_synonym.id))
+          expect(@hierarchy).to_not have_link('Aus', href: browse_nomenclature_task_path(taxon_name_id: genus.id))
+        end
+
+        specify 'selecting the valid filter should not show invalid names' do
+          visit browse_nomenclature_task_path(taxon_name_id: root.id)
+          @hierarchy.find('label[for=display_herarchy_valid]').click
+          expect(@hierarchy).to have_link('Aus')
+          expect(@hierarchy).to_not have_link('Bus')
+        end
       end
     end
   end


### PR DESCRIPTION
When reporting #2487, I noticed there weren't any tests for the name hierarchy in the Browse Nomenclature task. Until that issue's fixed, these tests will fail, so I'll mark it as a draft for now.