### PR TITLE
Add check for mismatched authorship year in DwC Taxon import

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -54,6 +54,7 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
         authorship = parse_results_details.dig(:authorship, :normalized) || get_field_value('scientificNameAuthorship')
 
         author_name = nil
+        year = nil
 
         # split authorship into name and year
         if nomenclature_code == :iczn
@@ -75,7 +76,13 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
           year = Utilities::Strings.year_of_publication(authorship)
         end
 
-        # TODO should a year provided in namePublishedInYear overwrite the parsed value?
+        if year && (name_published_in_year = get_field_value('namePublishedInYear')) &&
+          year != name_published_in_year
+          raise DarwinCore::InvalidData.new(
+            { "namePublishedInYear": ["parsed year from scientificName or scientificNameAuthorship (#{year}) "\
+                                      "does not match namePublishedInYear (#{name_published_in_year})"]
+            })
+        end
         year ||= get_field_value('namePublishedInYear')
 
         # TODO validate that rank is a real rank, otherwise Combination will crash on find_or_initialize_by

--- a/spec/files/import_datasets/checklists/error_tests/mismatched_year.tsv
+++ b/spec/files/import_datasets/checklists/error_tests/mismatched_year.tsv
@@ -1,0 +1,2 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	class	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsage	originalNameUsageID	namePublishedInYear	nomenclaturalCode
+429011		429011	Formicidae	Animalia	Insecta	Hymenoptera	Formicidae					Family	Latreille, 1809	valid		429011	2009	ICZN

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -1025,6 +1025,24 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
     end
   end
 
+  context 'when importing a record with mismatched authorship year data' do
+    before(:all) { import_checklist_tsv('error_tests/mismatched_year.tsv', 1) }
+
+    after :all do
+      DatabaseCleaner.clean
+    end
+
+    let(:record) {DatasetRecord.first}
+    it 'should have an errored status' do
+
+      expect(record.status).to eq("Errored")
+    end
+    it 'should have the right error message' do
+
+      expect(record[:metadata].dig("error_data", "messages", "namePublishedInYear")).to_not be_nil
+    end
+  end
+
   # TODO test missing parent
   #
   # TODO test protonym is unavailable --- set classification on unsaved TaxonName


### PR DESCRIPTION
This check raises an error if the year parsed from `scientificName` or `scientificNameAuthorship` doesn't match the value in `namePublishedInYear`.