### PR TITLE
Add option to enable organization determiners in import

### DIFF
--- a/app/javascript/vue/tasks/dwca_import/components/settings/EnableOrganizationDeterminers.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/EnableOrganizationDeterminers.vue
@@ -7,6 +7,14 @@
       Enable searching for Organization name in determinedBy field
     </label>
   </div>
+  <div class="label-above">
+    <label>
+      <input
+        type="checkbox"
+        v-model="enableOrganizationDeterminersAltName">
+      Also search for Organization alternate name
+    </label>
+  </div>
 </template>
 
 <script>
@@ -26,6 +34,21 @@ export default {
           import_dataset_id: this.dataset.id,
           import_settings: {
             enable_organization_determiners: value
+          }
+        }).then(response => {
+          this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)
+        })
+      }
+    },
+    enableOrganizationDeterminersAltName: {
+      get () {
+        return this.$store.getters[GetterNames.GetDataset].metadata?.import_settings?.enable_organization_determiners_alt_name
+      },
+      set (value) {
+        UpdateImportSettings({
+          import_dataset_id: this.dataset.id,
+          import_settings: {
+            enable_organization_determiners_alt_name: value
           }
         }).then(response => {
           this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)

--- a/app/javascript/vue/tasks/dwca_import/components/settings/EnableOrganizationDeterminers.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/EnableOrganizationDeterminers.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="label-above">
+    <label>
+      <input
+        type="checkbox"
+        v-model="enableOrganizationDeterminers">
+      Enable searching for Organization name in determinedBy field
+    </label>
+  </div>
+</template>
+
+<script>
+
+import { ActionNames } from '../../store/actions/actions'
+import { GetterNames } from '../../store/getters/getters'
+import { UpdateImportSettings } from '../../request/resources'
+
+export default {
+  computed: {
+    enableOrganizationDeterminers: {
+      get () {
+        return this.$store.getters[GetterNames.GetDataset].metadata?.import_settings?.enable_organization_determiners
+      },
+      set (value) {
+        UpdateImportSettings({
+          import_dataset_id: this.dataset.id,
+          import_settings: {
+            enable_organization_determiners: value
+          }
+        }).then(response => {
+          this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)
+        })
+      }
+    },
+    dataset () {
+      return this.$store.getters[GetterNames.GetDataset]
+    }
+  }
+}
+</script>

--- a/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
@@ -28,6 +28,7 @@
             <require-type-material-success-checkbox />
             <require-trip-code-match-verbatim-checkbox />
             <require-catalog-number-match-verbatim-checkbox />
+            <enable-organization-determiners />
           </div>
 
           <h3>Geographic Areas</h3>
@@ -52,6 +53,7 @@ import RestrictToNomenclatureCheckbox from './RestrictToNomenclature'
 import RequireTypeMaterialSuccessCheckbox from './RequireTypeMaterialSuccess'
 import RequireTripCodeMatchVerbatimCheckbox from './RequireTripCodeMatchVerbatim'
 import RequireCatalogNumberMatchVerbatimCheckbox from './RequireCatalogNumberMatchVerbatim.vue'
+import EnableOrganizationDeterminers from './EnableOrganizationDeterminers.vue'
 import NomenclatureCode from './NomenclatureCode.vue'
 import GeographicAreaDataOrigin from './GeographicAreaDataOrigin.vue'
 import RequireGeographicAreaHasShapeCheckbox from './RequireGeographicAreaHasShapeCheckbox.vue'

--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -397,37 +397,43 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
     value
   end
 
-  # Parse for names in a given field and find or create one or more Person::Unvetted (scoped to the import dataset).
-  # Also supports searching for an Organization, if the column value is an exact match for the Organization's name or alternate_name
-  # NOTE: Sometimes an identifier/collector happens to be a non-person (like "ANSP Orthopterist"). Does TW (will) have something for this? Currently imported as an Unvetted Person.
+
+  # Search for an Organization by name or alternate name in the given field. If no organization found, find or create a
+  # Person::Unvetted, scoped to the import_dataset
   #
   # @param [String, Symbol] field_name Field name (column) to parse for people in
-  # @param [Boolean] enable_organization_search Should we search for an organization whose name matches the field value
-  # @return [Array<Person::Unvetted, Organization>, nil]
-  def parse_people(field_name, enable_organization_search = false)
-    if enable_organization_search
-      # check if people name matches an organization
-      org_name = get_field_value(field_name)
-      if Organization.where(name: org_name).or(Organization.where(alternate_name: org_name)).exists?
-        possible_organizations = Organization.where(name: org_name).or(Organization.where(alternate_name: org_name))
+  # @param [Boolean] search_alt_name Search by alternate_name in addition to name
+  # @return [Array<Organization, Person::Unvetted>, nil]
+  def parse_organizations_and_people(field_name, search_alt_name = false)
+    org_name = get_field_value(field_name)
+    possible_organizations = Organization.where(name: org_name)
+    if search_alt_name
+      possible_organizations = possible_organizations.or(Organization.where(alternate_name: org_name))
+    end
+    if possible_organizations.exists?
+      if possible_organizations.count == 1
+        return [possible_organizations.first]
 
-        if possible_organizations.count == 1
-          return [possible_organizations.first]
-
-        elsif possible_organizations.count > 1
-          matching_orgs = possible_organizations.map do |o|
-            str = "[id:#{o.id} #{o.name}"
-            unless o.alternate_name.blank?
-              str << " (AKA: #{o.alternate_name})"
-            end
-            str << "]"
-          end.join(", ")
-          # TODO how should the user disambiguate which organization they are referring to?
-          raise DarwinCore::InvalidData.new({ field_name => ["Multiple organizations matched name or alternate name '#{org_name}': #{matching_orgs}"] })
-        end
+      elsif possible_organizations.count > 1
+        matching_orgs = possible_organizations.map do |o|
+          str = "[id:#{o.id} #{o.name}"
+          unless o.alternate_name.blank?
+            str << " (AKA: #{o.alternate_name})"
+          end
+          str << "]"
+        end.join(", ")
+        # TODO how should the user disambiguate which organization they are referring to?
+        raise DarwinCore::InvalidData.new({ field_name => ["Multiple organizations matched name or alternate name '#{org_name}': #{matching_orgs}"] })
       end
     end
 
+    parse_people(field_name)
+  end
+
+  # Parse for names in a given field and find or create one or more Person::Unvetted (scoped to the import dataset).
+  # @param [String, Symbol] field_name Field name (column) to parse for people in
+  # @return [Array<Person::Unvetted>, nil]
+  def parse_people(field_name)
     #noinspection RubyMismatchedReturnType
     Person.transaction(requires_new: true) do
       DwcAgent.parse(get_field_value(field_name)).map! { |n| DwcAgent.clean(n) }.map! do |name|
@@ -1007,7 +1013,13 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
     end
 
     # identifiedBy: determiners of taxon determination
-    determiners = parse_people(:identifiedBy, search_organization = self.import_dataset.enable_organization_determiners? )
+    determiners = nil
+    if self.import_dataset.enable_organization_determiners?
+      determiners = parse_organizations_and_people(:identifiedBy,
+                                                   self.import_dataset.enable_organization_determiners_alt_name?)
+    else
+      determiners = parse_people(:identifiedBy)
+    end
     unless determiners.nil?
       if determiners.first.is_a?(Person)
         taxon_determination[:determiners] = determiners

--- a/app/models/import_dataset/darwin_core/occurrences.rb
+++ b/app/models/import_dataset/darwin_core/occurrences.rb
@@ -235,6 +235,10 @@ class ImportDataset::DarwinCore::Occurrences < ImportDataset::DarwinCore
     !!self.metadata.dig("import_settings", "require_catalog_number_match_verbatim")
   end
 
+  def enable_organization_determiners?
+    !!self.metadata.dig("import_settings", "enable_organization_determiners")
+  end
+
   private
 
   def get_catalog_number_namespace_mapping(institution_code, collection_code)

--- a/app/models/import_dataset/darwin_core/occurrences.rb
+++ b/app/models/import_dataset/darwin_core/occurrences.rb
@@ -239,6 +239,10 @@ class ImportDataset::DarwinCore::Occurrences < ImportDataset::DarwinCore
     !!self.metadata.dig("import_settings", "enable_organization_determiners")
   end
 
+  def enable_organization_determiners_alt_name?
+    !!self.metadata.dig("import_settings", "enable_organization_determiners_alt_name")
+  end
+
   private
 
   def get_catalog_number_namespace_mapping(institution_code, collection_code)


### PR DESCRIPTION
I'm not 100% sure about the best wording for the setting, "Enable searching for Organization name in determinedBy field" is the best I could come up with.

I added a second setting to enable matching on alternate name to help users disambiguate multiple organizations with the same name, and fingers crossed we don't need anything more complex.
