### PR TITLE
Fix dependency loop in checklist import 

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -447,7 +447,7 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
 
   private
 
-  # @return [DatasetRecord::DarwinCore::Taxon, Array<DatasetRecord::DarwinCore::Taxon>]
+  # @return Optional[DatasetRecord::DarwinCore::Taxon, Array<DatasetRecord::DarwinCore::Taxon>]
   def get_parent
     DatasetRecord::DarwinCore::Taxon.where(id: import_dataset.core_records_fields
                                                              .at(get_field_mapping(:taxonID))
@@ -456,7 +456,7 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
     ).first
   end
 
-  # @return [DatasetRecord::DarwinCore::Taxon, Array<DatasetRecord::DarwinCore::Taxon>]
+  # @return Optional[DatasetRecord::DarwinCore::Taxon, Array<DatasetRecord::DarwinCore::Taxon>]
   def get_original_combination
     DatasetRecord::DarwinCore::Taxon.where(id: import_dataset.core_records_fields
                                                              .at(get_field_mapping(:taxonID))
@@ -465,7 +465,7 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
     ).first
   end
 
-  # @return [DatasetRecord::DarwinCore::Taxon, Array<DatasetRecord::DarwinCore::Taxon>]
+  # @return Optional[DatasetRecord::DarwinCore::Taxon, Array<DatasetRecord::DarwinCore::Taxon>]
   def find_by_taxonID(taxon_id)
     DatasetRecord::DarwinCore::Taxon.where(id: import_dataset.core_records_fields
                                                              .at(get_field_mapping(:taxonID))

--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -208,6 +208,7 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
               iczn: {
                 synonym: 'TaxonNameRelationship::Iczn::Invalidating::Synonym',
                 homonym: 'TaxonNameRelationship::Iczn::Invalidating::Synonym::Objective::ReplacedHomonym',
+                misspelling: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling'
               },
               # TODO support other nomenclatural codes
               # icnp: {
@@ -252,7 +253,8 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
               unavailable: 'TaxonNameClassification::Iczn::Unavailable',
               excluded: 'TaxonNameClassification::Iczn::Unavailable::Excluded',
               'nomen nudum': 'TaxonNameClassification::Iczn::Unavailable::NomenNudum',
-              ichnotaxon: 'TaxonNameClassification::Iczn::Fossil::Ichnotaxon'
+              ichnotaxon: 'TaxonNameClassification::Iczn::Fossil::Ichnotaxon',
+              'nomen dubium': 'TaxonNameClassification::Iczn::Available::Valid::NomenDubium'
             }.freeze
 
             if (status = get_field_value(:taxonomicStatus)&.downcase)

--- a/app/models/import_dataset/darwin_core/checklist.rb
+++ b/app/models/import_dataset/darwin_core/checklist.rb
@@ -184,7 +184,8 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
         end
 
         # make protonym depend on original combination's parent, if protonym is not the original combination
-        if current_record[:index] != oc_index
+        # do not make valid record depend on self if OC's parent is the valid name. Ex: Aus with OC Aus (Aus)
+        if current_record[:index] != oc_index && (core_records[oc_index][:parent] != current_record[:src_data]["taxonID"])
           current_record[:dependencies] << records_lut[core_records[oc_index][:parent]][:index]
           records_lut[core_records[oc_index][:parent]][:dependants] << current_record[:index]
         end

--- a/spec/files/import_datasets/checklists/genus_subgenus_oc.tsv
+++ b/spec/files/import_datasets/checklists/genus_subgenus_oc.tsv
@@ -1,0 +1,6 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	lass	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender	TW:TaxonNameClassification:Latinized:PartOfSpeech	TW:TaxonNameRelationship:incertae_sedis_in_rank
+429011		429011	Formicidae	Animalia	Insecta	Hymenoptera	Formicidae					Family	Latreille, 1809	valid	429011	1809	ICZN
+429609	429011	429609	Attini	Animalia	Insecta	Hymenoptera	Formicidae					Tribe	Smith, 1858	valid	429609	1858	ICZN
+429559	429609	429559	Strumigenys	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Smith, 1860	valid	429559	1860	ICZN	feminine
+429571	429609	429559	Smithistruma	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Brown, 1948	synonym	509064	1948	ICZN	feminine
+509064	429571	429559	Smithistruma (Smithistruma)	Animalia	Insecta	Hymenoptera	Formicidae	Smithistruma				Subgenus	Brown, 1948	obsolete classification	509064	1948	ICZN


### PR DESCRIPTION
When current name rank is genus and original combination is with self at subgenus level, eg: originally described as Aus (Aus) but now just Aus, the staging function would mark names as depending on themselves.