### PR TITLE
Use Levenshtein distance to order namespace autocomplete suggestions

### DIFF
--- a/lib/queries/namespace/autocomplete.rb
+++ b/lib/queries/namespace/autocomplete.rb
@@ -29,8 +29,13 @@ module Queries
         table[:verbatim_short_name].matches_any(terms)
       end
 
+      # override method, providing fields to search
+      def least_levenshtein
+        super([:name, :short_name, :verbatim_short_name], query_string)
+      end
+
       def all
-        ::Namespace.where(where_sql)
+        ::Namespace.where(where_sql).order(least_levenshtein)
       end
 
     end

--- a/lib/queries/query/autocomplete.rb
+++ b/lib/queries/query/autocomplete.rb
@@ -285,6 +285,15 @@ module Queries
       base_query.joins(:common_names).where(common_name_wild_pieces.to_sql).limit(5)
     end
 
+    # Calculate the levenshtein distance for a value across multiple columns, and keep the smallest.
+    #
+    # @param fields [Array] the table column names to take strings from
+    # @param value [String] the string to calculate distances to
+    def least_levenshtein(fields, value)
+      levenshtein_sql = fields.map {|f| levenshtein_distance(f, value).to_sql }
+      Arel.sql("least(#{levenshtein_sql.join(", ")})")
+    end
+
     # TODO: not used
     # @return [Arel:Nodes]
     # def or_and


### PR DESCRIPTION
Namespace autocomplete suggestions have no defined order, making it frustrating for short (2-3 letter) names. I often have to scroll down to find the match, even when I've typed an exact match. 

Levenshtein distance should order the suggestion list by edit distance, so exact matches come first.