### PR TITLE
Add option to ensure generated identifiers match verbatim 

### DIFF
--- a/app/javascript/vue/tasks/dwca_import/components/settings/RequireCatalogNumberMatchVerbatim.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/RequireCatalogNumberMatchVerbatim.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="label-above">
+    <label>
+      <input
+        type="checkbox"
+        v-model="requireCatalogNumberMatchVerbatim">
+      Error records when computed identifier will not match catalogNumber
+    </label>
+  </div>
+</template>
+
+<script>
+
+import { ActionNames } from '../../store/actions/actions'
+import { GetterNames } from '../../store/getters/getters'
+import { UpdateImportSettings } from '../../request/resources'
+
+export default {
+  computed: {
+    requireCatalogNumberMatchVerbatim: {
+      get () {
+        return this.$store.getters[GetterNames.GetDataset].metadata?.import_settings?.require_catalog_number_match_verbatim
+      },
+      set (value) {
+        UpdateImportSettings({
+          import_dataset_id: this.dataset.id,
+          import_settings: {
+            require_catalog_number_match_verbatim: value
+          }
+        }).then(response => {
+          this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)
+        })
+      }
+    },
+    dataset () {
+      return this.$store.getters[GetterNames.GetDataset]
+    }
+  }
+}
+</script>

--- a/app/javascript/vue/tasks/dwca_import/components/settings/RequireTripCodeMatchVerbatim.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/RequireTripCodeMatchVerbatim.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="label-above">
+    <label>
+      <input
+        type="checkbox"
+        v-model="requireTripCodeMatchVerbatim">
+      Error records when computed Trip code will not match fieldNumber
+    </label>
+  </div>
+</template>
+
+<script>
+
+import { ActionNames } from '../../store/actions/actions'
+import { GetterNames } from '../../store/getters/getters'
+import { UpdateImportSettings } from '../../request/resources'
+
+export default {
+  computed: {
+    requireTripCodeMatchVerbatim: {
+      get () {
+        return this.$store.getters[GetterNames.GetDataset].metadata?.import_settings?.require_tripcode_match_verbatim
+      },
+      set (value) {
+        UpdateImportSettings({
+          import_dataset_id: this.dataset.id,
+          import_settings: {
+            require_tripcode_match_verbatim: value
+          }
+        }).then(response => {
+          this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)
+        })
+      }
+    },
+    dataset () {
+      return this.$store.getters[GetterNames.GetDataset]
+    }
+  }
+}
+</script>

--- a/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
@@ -26,6 +26,8 @@
             <containerize-checkbox />
             <restrict-to-nomenclature-checkbox />
             <require-type-material-success-checkbox />
+            <require-trip-code-match-verbatim-checkbox />
+            <require-catalog-number-match-verbatim-checkbox />
           </div>
 
           <h3>Geographic Areas</h3>
@@ -48,6 +50,8 @@ import ModalComponent from '@/components/ui/Modal'
 import ContainerizeCheckbox from './Containerize'
 import RestrictToNomenclatureCheckbox from './RestrictToNomenclature'
 import RequireTypeMaterialSuccessCheckbox from './RequireTypeMaterialSuccess'
+import RequireTripCodeMatchVerbatimCheckbox from './RequireTripCodeMatchVerbatim'
+import RequireCatalogNumberMatchVerbatimCheckbox from './RequireCatalogNumberMatchVerbatim.vue'
 import NomenclatureCode from './NomenclatureCode.vue'
 import GeographicAreaDataOrigin from './GeographicAreaDataOrigin.vue'
 import RequireGeographicAreaHasShapeCheckbox from './RequireGeographicAreaHasShapeCheckbox.vue'

--- a/app/models/import_dataset/darwin_core/occurrences.rb
+++ b/app/models/import_dataset/darwin_core/occurrences.rb
@@ -227,6 +227,14 @@ class ImportDataset::DarwinCore::Occurrences < ImportDataset::DarwinCore
     !!self.metadata.dig("import_settings", "require_type_material_success")
   end
 
+  def require_tripcode_match_verbatim?
+    !!self.metadata.dig("import_settings", "require_tripcode_match_verbatim")
+  end
+
+  def require_catalog_number_match_verbatim?
+    !!self.metadata.dig("import_settings", "require_catalog_number_match_verbatim")
+  end
+
   private
 
   def get_catalog_number_namespace_mapping(institution_code, collection_code)


### PR DESCRIPTION
Incorrectly configured delimiters in namespaces can cause TripCode and catalogNumber identifiers to become malformed. When enabled, these options will raise an error if the cached identifier doesn't match the original (verbatim) value.
