### PR TITLE
Add DwC Importer option to skip rows where type material creation fails

### DIFF
--- a/app/javascript/vue/tasks/dwca_import/components/settings/RequireTypeMaterialSuccess.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/RequireTypeMaterialSuccess.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="label-above">
+    <label>
+      <input
+        type="checkbox"
+        v-model="requireTypeMaterialSuccess"
+      >
+      Skip/error rows where type material creation fails
+    </label>
+  </div>
+</template>
+
+<script>
+
+import { ActionNames } from '../../store/actions/actions'
+import { GetterNames } from '../../store/getters/getters'
+import { UpdateImportSettings } from '../../request/resources'
+
+export default {
+  computed: {
+    requireTypeMaterialSuccess: {
+      get () {
+        return this.$store.getters[GetterNames.GetDataset].metadata?.import_settings?.require_type_material_success
+      },
+      set (value) {
+        UpdateImportSettings({
+          import_dataset_id: this.dataset.id,
+          import_settings: {
+            require_type_material_success: value
+          }
+        }).then(response => {
+          this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)
+        })
+      }
+    },
+    dataset () {
+      return this.$store.getters[GetterNames.GetDataset]
+    }
+  }
+}
+</script>

--- a/app/javascript/vue/tasks/dwca_import/components/settings/RequireTypeMaterialSuccess.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/RequireTypeMaterialSuccess.vue
@@ -5,7 +5,7 @@
         type="checkbox"
         v-model="requireTypeMaterialSuccess"
       >
-      Skip/error rows where type material creation fails
+      Error records with unprocessable typeStatus information
     </label>
   </div>
 </template>

--- a/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
@@ -23,6 +23,7 @@
           <div class="field">
             <containerize-checkbox />
             <restrict-to-nomenclature-checkbox />
+            <require-type-material-success-checkbox />
           </div>
 
           <h3>Catalog number namespace mapping</h3>
@@ -60,12 +61,14 @@ import ModalComponent from 'components/ui/Modal'
 import RowComponent from './Row'
 import ContainerizeCheckbox from './Containerize'
 import RestrictToNomenclatureCheckbox from './RestrictToNomenclature'
+import RequireTypeMaterialSuccessCheckbox from './RequireTypeMaterialSuccess'
 import NomenclatureCode from './NomenclatureCode.vue'
 
 export default {
   components: {
     ContainerizeCheckbox,
     RestrictToNomenclatureCheckbox,
+    RequireTypeMaterialSuccessCheckbox,
     ModalComponent,
     RowComponent,
     NomenclatureCode

--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -142,7 +142,7 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
             }.merge!(attributes[:type_material])) # protoynm can be overwritten in type_materials hash if OC did not match scientific name / innermost_protonym
 
           if self.import_dataset.require_type_material_success? # raise error if validations fail and it cannot be imported
-            type_material.save
+            type_material.save!
           else
             # Best effort only, import will proceed even if creating the type material fails
             type_material.save

--- a/app/models/import_dataset/darwin_core/occurrences.rb
+++ b/app/models/import_dataset/darwin_core/occurrences.rb
@@ -174,6 +174,10 @@ class ImportDataset::DarwinCore::Occurrences < ImportDataset::DarwinCore
     !!self.metadata.dig("import_settings", "restrict_to_existing_nomenclature")
   end
 
+  def require_type_material_success?
+    !!self.metadata.dig("import_settings", "require_type_material_success")
+  end
+
   private
 
   def get_catalog_number_namespace_mapping(institution_code, collection_code)

--- a/spec/files/import_datasets/occurrences/type_material.tsv
+++ b/spec/files/import_datasets/occurrences/type_material.tsv
@@ -1,0 +1,3 @@
+occurrenceID	scientificName	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Bothroponera cambouei	species	Bothroponera	cambouei				Ponerinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	Lectotype of Bothroponera cambouei
+7d228469-b66b-4bef-b3a5-65d3e2bc4b50	Euponera agnivo	species	Euponera	agnivo				Ponerinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	Holotype of Pachycondyla agnivo

--- a/spec/models/dataset_record/darwin_core/occurrence_spec.rb
+++ b/spec/models/dataset_record/darwin_core/occurrence_spec.rb
@@ -62,11 +62,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/intermediate_protonym.tsv'), 'text/plain'),
         description: 'Missing Ancestor Protonym',
-        metadata: {'import_settings' => {'restrict_to_existing_nomenclature' => true}}
+        metadata: { 'import_settings' => { 'restrict_to_existing_nomenclature' => true } }
       ).tap { |i| i.stage }
-      @import_dataset.metadata['import_settings']['restrict_to_existing_nomenclature'] = true
-      @import_dataset.save!
-
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
       phylum = Protonym.create(parent: kingdom, name: "Arthropoda", rank_class: Ranks.lookup(:iczn, :phylum))
@@ -80,9 +77,7 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
 
     end
 
-
     let!(:results) { @import_dataset.import(5000, 100) }
-
 
     it "should import the record without failing" do
       expect(results.length).to eq(1)
@@ -96,6 +91,61 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
     after :all do
       DatabaseCleaner.clean
     end
+  end
+
+  context 'when import an occurrence with a type material' do
+    before :all do
+      DatabaseCleaner.start
+      @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
+        source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/type_material.tsv'), 'text/plain'),
+        description: 'Type Material',
+        metadata: { 'import_settings' =>
+                      { 'restrict_to_existing_nomenclature' => true,
+                        'require_type_material_success' => true } }
+      ).tap { |i| i.stage }
+
+      kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
+      phylum = Protonym.create(parent: kingdom, name: "Arthropoda", rank_class: Ranks.lookup(:iczn, :phylum))
+      klass = Protonym.create(parent: phylum, name: "Insecta", rank_class: Ranks.lookup(:iczn, :class))
+      order = Protonym.create(parent: klass, name: "Hymenoptera", rank_class: Ranks.lookup(:iczn, :order))
+      family = Protonym.create(parent: order, name: "Formicidae", rank_class: Ranks.lookup(:iczn, :family))
+      subfamily = Protonym.create(parent: family, name: "Ponerinae", rank_class: Ranks.lookup(:iczn, :subfamily))
+      tribe = Protonym.create(parent: subfamily, name: "Ponerini", rank_class: Ranks.lookup(:iczn, :tribe))
+      genus = Protonym.create(parent: tribe, name: "Bothroponera", rank_class: Ranks.lookup(:iczn, :genus), also_create_otu: true)
+      Protonym.create(parent: genus, name: "cambouei", rank_class: Ranks.lookup(:iczn, :species), also_create_otu: true)
+
+      g_pachycondyla = Protonym.create(parent: tribe, name: "Pachycondyla", rank_class: Ranks.lookup(:iczn, :genus), also_create_otu: true)
+      g_euponera = Protonym.create(parent: tribe, name: "Euponera", rank_class: Ranks.lookup(:iczn, :genus), also_create_otu: true)
+      s_agnivo = Protonym.create(parent: g_euponera, name: "agnivo", rank_class: Ranks.lookup(:iczn, :species), also_create_otu: true)
+
+      # Create original combination relationship
+      TaxonNameRelationship::OriginalCombination::OriginalGenus.create!(subject_taxon_name: g_pachycondyla, object_taxon_name: s_agnivo)
+
+    end
+
+    let!(:results) { @import_dataset.import(5000, 100) }
+
+    it "should import both records without failing" do
+      expect(results.length).to eq(2)
+      expect(results.map { |row| row.status }).to all(eq('Imported'))
+    end
+
+    it 'does not create any new protonyms' do
+      expect(TaxonName.where(name: 'Bothroponera').count).to eq(1)
+      expect(TaxonName.where(name: 'Euponera').count).to eq(1)
+      expect(TaxonName.where(name: 'agnivo').count).to eq(1)
+      expect(TaxonName.where(name: 'cambouei').count).to eq(1)
+    end
+
+    it 'should have 1 type material record' do
+      expect(TypeMaterial.count).to eq 2
+    end
+
+    after :all do
+      DatabaseCleaner.clean
+    end
+
+
   end
 
 end


### PR DESCRIPTION
I realized that failing silently might not be the desired behavior for everyone, so I added an option to make rows fail if the type material couldn't be created.