### PR TITLE
Fix #3512 undefined method for COLDP exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 
 - New species name button is now always visible in Type section on New taxon name task
 
+### Fixed
+- Fix coldp.rb undefined method `iso8601' for nil:NilClass [#3512]
+
 ## [0.34.1] - 2023-08-07
 
 ### Fixed

--- a/lib/export/coldp.rb
+++ b/lib/export/coldp.rb
@@ -40,7 +40,11 @@ module Export
     end
 
     def self.modified(updated_at)
-      updated_at.iso8601
+      if updated_at.nil?
+        ''
+      else
+        updated_at&.iso8601
+      end
     end
 
     def self.modified_by(updated_by_id, project_members)


### PR DESCRIPTION
Fixes undefined method `iso8601' for nil:NilClass when the modified by date isn't set for COL data package exports