### PR TITLE
Added 10km tolerance to geographic area validation for verbatim georeference

### DIFF
--- a/app/models/collecting_event/georeference.rb
+++ b/app/models/collecting_event/georeference.rb
@@ -110,7 +110,7 @@ module CollectingEvent::Georeference
     when :verbatim_map_center
       verbatim_map_center
     when :geographic_area
-      geographic_area.default_geographic_item.geo_object.centroid
+      geographic_area.default_geographic_item.centroid
     else
       nil
     end

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -996,13 +996,13 @@ class GeographicItem < ApplicationRecord
     unless !persisted? || changed?
       a = "(#{GeographicItem.select_geography_sql(id)})"
     else
-      a = "'#{geo_object.to_s}'::geography"
+      a = "ST_GeographyFromText('#{geo_object.to_s}')"
     end
 
     unless !geographic_item.persisted? || geographic_item.changed?
       b = "(#{GeographicItem.select_geography_sql(geographic_item.id)})"
     else
-      b = "'#{geographic_item.geo_object.to_s}'::geography"
+      b = "ST_GeographyFromText('#{geographic_item.geo_object.to_s}')"
     end
 
     ActiveRecord::Base.connection.select_value("SELECT ST_Distance(#{a}, #{b})")

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -1082,13 +1082,6 @@ class GeographicItem < ApplicationRecord
     self.geo_object.intersects?(target_geo_object)
   end
 
-  # @TODO doesn't work?
-  # @param [geo_object]
-  # @return [Boolean]
-  def distance?(target_geo_object)
-    self.geo_object.distance(target_geo_object)
-  end
-
   # @param [geo_object, Double]
   # @return [Boolean]
   def near(target_geo_object, distance)

--- a/app/models/georeference/verbatim_data.rb
+++ b/app/models/georeference/verbatim_data.rb
@@ -8,6 +8,7 @@
 # @param error_radius
 #   is taken from collecting_event#verbatim_geolocation_uncertainty
 class Georeference::VerbatimData < Georeference
+  GEO_AREA_TOLERANCE = 10000.0 # Meters. Maximum allowed distance to consider geographic area valid.Exif
 
   # @param [ActionController::Parameters] params
   def initialize(params = {})
@@ -92,7 +93,7 @@ class Georeference::VerbatimData < Georeference
 
   # @return [Boolean] true iff collecting_event contains georeference geographic_item.
   def add_obj_inside_area
-    unless check_obj_within_distance_from_area(10000.0)
+    unless check_obj_within_distance_from_area(GEO_AREA_TOLERANCE)
       errors.add(
         :geographic_item,
         'for georeference is not contained in the geographic area bound to the collecting event')

--- a/app/models/georeference/verbatim_data.rb
+++ b/app/models/georeference/verbatim_data.rb
@@ -74,6 +74,32 @@ class Georeference::VerbatimData < Georeference
     h
   end
 
+  # @return [Boolean]
+  #    true if geographic_item.geo_object is completely contained in collecting_event.geographic_area
+  # .default_geographic_item
+  def check_obj_within_distance_from_area(distance)
+    # case 6
+    retval = true
+    if collecting_event.present?
+      if geographic_item.present? && collecting_event.geographic_area.present?
+        if geographic_item.geo_object && collecting_event.geographic_area.default_geographic_item.present?
+          retval = geographic_item.st_distance_to_geographic_item(collecting_event.geographic_area.default_geographic_item) <= distance
+        end
+      end
+    end
+    retval
+  end
 
+  # @return [Boolean] true iff collecting_event contains georeference geographic_item.
+  def add_obj_inside_area
+    unless check_obj_within_distance_from_area(10000.0)
+      errors.add(
+        :geographic_item,
+        'for georeference is not contained in the geographic area bound to the collecting event')
+      errors.add(
+        :collecting_event,
+        'is assigned a geographic area which does not contain the supplied georeference/geographic item')
+    end
+  end
 
 end

--- a/spec/models/collecting_event/geo_spec.rb
+++ b/spec/models/collecting_event/geo_spec.rb
@@ -195,7 +195,6 @@ describe CollectingEvent, type: :model, group: [:geo, :shared_geo, :collecting_e
                 FactoryBot.create(:georeference_verbatim_data,
                                   collecting_event: collecting_event,
                                   geographic_item: GeographicItem.new(point: area_a.default_geographic_item
-                                                                                .geo_object
                                                                                 .centroid))
                 collecting_event.reload
               }
@@ -205,7 +204,7 @@ describe CollectingEvent, type: :model, group: [:geo, :shared_geo, :collecting_e
               end
 
               specify 'return georeference#geographic_item centroid' do
-                expect(collecting_event.map_center).to eq(area_a.default_geographic_item.geo_object.centroid)
+                expect(collecting_event.map_center).to eq(area_a.default_geographic_item.centroid)
               end
             end
           end

--- a/spec/models/geographic_item_spec.rb
+++ b/spec/models/geographic_item_spec.rb
@@ -370,10 +370,6 @@ describe GeographicItem, type: :model, group: [:geo, :shared_geo] do
         expect(geographic_item).to respond_to(:within?)
       end
 
-      specify '#distance? - to see how far one object is from another.' do
-        expect(geographic_item).to respond_to(:distance?)
-      end
-
       specify '#near' do
         expect(geographic_item).to respond_to(:near)
       end

--- a/spec/models/georeference_spec.rb
+++ b/spec/models/georeference_spec.rb
@@ -235,7 +235,23 @@ describe Georeference, type: :model, group: [:geo, :shared_geo, :georeferences] 
             g.valid?
 
             expect(g.errors[:geographic_item]).to be_present
-          end
+        end
+
+        specify 'If point is within 10km from collecting event''s geographic area georeference is valid' do
+          g = Georeference::VerbatimData.new(
+            collecting_event: ce_e1, # p0 is outside of both e_g_i and ce.geographic_area
+            geographic_item: GeographicItem.new(point: RSPEC_GEO_FACTORY.point(-9.0, 9.0904, 0.0)) # e_g_i is test_box_1
+          )
+          expect(g).to be_valid
+        end
+
+        specify 'If point is exceeds 10km from collecting event''s geographic area georeference is valid' do
+          g = Georeference::VerbatimData.new(
+            collecting_event: ce_e1, # p0 is outside of both e_g_i and ce.geographic_area
+            geographic_item: GeographicItem.new(point: RSPEC_GEO_FACTORY.point(-9.0, 9.0907, 0.0)) # e_g_i is test_box_1
+          )
+          expect(g).to_not be_valid
+        end
 
         specify 'an error is added to #error_geographic_item if collecting_event.geographic_area.geo_object ' \
                           'does not contain #error_geographic_item' do


### PR DESCRIPTION
This enables users to specify a geographic area other than the one that a verbatim georeference it is contained in provided it is not farther than 10km.