### PR TITLE
Use OC conjugation for names in name importer when appropriate

### DIFF
--- a/spec/files/import_datasets/checklists/conjugated_species.tsv
+++ b/spec/files/import_datasets/checklists/conjugated_species.tsv
@@ -1,0 +1,6 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	lass	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender	TW:TaxonNameClassification:Latinized:PartOfSpeech
+429639		429639	Stenammini	Animalia	Insecta	Hymenoptera	Formicidae					Tribe	Ashmead, 1905	valid	429639	1905	ICZN
+429830	429639	429830	Veromessor	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Forel, 1917	valid	429830	1917	ICZN	masculine
+429816	429639	429816	Aphaenogaster	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Mayr, 1853	valid	429816	1853	ICZN	feminine
+440100	429830	440100	Veromessor julianus	Animalia	Insecta	Hymenoptera	Formicidae	Veromessor		julianus		Species	(Pergande, 1894)	valid	458411	1894	ICZN		adjective
+458411	429816	440100	Aphaenogaster juliana	Animalia	Insecta	Hymenoptera	Formicidae	Aphaenogaster		juliana		Species	Pergande, 1894	obsolete combination	458411	1894	ICZN		adjective

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -916,6 +916,38 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
     end
   end
 
+  context 'when importing species with different congugation' do
+    before(:all) { import_checklist_tsv('conjugated_species.tsv', 5) }
+
+    after :all do
+      DatabaseCleaner.clean
+    end
+
+    let(:valid) { TaxonName.find_by(cached: 'Atta sexdens') }
+    let(:misspelling) { TaxonName.find_by({ name: 'sexdentata' }) }
+
+    it 'should create and import 5 records' do
+      verify_all_records_imported(5)
+    end
+
+    # Stenammini
+    # Veromessor
+    # Veromessor julianus
+    # Aphaenogaster
+    it 'should have four original combinations' do
+      expect(TaxonNameRelationship::OriginalCombination.all.length).to eq 4
+    end
+
+    it 'should have properly conjugated original combination' do
+      expect(TaxonName.find_by_cached_original_combination("Aphaenogaster juliana")).to_not be_nil
+    end
+
+    it 'should have properly conjugated valid name' do
+      expect(TaxonName.find_by_cached("Veromessor julianus")).to_not be_nil
+    end
+
+  end
+
   # TODO test missing parent
   #
   # TODO test protonym is unavailable --- set classification on unsaved TaxonName


### PR DESCRIPTION
Prefer OC conjugation when different from current and we know the valid genus' gender. It will be conjugated correctly with new genus and the original combination will use the correct conjugation.

The conditions for this are very strict, since correctness of valid name is the highest priority. This modification should only be performed when we know the valid name's representation won't be changed.