### PR TITLE
Add wildcard subgenus matching for typeStatus in DwC Occurrence import

### DIFF
--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -861,7 +861,7 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
       # Try wildcard match on subgenus if not present
       type_name_elements = type_scientific_name.split
       if type_name_elements.length > 1 && type_name_elements[1].first != "(" && type_name_elements[1].last != ")"
-
+        type_name_elements.map! { |s| Regexp.escape(s) }
         # append subgenus wildcard to genus string
         type_name_elements[0] << '( \(\w+\))?'
         name_pattern = type_name_elements.join(" ")

--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -830,21 +830,57 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
   def parse_typestatus(type_status)
     type_material = nil
     type_status_parsed = type_status&.match(/^(?<type>\w+)$/i) || type_status&.match(/(?<type>\w+)(\s+OF\s+(?<scientificName>.*))/i)
+
+    # only nil if non-alphanumeric entry, or multiple words not matching "\w+ of \w+"
+    raise DarwinCore::InvalidData.new({ "typeStatus": ["Unprocessable typeStatus information"] }) unless type_status_parsed
+
+    code = get_field_value(:nomenclaturalCode)&.downcase&.to_sym || import_dataset.default_nomenclatural_code
+    unless TypeMaterial::legal_type_type(code, type_status_parsed[:type].downcase)
+      raise DarwinCore::InvalidData.new({ "typeStatus": ["could not extract legal type from typeStatus"] })
+    end
+
     scientific_name = get_field_value(:scientificName)&.gsub(/\s+/, ' ')
+
+    # if typeStatus is single word, assume the user wants the specimen name as the type name
     type_scientific_name = (type_status_parsed&.[](:scientificName)&.gsub(/\s+/, ' ') rescue nil) || scientific_name
 
-    if type_status_parsed && scientific_name && type_scientific_name.present?
-
+    if scientific_name && type_scientific_name.present?
       # if type_scientific_name matches the current name of the occurrence, use that
       if type_scientific_name.delete_prefix(scientific_name)&.match(/^\W*$/)
-        type_material = {
+        return {
           type_type: type_status_parsed[:type].downcase
         }
-      elsif (original_combination_protonym = Protonym.find_by(cached_original_combination: type_scientific_name, project_id: self.project_id))
-        type_material = {
+      end
+      if (original_combination_protonym = Protonym.find_by(cached_original_combination: type_scientific_name, project_id: self.project_id))
+        return {
           type_type: type_status_parsed[:type].downcase,
           protonym: original_combination_protonym
         }
+      end
+
+      # Try wildcard match on subgenus if not present
+      type_name_elements = type_scientific_name.split
+      if type_name_elements.length > 1 && type_name_elements[1].first != "(" && type_name_elements[1].last != ")"
+
+        # append subgenus wildcard to genus string
+        type_name_elements[0] << '( \(\w+\))?'
+        name_pattern = type_name_elements.join(" ")
+
+        wildcard_original_protonym = Protonym.where('cached_original_combination ~ :pat', pat: name_pattern)
+                                             .where(project_id: self.project_id)
+
+        if wildcard_original_protonym.count == 1
+          return {
+            type_type: type_status_parsed[:type].downcase,
+            protonym: wildcard_original_protonym.first
+          }
+        elsif wildcard_original_protonym.count > 1
+          matching_protonyms = wildcard_original_protonym.map{|p| "[id: #{p.id} #{p.cached_html_original_name_and_author_year}]"}
+                                                         .join(", ")
+          raise DarwinCore::InvalidData.new({ "typeStatus": ["could not find exact original combination match for typeStatus, and multiple names returned in wildcard search: #{matching_protonyms}"] })
+        else
+          raise DarwinCore::InvalidData.new({ "typeStatus": ["could not find exact original combination match for typeStatus, and no names returned in wildcard search"] })
+        end
       end
     end
     type_material

--- a/app/models/type_material.rb
+++ b/app/models/type_material.rb
@@ -86,7 +86,7 @@ class TypeMaterial < ApplicationRecord
     [source, protonym.try(:source), nil].compact.first
   end
 
-  def legal_type_type(code, type_type)
+  def self.legal_type_type(code, type_type)
     case code
     when :iczn
       ICZN_TYPES.keys.include?(type_type)
@@ -102,7 +102,7 @@ class TypeMaterial < ApplicationRecord
   def check_type_type
     if protonym
       code = protonym.rank_class.nomenclatural_code
-      errors.add(:type_type, 'Not a legal type for the nomenclatural code provided') if !legal_type_type(code, type_type)
+      errors.add(:type_type, 'Not a legal type for the nomenclatural code provided') unless TypeMaterial::legal_type_type(code, type_type)
     end
   end
 


### PR DESCRIPTION
Subgenus may be missing from typeStatus strings, but present in TW original combination nomenclature. 

This wildcard search ensures uniqueness among the results, and will not be applied if multiple original combinations match.