### PR TITLE
Add option to require matching geographic area to exist in DwC import

### DIFF
--- a/app/javascript/vue/tasks/dwca_import/components/settings/RequireGeographicAreaExists.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/RequireGeographicAreaExists.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="label-above">
+        <label>
+            <input
+                    type="checkbox"
+                    v-model="requireGeographicAreaExists">
+            Error if no geographic area with provided name exists (works best with "Only search for the finest geographical name provided")
+        </label>
+    </div>
+</template>
+
+<script>
+
+import { ActionNames } from '../../store/actions/actions'
+import { GetterNames } from '../../store/getters/getters'
+import { UpdateImportSettings } from '../../request/resources'
+
+export default {
+    computed: {
+      requireGeographicAreaExists: {
+            get () {
+                return this.$store.getters[GetterNames.GetDataset].metadata?.import_settings?.require_geographic_area_exists
+            },
+            set (value) {
+                UpdateImportSettings({
+                    import_dataset_id: this.dataset.id,
+                    import_settings: {
+                        require_geographic_area_exists: value
+                    }
+                }).then(response => {
+                    this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)
+                })
+            }
+        },
+        dataset () {
+            return this.$store.getters[GetterNames.GetDataset]
+        }
+    }
+}
+</script>

--- a/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
@@ -35,6 +35,7 @@
             <geographic-area-data-origin class="margin-medium-bottom" />
             <require-geographic-area-has-shape-checkbox />
             <require-geographic-area-exact-match />
+            <require-geographic-area-exists />
           </div>
 
           <CatalogNumberMain />
@@ -56,6 +57,7 @@ import NomenclatureCode from './NomenclatureCode.vue'
 import GeographicAreaDataOrigin from './GeographicAreaDataOrigin.vue'
 import RequireGeographicAreaHasShapeCheckbox from './RequireGeographicAreaHasShapeCheckbox.vue'
 import RequireGeographicAreaExactMatch from './RequireGeographicAreaExactMatch.vue'
+import RequireGeographicAreaExists from './RequireGeographicAreaExists.vue'
 import CatalogNumberMain from './CatalogNumber/CatalogNumberMain.vue'
 
 const showModal = ref(false)


### PR DESCRIPTION
This adds an alternative to silently failing to add a geographic area when importing specimens if the name wasn't recognized.