### PR TITLE
Add eventRemarks to DwC export

### DIFF
--- a/app/models/collection_object/dwc_extensions.rb
+++ b/app/models/collection_object/dwc_extensions.rb
@@ -93,6 +93,8 @@ module CollectionObject::DwcExtensions
 
       occurrenceRemarks: :dwc_occurrence_remarks,
 
+      eventRemarks: :dwc_event_remarks
+
       # -- Core taxon? --
       # nomenclaturalCode
       # scientificName
@@ -159,6 +161,10 @@ module CollectionObject::DwcExtensions
   # https://dwc.tdwg.org/list/#dwc_georeferenceRemarks
   def dwc_occurrence_remarks
     notes.collect{|n| n.text}.join('|')
+  end
+
+  def dwc_event_remarks
+    collecting_event&.notes&.collect {|n| n.text}&.join('|')
   end
 
   # https://dwc.tdwg.org/terms/#dwc:associatedMedia


### PR DESCRIPTION
To match import behavior, eventRemarks should be included in DwC Exports. Remarks are generated from CollectingEvent notes.

**dwc:eventRemarks**: Comments or notes about the dwc:Event. (https://dwc.tdwg.org/list/#dwc_eventRemarks)