### PR TITLE
Remove [sic] suffix when checking synonyms for typeStatus in DwC importer

### DIFF
--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -964,7 +964,12 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
       synonyms = taxon_protonym.synonyms
       matching_synonyms = []
       synonyms.each do |s|
-        if [s.cached, s.cached_original_combination].compact.include?(type_scientific_name)
+        possible_names = [s.cached, s.cached_original_combination].compact
+        if s.has_misspelling_relationship?
+          extra = possible_names.map { |n| n.delete_suffix(" [sic]") }
+          possible_names += extra
+        end
+        if possible_names.include?(type_scientific_name)
           if s.is_combination?
             matching_synonyms << s.finest_protonym
           else


### PR DESCRIPTION
`.cached` and `.cached_original_combination` have " [sic]" appended to the misspelled name, so it must be removed before comparing to the name extracted from the typeStatus field.