### PR TITLE
Create config.yml for taxonworks dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community events 
+    url: https://speciesfilegroup.org/events.html
+    about: See, and participate in weekly events to answer questions, help develop your ideas, and more. 
+  - name: Chat with developers 
+    url: https://gitter.im/SpeciesFileGroup/taxonworks 
+    about: Contact the developer team directly in a Gitter chatroom. 


### PR DESCRIPTION
First attempt to add a config.yml file to this repo.
Note: blank_issues_enabled: set to **true** else the bug template will not be used. 
If I've understood, the bug template will be default if someone creates a new issue.

I could change the old md templates to yml files instead.