### PR TITLE
Use splatting in old batch loader `super()` calls 

### DIFF
--- a/lib/batch_file_load/import/otus/simple_interpreter.rb
+++ b/lib/batch_file_load/import/otus/simple_interpreter.rb
@@ -2,7 +2,7 @@ module BatchFileLoad
   class Import::Otus::SimpleInterpreter < BatchFileLoad::Import
     # @param [Array] args
     def initialize(**args)
-      super(args)
+      super(**args)
     end
 
     # @return [Array]

--- a/lib/batch_file_load/import/sequences/genbank_interpreter.rb
+++ b/lib/batch_file_load/import/sequences/genbank_interpreter.rb
@@ -4,7 +4,7 @@ module BatchFileLoad
 
     # @param [Array] args
     def initialize(**args)
-      super(args)
+      super(**args)
     end
 
 =begin

--- a/lib/batch_load/import/asserted_distributions.rb
+++ b/lib/batch_load/import/asserted_distributions.rb
@@ -10,7 +10,7 @@ module BatchLoad
     def initialize(data_origin: nil, **args)
       @asserted_distributions = {}
       @data_origin            = data_origin
-      super(args)
+      super(**args)
     end
 
     # when this routine is invoked, the following class variables must be instantiated:

--- a/lib/batch_load/import/collecting_events.rb
+++ b/lib/batch_load/import/collecting_events.rb
@@ -10,7 +10,7 @@ module BatchLoad
     def initialize(ce_namespace: nil, **args)
       @collecting_events = {}
       @ce_namespace      = ce_namespace
-      super(args)
+      super(**args)
     end
 
     # @return [Hash]

--- a/lib/batch_load/import/collecting_events/castor_interpreter.rb
+++ b/lib/batch_load/import/collecting_events/castor_interpreter.rb
@@ -4,7 +4,7 @@ module BatchLoad
     # @param [Hash] args
     def initialize(**args)
       @collecting_events = {}
-      super(args)
+      super(**args)
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/lib/batch_load/import/collection_objects/castor_interpreter.rb
+++ b/lib/batch_load/import/collection_objects/castor_interpreter.rb
@@ -4,7 +4,7 @@ module BatchLoad
     # @param [Hash] args
     def initialize(**args)
       @collection_objects = {}
-      super(args)
+      super(**args)
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/lib/batch_load/import/descriptors/modify_gene_descriptor_interpreter.rb
+++ b/lib/batch_load/import/descriptors/modify_gene_descriptor_interpreter.rb
@@ -4,7 +4,7 @@ module BatchLoad
     # @param [Hash] args
     def initialize(**args)
       @descriptors = {}
-      super(args)
+      super(**args)
     end
 
     # @return [Integer]

--- a/lib/batch_load/import/namespaces/simple_interpreter.rb
+++ b/lib/batch_load/import/namespaces/simple_interpreter.rb
@@ -3,7 +3,7 @@ module BatchLoad
 
     # @param [Hash] args
     def initialize(**args)
-      super(args)
+      super(**args)
     end
 
     # @return [Integer]

--- a/lib/batch_load/import/otus/identifiers_interpreter.rb
+++ b/lib/batch_load/import/otus/identifiers_interpreter.rb
@@ -3,7 +3,7 @@ module BatchLoad
 
     # @param [Hash] args
     def initialize(**args)
-      super(args)
+      super(**args)
     end
 
     # @return [Integer]

--- a/lib/batch_load/import/sequence_relationships/primers_interpreter.rb
+++ b/lib/batch_load/import/sequence_relationships/primers_interpreter.rb
@@ -4,7 +4,7 @@ module BatchLoad
     # @param [Hash] args
     def initialize(**args)
       @sequence_relationships = {}
-      super(args)
+      super(**args)
     end
 
     # @return [Integer]

--- a/lib/batch_load/import/sequences/genbank_interpreter.rb
+++ b/lib/batch_load/import/sequences/genbank_interpreter.rb
@@ -5,7 +5,7 @@ module BatchLoad
     # @param [Hash] args
     def initialize(**args)
       @sequences = {}
-      super(args)
+      super(**args)
     end
 
     # TODO: update this

--- a/lib/batch_load/import/sequences/primers_interpreter.rb
+++ b/lib/batch_load/import/sequences/primers_interpreter.rb
@@ -4,7 +4,7 @@ module BatchLoad
     # @param [Hash] args
     def initialize(**args)
       @sequences = {}
-      super(args)
+      super(**args)
     end
 
     # TODO: update this

--- a/lib/batch_load/import/taxon_names/castor_interpreter.rb
+++ b/lib/batch_load/import/taxon_names/castor_interpreter.rb
@@ -22,7 +22,7 @@ module BatchLoad
       @parent_taxon_name_id = parent_taxon_name_id
       @also_create_otu = also_create_otu
 
-      super(args)
+      super(**args)
     end
 
     # @return [String]

--- a/lib/generators/taxonworks/batch_load/templates/interpreter.tt
+++ b/lib/generators/taxonworks/batch_load/templates/interpreter.tt
@@ -4,7 +4,7 @@ module BatchLoad
 
     def initialize(**args)
       @<%= table_name %> = {}
-      super(args)
+      super(**args)
     end
 
     # TODO: update this


### PR DESCRIPTION
I *think* ruby 3.0 removed automatic conversion of keyword arguments, so the splat is needed to convert from a hash to keywords.
