### PR TITLE
Save taxon in DwC importer sooner so ancestor calculation works

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -266,6 +266,9 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
                 # if user has provided a `TW:TaxonNameRelationship:incertae_sedis_in_rank` field, use that to determine
                 # which rank of parent should be used for I.S. relationship
                 if (verbatim_is_rank = get_field_value('TW:TaxonNameRelationship:incertae_sedis_in_rank'))
+                  # must save here so that `ancestor_at_rank` works
+                  # (otherwise could use `ancestors_through_parents` and check rank manually)
+                  taxon_name.save
                   incertae_sedis_parent = taxon_name.ancestor_at_rank(verbatim_is_rank.downcase)
 
                   if incertae_sedis_parent.nil?


### PR DESCRIPTION
Incertae sedis parent calculation depends on `Taxon.ancestor_at_rank`, which only works if the taxon has been saved. Normally, the taxon would be saved by this point (from generating original combinations), but if no OC relationships were created the taxon would not yet be saved.