### PR TITLE
DwC Importer tag fix: only save CE if new tags were added

### DIFF
--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -219,8 +219,10 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
             new_tags = attributes[:collecting_event][:tags_attributes].reject { |t| current_tags.member?(t[:keyword].id) }
 
             # add tags if there were any new ones
-            collecting_event.tags.build(new_tags)
-            collecting_event.save!
+            unless new_tags.empty?
+              collecting_event.tags.build(new_tags)
+              collecting_event.save!
+            end
           end
 
           specimen.update!(collecting_event: collecting_event)


### PR DESCRIPTION
I missed an if statement for saving collecting events, causing collecting events to be saved even if there were no new tags added. As a result, importing collection objects was significantly slowed down when the collecting event had many related COs.