### PR TITLE
Create combinations for synonyms with different valid rank in DwC taxon importer

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -154,17 +154,17 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
 
             original_combination_parents.each do |ancestor|
               ancestor_protonym = ancestor[:protonym]
-              rank = ancestor[:rank]
+              ancestor_rank = ancestor[:rank]
 
               # If OC parent is combination, need to create relationship for lowest element
               if ancestor_protonym.is_a?(Combination)
                 ancestor_protonym = ancestor[:protonym].finest_protonym
               end
 
-              if (rank_in_type = ORIGINAL_COMBINATION_RANKS[rank&.downcase&.to_sym])
+              if (rank_in_type = ORIGINAL_COMBINATION_RANKS[ancestor_rank&.downcase&.to_sym])
 
                 # if the subgenus is newer than taxon_name's authorship, skip it (the name must have been classified in the subgenus later)
-                next if rank&.downcase&.to_sym == :subgenus &&
+                next if ancestor_rank&.downcase&.to_sym == :subgenus &&
                   !ancestor_protonym.year_integer.nil? &&
                   !taxon_name.year_integer.nil? &&
                   ancestor_protonym.year_integer > taxon_name.year_integer

--- a/spec/files/import_datasets/checklists/create_combination_for_moved_synonym.tsv
+++ b/spec/files/import_datasets/checklists/create_combination_for_moved_synonym.tsv
@@ -1,0 +1,7 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	lass	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender
+430098		430098	Odontomachus	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Latreille, 1804	valid	430098	1804	ICZN	masculine
+430100		430098	Champsomyrmex	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Emery, 1892	synonym	430100	1892	ICZN	masculine
+442479	430098	442479	Odontomachus coquereli	Animalia	Insecta	Hymenoptera	Formicidae	Odontomachus		coquereli		Species	Roger, 1861	valid	442479	1861	ICZN
+442526	442479	442479	Odontomachus coquereli minor	Animalia	Insecta	Hymenoptera	Formicidae	Odontomachus		coquereli	minor	Subspecies	(Emery, 1899)	synonym	459047	1899	ICZN
+459047	476555	442479	Champsomyrmex coquereli minor	Animalia	Insecta	Hymenoptera	Formicidae	Champsomyrmex		coquereli	minor	Subspecies	Emery, 1899	obsolete combination	459047	1899	ICZN
+476555	430100	442479	Champsomyrmex coquereli	Animalia	Insecta	Hymenoptera	Formicidae	Champsomyrmex		coquereli		Species	(Roger, 1861)	obsolete combination	442479	1861	ICZN


### PR DESCRIPTION
When a subspecies name changes genus and is synonymized with its species name, no combination is created for [New genus] [species] [subspecies]. Only [New genus] [subspecies] (current placement) and [Old genus] [species] [subspecies] (original combination) exists.

Eg: _Champsomyrmex coquereli minor_ is the original combination, and a junior synonym of _Odontomachus coquereli_. _Odontomachus coquereli minor_ should exist as a combination, because _Champsomyrmex_ is a junior synonym of _Odontomachus_.

Effectively, this creates the combination as it's described in the imported file if we modify the parent & rank to match the senior synonym.