### PR TITLE
DwC importer name handling fixes (incertae sedis, misspelling, types)

### DIFF
--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -844,7 +844,7 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
     if type_status_parsed && scientific_name && type_scientific_name.present?
 
       # if type_scientific_name matches the current name of the occurrence, use that
-      if type_scientific_name&.delete_prefix!(scientific_name)&.match(/^\W*$/)
+      if type_scientific_name.delete_prefix(scientific_name)&.match(/^\W*$/)
         type_material = {
           type_type: type_status_parsed[:type].downcase
         }

--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -274,15 +274,18 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
                                                             Available ancestors are #{available_parent_ranks}.".squish] })
                   end
 
+                  # Parent should be same as incertae sedis object_taxon
+                  # Supplying a parent taxonID with a different rank than the incertae sedis parent
+                  # will an original combination relationship with the old parent, which
+                  # the ui will render as [Aus] bus, (where the incertae sedis parent is Cus)
+                  taxon_name.parent = incertae_sedis_parent
+
                 else
                   # if parent has uncertain placement in rank, taxon's parent should be changed to whichever taxon the parent's UncertainRelationship is with
-                  #noinspection RubyResolve
-                  if (r = parent.iczn_uncertain_placement_relationship)
-                    incertae_sedis_parent = TaxonName.find(r.object_taxon_name_id)
-                  else
-                    # if parent doesn't have uncertain placement, make relationship with family or subfamily (FamilyGroup)
-                    incertae_sedis_parent = taxon_name.ancestors.with_base_of_rank_class('NomenclaturalRank::Iczn::FamilyGroup').first
-                  end
+                  incertae_sedis_parent = parent.iczn_uncertain_placement
+                  # if parent doesn't have uncertain placement, make relationship with family or subfamily (FamilyGroup)
+                  incertae_sedis_parent ||= taxon_name.ancestors.with_base_of_rank_class('NomenclaturalRank::Iczn::FamilyGroup').first
+
                   # Parent should be same as incertae sedis object_taxon
                   taxon_name.parent = incertae_sedis_parent
                 end

--- a/app/models/import_dataset/darwin_core/checklist.rb
+++ b/app/models/import_dataset/darwin_core/checklist.rb
@@ -91,6 +91,11 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
       end
       oc_index = records_lut[record[:src_data]['originalNameUsageID']][:index]
 
+      # misspellings are treated as separate protonyms, so don't bundle them in original combination with the correct spelling
+      if record[:src_data]['taxonomicStatus'] == 'misspelling'
+        oc_index = index
+      end
+
       original_combination_groups[oc_index] ||= []
       original_combination_groups[oc_index] << index
 

--- a/spec/files/import_datasets/checklists/misspelling_combination.tsv
+++ b/spec/files/import_datasets/checklists/misspelling_combination.tsv
@@ -1,0 +1,7 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	class	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender	TW:TaxonNameClassification:Latinized:PartOfSpeech	TW:TaxonNameRelationship:incertae_sedis_in_rank
+429349		429349	Formica	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Linnaeus, 1758	valid	429349	1758	ICZN	feminine
+429609		429609	Attini	Animalia	Insecta	Hymenoptera	Formicidae					Tribe	Smith, 1858	valid	429609	1858	ICZN
+429613	429609	429613	Atta	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Fabricius, 1804	valid	429613	1804	ICZN	feminine
+431467	429613	431467	Atta sexdens	Animalia	Insecta	Hymenoptera	Formicidae	Atta		sexdens		Species	(Linnaeus, 1758)	valid	456688	1758	ICZN
+431468	429613	431467	Atta sexdentata	Animalia	Insecta	Hymenoptera	Formicidae	Atta		sexdentata		Species	(Linnaeus, 1758)	misspelling	456688	1758	ICZN
+456688	429349	431467	Formica sexdens	Animalia	Insecta	Hymenoptera	Formicidae	Formica		sexdens		Species	Linnaeus, 1758	obsolete combination	456688	1758	ICZN


### PR DESCRIPTION
* Fix how misspellings were handled in the checklist staging process
  * add test case for importing names with misspellings
* Fix type scientific name detection in occurrence import when it doesn't match the current scientific name
* Fix incertae sedis imports when a rank was given (via the `TW:TaxonNameRelationship:incertae_sedis_in_rank` field) and had a different rank than the taxon's parent