### PR TITLE
Skip subgenus in OC if newer than taxon's authorship in DwC importer

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -162,6 +162,13 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
               end
 
               if (rank_in_type = ORIGINAL_COMBINATION_RANKS[rank&.downcase&.to_sym])
+
+                # if the subgenus is newer than taxon_name's authorship, skip it (the name must have been classified in the subgenus later)
+                next if rank&.downcase&.to_sym == :subgenus &&
+                  !ancestor_protonym.year_integer.nil? &&
+                  !taxon_name.year_integer.nil? &&
+                  ancestor_protonym.year_integer > taxon_name.year_integer
+
                 taxon_name.save!
                 TaxonNameRelationship.find_or_create_by!(type: rank_in_type, subject_taxon_name: ancestor_protonym, object_taxon_name: taxon_name)
               end

--- a/spec/files/import_datasets/checklists/younger_oc_subgenus.tsv
+++ b/spec/files/import_datasets/checklists/younger_oc_subgenus.tsv
@@ -1,0 +1,4 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	lass	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender	TW:TaxonNameClassification:Latinized:PartOfSpeech
+429244		429244	Camponotus	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Mayr, 1861	valid	429244	1861	ICZN	masculine
+429289	429244	429289	Camponotus (Myrmocladoecus)	Animalia	Insecta	Hymenoptera	Formicidae	Camponotus				Subgenus	Wheeler, 1921	valid	429289	1921	ICZN
+433459	429289	433459	Camponotus planus	Animalia	Insecta	Hymenoptera	Formicidae	Camponotus	Camponotus (Myrmocladoecus)	planus		Species	Smith, 1877	valid	433459	1877	ICZN

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -948,6 +948,29 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
 
   end
 
+  context 'when importing a name classified in a subgenus later' do
+    before(:all) { import_checklist_tsv('younger_oc_subgenus.tsv', 3) }
+
+    after :all do
+      DatabaseCleaner.clean
+    end
+
+    it 'should create and import 3 records' do
+      verify_all_records_imported(3)
+    end
+
+    # Camponotus
+    # Camponotus (Myrmocladoecus) 2x
+    # Camponotus planus 2x
+    it 'should have five original combinations' do
+      expect(TaxonNameRelationship::OriginalCombination.all.length).to eq 5
+    end
+
+    it 'should not include the subgenus in the original combination' do
+      expect(TaxonName.find_by_name('planus').cached_original_combination).to eq "Camponotus planus"
+    end
+  end
+
   # TODO test missing parent
   #
   # TODO test protonym is unavailable --- set classification on unsaved TaxonName

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -101,8 +101,8 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
       expect(relationship.type_name).to eq('TaxonNameRelationship::Iczn::Invalidating::Synonym::Objective::ReplacedHomonym')
     end
 
-    it 'should have 12 original combination relationships' do
-      expect(TaxonNameRelationship::OriginalCombination.all.length).to eq 12
+    it 'should have 11 original combination relationships' do
+      expect(TaxonNameRelationship::OriginalCombination.all.length).to eq 11
     end
 
     it 'should have Baroni Urbani as the author of the replacement species' do


### PR DESCRIPTION
If the currently importing taxon's subgenus is newer than  the taxon's authorship, the subgenus should not be part of the original combination. (the name must have been classified in the subgenus later)