### PR TITLE
3522 improve coldp export delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 ### Changed
 
 - New species name button is now always visible in Type section on New taxon name task
+- Improve COLDP export delimiter usability [#3522] 
 
 [#3460]: https://github.com/SpeciesFileGroup/taxonworks/issues/3460
 

--- a/lib/export/coldp.rb
+++ b/lib/export/coldp.rb
@@ -47,6 +47,10 @@ module Export
       project_members[updated_by_id]
     end
 
+    def self.sanitize_remarks(remarks)
+      remarks&.gsub('\r\n', ' ')&.gsub('\n', ' ')&.gsub('\t', ' ')&.gsub(/[ ]+/, ' ')
+    end
+
     def self.export(otu_id, prefer_unlabelled_otus: true)
       otus = otus(otu_id)
 

--- a/lib/export/coldp.rb
+++ b/lib/export/coldp.rb
@@ -55,7 +55,7 @@ module Export
       otus = otus(otu_id)
 
       # source_id: [csv_array]
-      ref_csv = {}
+      ref_tsv = {}
 
       otu = ::Otu.find(otu_id)
       project = ::Project.find(otu.project_id)
@@ -81,25 +81,25 @@ module Export
       Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
         (FILETYPES - ['Name']).each do |ft|
           m = "Export::Coldp::Files::#{ft}".safe_constantize
-          zipfile.get_output_stream("#{ft}.csv") { |f| f.write m.generate(otus, project_members, ref_csv) }
+          zipfile.get_output_stream("#{ft}.tsv") { |f| f.write m.generate(otus, project_members, ref_tsv) }
         end
 
-        zipfile.get_output_stream('Name.csv') { |f| f.write Export::Coldp::Files::Name.generate(otu, project_members, ref_csv) }
-        zipfile.get_output_stream('Taxon.csv') do |f|
-          f.write Export::Coldp::Files::Taxon.generate(otus, project_members, otu_id, ref_csv)
+        zipfile.get_output_stream('Name.tsv') { |f| f.write Export::Coldp::Files::Name.generate(otu, project_members, ref_tsv) }
+        zipfile.get_output_stream('Taxon.tsv') do |f|
+          f.write Export::Coldp::Files::Taxon.generate(otus, project_members, otu_id, ref_tsv)
         end
 
         # Sort the refs by full citation string
-        sorted_refs = ref_csv.values.sort{|a,b| a[1] <=> b[1]}
+        sorted_refs = ref_tsv.values.sort{|a,b| a[1] <=> b[1]}
 
-        d = CSV.generate(col_sep: "\t") do |csv|
-          csv << %w{ID citation	doi modified modifiedBy} # author year source details
+        d = CSV.generate(col_sep: "\t") do |tsv|
+          tsv << %w{ID citation	doi modified modifiedBy} # author year source details
           sorted_refs.each do |r|
-            csv << r
+            tsv << r
           end
         end
 
-        zipfile.get_output_stream('References.csv') { |f| f.write d }
+        zipfile.get_output_stream('References.tsv') { |f| f.write d }
         zipfile.add("metadata.yaml", metadata_file.path)
       end
 

--- a/lib/export/coldp/files/name.rb
+++ b/lib/export/coldp/files/name.rb
@@ -116,26 +116,26 @@ module Export::Coldp::Files::Name
     end
 
     csv << [
-      id,                                                            # ID
-      basionym_id,                                                   # basionymID
-      clean_sic(t.cached_original_combination),                      # scientificName
-      authorship_field(t, true),                                     # authorship
-      rank,                                                          # rank
-      uninomial,                                                     # uninomial
-      genus,                                                         # genus
-      subgenus,                                                      # subgenus (no parens)
-      species,                                                       # species
-      infraspecific_element ? infraspecific_element.last : nil,      # infraspecificEpithet
-      origin_citation&.source_id,                                    # referenceID    |
-      origin_citation&.pages,                                        # publishedInPage  | !! All origin citations get added to reference_csv via the main loop, not here
-      t.year_of_publication,                                         # publishedInYear  |
-      true,                                                          # original
-      code_field(t),                                                 # code
-      nil,                                                           # status https://api.checklistbank.org/vocab/nomStatus
-      nil,                                                           # link (probably TW public or API)
-      remarks(t, name_remarks_vocab_id),                             # remarks
-      Export::Coldp.modified(t[:updated_at]),                        # modified
-      Export::Coldp.modified_by(t[:updated_by_id], project_members)  # modifiedBy
+      id,                                                                 # ID
+      basionym_id,                                                        # basionymID
+      clean_sic(t.cached_original_combination),                           # scientificName
+      authorship_field(t, true),                                          # authorship
+      rank,                                                               # rank
+      uninomial,                                                          # uninomial
+      genus,                                                              # genus
+      subgenus,                                                           # subgenus (no parens)
+      species,                                                            # species
+      infraspecific_element ? infraspecific_element.last : nil,           # infraspecificEpithet
+      origin_citation&.source_id,                                         # referenceID    |
+      origin_citation&.pages,                                             # publishedInPage  | !! All origin citations get added to reference_csv via the main loop, not here
+      t.year_of_publication,                                              # publishedInYear  |
+      true,                                                               # original
+      code_field(t),                                                      # code
+      nil,                                                                # status https://api.checklistbank.org/vocab/nomStatus
+      nil,                                                                # link (probably TW public or API)
+      Export::Coldp.sanitize_remarks(remarks(t, name_remarks_vocab_id)),  # remarks
+      Export::Coldp.modified(t[:updated_at]),                             # modified
+      Export::Coldp.modified_by(t[:updated_by_id], project_members)       # modifiedBy
     ]
   end
 
@@ -233,26 +233,26 @@ module Export::Coldp::Files::Name
           # Set is: no original combination OR (valid or invalid higher, valid lower, past combinations)
           if t.cached_original_combination.blank? || higher || t.is_valid? || t.is_combination?
             csv << [
-              t.id,                                                          # ID
-              basionym_id,                                                   # basionymID
-              name_string,                                                   # scientificName  # should just be t.cached
-              t.cached_author_year,                                          # authorship
-              rank,                                                          # rank
-              uninomial,                                                     # uninomial   <- if genus here
-              generic_epithet,                                               # genus and below - IIF species or lower
-              infrageneric_epithet,                                          # infragenericEpithet
-              specific_epithet,                                              # specificEpithet
-              infraspecific_epithet,                                         # infraspecificEpithet
-              origin_citation&.source_id,                                    # publishedInID
-              origin_citation&.pages,                                        # publishedInPage
-              t.year_of_publication,                                         # publishedInYear
-              original,                                                      # original
-              code_field(t),                                                 # code
-              nom_status_field(t),                                           # nomStatus
-              nil,                                                           # link (probably TW public or API)
-              remarks(t, name_remarks_vocab_id),                             # remarks
-              Export::Coldp.modified(t[:updated_at]),                        # modified
-              Export::Coldp.modified_by(t[:updated_by_id], project_members)  # modifiedBy
+              t.id,                                                               # ID
+              basionym_id,                                                        # basionymID
+              name_string,                                                        # scientificName  # should just be t.cached
+              t.cached_author_year,                                               # authorship
+              rank,                                                               # rank
+              uninomial,                                                          # uninomial   <- if genus here
+              generic_epithet,                                                    # genus and below - IIF species or lower
+              infrageneric_epithet,                                               # infragenericEpithet
+              specific_epithet,                                                   # specificEpithet
+              infraspecific_epithet,                                              # infraspecificEpithet
+              origin_citation&.source_id,                                         # publishedInID
+              origin_citation&.pages,                                             # publishedInPage
+              t.year_of_publication,                                              # publishedInYear
+              original,                                                           # original
+              code_field(t),                                                      # code
+              nom_status_field(t),                                                # nomStatus
+              nil,                                                                # link (probably TW public or API)
+              Export::Coldp.sanitize_remarks(remarks(t, name_remarks_vocab_id)),  # remarks
+              Export::Coldp.modified(t[:updated_at]),                             # modified
+              Export::Coldp.modified_by(t[:updated_by_id], project_members)       # modifiedBy
             ]
           end
 

--- a/lib/export/coldp/files/synonym.rb
+++ b/lib/export/coldp/files/synonym.rb
@@ -91,7 +91,7 @@ module Export::Coldp::Files::Synonym
                 o[0],                                             # taxonID attached to the current valid concept
                 reified_id,                                       # nameID
                 nil,                                              # status  TODO: def status(taxon_name_id)
-                remarks_field,                                    # remarks
+                Export::Coldp.sanitize_remarks(remarks_field),    # remarks
                 nil,                                              # referenceID   Unclear what this means in TW
                 Export::Coldp.modified(t[6]),                     # modified
                 Export::Coldp.modified_by(t[7], project_members)  # modifiedBy

--- a/lib/export/coldp/files/taxon.rb
+++ b/lib/export/coldp/files/taxon.rb
@@ -184,24 +184,24 @@ module Export::Coldp::Files::Taxon
         parent_id = (root_otu_id == o.id ? nil : parent_id )
 
         csv << [
-          o.id,                                                          # ID (Taxon)
-          parent_id,                                                     # parentID (Taxon)
-          o.taxon_name.id,                                               # nameID (Name)
-          name_phrase(o, name_phrase_vocab_id),                          # namePhrase
-          provisional(o),                                                # provisional
-          according_to_id(o),                                            # accordingToID
-          scrutinizer(o),                                                # scrutinizer
-          scrutinizer_id(o),                                             # scrutinizerID
-          scrutinizer_date(o),                                           # scrutizinerDate
-          reference_id(sources),                                         # referenceID
-          predicate_value(o, :extinct),                                  # extinct
-          predicate_value(o, :temporal_range_start),                     # temporalRangeStart
-          predicate_value(o, :temporal_range_end),                       # temporalRangeEnd
-          predicate_value(o, :lifezone),                                 # environment (formerly named lifezone)
-          link(o),                                                       # link
-          remarks(o, taxon_remarks_vocab_id),                            # remarks
-          Export::Coldp.modified(o[:updated_at]),                        # modified
-          Export::Coldp.modified_by(o[:updated_by_id], project_members)  # modifiedBy
+          o.id,                                                                # ID (Taxon)
+          parent_id,                                                           # parentID (Taxon)
+          o.taxon_name.id,                                                     # nameID (Name)
+          name_phrase(o, name_phrase_vocab_id),                                # namePhrase
+          provisional(o),                                                      # provisional
+          according_to_id(o),                                                  # accordingToID
+          scrutinizer(o),                                                      # scrutinizer
+          scrutinizer_id(o),                                                   # scrutinizerID
+          scrutinizer_date(o),                                                 # scrutizinerDate
+          reference_id(sources),                                               # referenceID
+          predicate_value(o, :extinct),                                        # extinct
+          predicate_value(o, :temporal_range_start),                           # temporalRangeStart
+          predicate_value(o, :temporal_range_end),                             # temporalRangeEnd
+          predicate_value(o, :lifezone),                                       # environment (formerly named lifezone)
+          link(o),                                                             # link
+          Export::Coldp.sanitize_remarks(remarks(o, taxon_remarks_vocab_id)),  # remarks
+          Export::Coldp.modified(o[:updated_at]),                              # modified
+          Export::Coldp.modified_by(o[:updated_by_id], project_members)        # modifiedBy
         ]
 
         Export::Coldp::Files::Reference.add_reference_rows(sources, reference_csv, project_members) if reference_csv


### PR DESCRIPTION
Sanitizes remarks fields to eliminate tabs and line breaks, and changes export file extension from csv to tsv