### PR TITLE
Support separate field for fossil status in DwC taxon import

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -295,11 +295,6 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
                   object_taxon_name: incertae_sedis_parent,
                   type: 'TaxonNameRelationship::Iczn::Validating::UncertainPlacement')
 
-                # possible to have both incertae sedis and fossil classification (since IS is a relationship, not classification)
-                if get_field_value('TW:TaxonNameClassification::Iczn::Fossil')
-                  taxon_name.taxon_name_classifications.find_or_initialize_by(type: 'TaxonNameClassification::Iczn::Fossil')
-                end
-
               else
                 type = status_types[status.to_sym]
 
@@ -308,6 +303,11 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
                 taxon_name.taxon_name_classifications.find_or_initialize_by(type: type)
               end
             end
+          end
+
+          # Taxon status might not be "fossil" if synonym, homonym, incertae sedis, etc.
+          if get_field_value('TW:TaxonNameClassification::Iczn::Fossil')
+            taxon_name.taxon_name_classifications.find_or_initialize_by(type: 'TaxonNameClassification::Iczn::Fossil')
           end
 
           # add gender or part of speech classification if given


### PR DESCRIPTION
A bug in my Antcat name exporter was prioritizing "fossil" over other legitimate taxonomic statuses like "synonym", hiding a bug in #3483 which causes the `TW:TaxonNameClassification::Iczn::Fossil` field to be ignored when the name had a replacement. Moving this check outside of the `taxonomicStatus` handler ensures the field will always be recognized and handled.