### PR TITLE
3414 coldp fix no parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- No parent Otu returned for TaxonName with more than 1 OTU [#3414]
 - Missing organization tab in Owner panel on New image task
 - BibTeX download shows incorrect results on New source task [#3510]
 - Asserted distribution API endpoint crashing when count is above 50

--- a/app/models/otu.rb
+++ b/app/models/otu.rb
@@ -355,8 +355,7 @@ class Otu < ApplicationRecord
 
   # @return [Otu#id, nil, false]
   #  nil - there is no OTU parent with a valid taxon name possible
-  #  false - there is > 1 OTU parent with a valid taxon name possible
-  #  id - the (unambiguous) id of the nearest parent OTU attached to a valid taoxn name
+  #  id - the (unambiguous) id of the nearest parent OTU attached to a valid taxon name
   #
   #  Note this is used CoLDP export. Do not change without considerations there.
   def parent_otu_id(skip_ranks: [], prefer_unlabelled_otus: false)
@@ -377,10 +376,8 @@ class Otu < ApplicationRecord
       otus = Otu.where(taxon_name_id: candidates.first).to_a
       otus.select! { |o| o.name.nil? } if prefer_unlabelled_otus && otus.size > 1
 
-      if otus.size == 1
+      if otus.size > 0
         return otus.first.id
-      elsif otus.size > 1
-        return false
       else
         return nil
       end

--- a/spec/models/otu_spec.rb
+++ b/spec/models/otu_spec.rb
@@ -30,7 +30,7 @@ describe Otu, type: :model, group: :otu do
       o0 = Otu.create(taxon_name: t)
       o1 = Otu.create(taxon_name: t)
       o2 = Otu.create(taxon_name: t1)
-      expect(o2.parent_otu_id).to eq(false)
+      expect(o2.parent_otu_id).to eq(o0.id)
     end
 
     specify '#parent_otu_id 3' do


### PR DESCRIPTION
To fix #3414, this changes the behavior of the Otu model's parent_otu_id method to return the first Otu if there is more than 1 parent Otu instead of returning false. So far only the otu.rb model (on the ancestor_otu_ids method which is not used yet) and CoLDP exporter use the parent_otu_id method, so I think it is safe to change.