### PR TITLE
Add basionyms to synonym export (Fix #3482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- Missing synonym record for basionym in COLDP export [#3482]
 - Fixed loan related links in several places [#3463]
 - Common name language ISO when no language [#3530]
 - Attribution displays owner/copyright holder Organization names [#3515]

--- a/lib/export/coldp/files/synonym.rb
+++ b/lib/export/coldp/files/synonym.rb
@@ -75,12 +75,14 @@ module Export::Coldp::Files::Synonym
                 end
               end
 
-              matches = t[1].match(/([A-Z][a-z]+) \(.+\) ([a-z]+)/)
-              if matches&.size == 3
-                if t[5] == "#{matches[1]} #{matches[2]}" and t[2] != t[5]
-                  next
-                end
-              end
+              # TODO: This code block is erroneously removing basionyms from the synonyms section but we may need an improved form of it to remove duplicate synonyms (https://github.com/SpeciesFileGroup/taxonworks/issues/3482)
+              # matches = t[1].match(/([A-Z][a-z]+) \(.+\) ([a-z]+)/)
+              # 
+              # if matches&.size == 3        # cached_original_combination != cached_secondary_homonym
+              #   if t[5] == "#{matches[1]} #{matches[2]}" and t[2] != t[5]
+              #     next
+              #   end
+              # end
 
               # skips combinations including parent binomial as a synonym of autonym trinomial
               if t[3] == 'Combination' and o[1].include? t[1]


### PR DESCRIPTION
@yroskov and I are planning on doing more testing to determine if this reintroduces a duplicate synonym bug when we update the SF checklists in COL