### PR TITLE
Use authorship information to distinguish homonyms when intermediate parent not provided

### DIFF
--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -78,7 +78,12 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
         if p.nil? && Protonym.where(name.slice(:rank_class).merge({ field => name[:name] })).where(project_id: parent.project_id).exists?
           potential_protonyms = Protonym.where(name.slice(:rank_class).merge!({ field => name[:name] })).with_ancestor(parent)
           if potential_protonyms.count > 1
-            return parent
+            # if multiple matches, then we need to narrow down with additional information
+            # TODO shouldn't we just use this to begin with?
+            potential_protonyms = Protonym.where(name.slice(:rank_class, :name, :verbatim_author, :year_of_publication)).with_ancestor(parent)
+            if potential_protonyms.count > 1
+              return parent
+            end
             # potential_protonym_strings = potential_protonyms.map { |proto| "[id: #{proto.id} #{proto.cached_html_name_and_author_year}]" }
             # raise DatasetRecord::DarwinCore::InvalidData.new(
             #   { "scientificName" => ["Intermediate name not present, and multiple matches found: #{potential_protonym_strings.join(', ')}"] }

--- a/app/models/dataset_record/darwin_core/occurrence.rb
+++ b/app/models/dataset_record/darwin_core/occurrence.rb
@@ -76,14 +76,9 @@ class DatasetRecord::DarwinCore::Occurrence < DatasetRecord::DarwinCore
         # Protonym might not exist, or might have intermediate parent not listed in file
         # if it exists, run more expensive query to see if it has an ancestor matching parent name and rank
         if p.nil? && Protonym.where(name.slice(:rank_class).merge({ field => name[:name] })).where(project_id: parent.project_id).exists?
-          potential_protonyms = Protonym.where(name.slice(:rank_class).merge!({ field => name[:name] })).with_ancestor(parent)
+          potential_protonyms = Protonym.where(name.slice(:rank_class, :verbatim_author, :year_of_publication).merge!({ field => name[:name] })).with_ancestor(parent)
           if potential_protonyms.count > 1
-            # if multiple matches, then we need to narrow down with additional information
-            # TODO shouldn't we just use this to begin with?
-            potential_protonyms = Protonym.where(name.slice(:rank_class, :name, :verbatim_author, :year_of_publication)).with_ancestor(parent)
-            if potential_protonyms.count > 1
-              return parent
-            end
+            return parent
             # potential_protonym_strings = potential_protonyms.map { |proto| "[id: #{proto.id} #{proto.cached_html_name_and_author_year}]" }
             # raise DatasetRecord::DarwinCore::InvalidData.new(
             #   { "scientificName" => ["Intermediate name not present, and multiple matches found: #{potential_protonym_strings.join(', ')}"] }

--- a/spec/files/import_datasets/occurrences/typeStatus_unresolved_homonym.tsv
+++ b/spec/files/import_datasets/occurrences/typeStatus_unresolved_homonym.tsv
@@ -1,0 +1,2 @@
+occurrenceID	scientificName	taxonRank	scientificNameAuthorship	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Camponotus nigripes	species	Dumpert, 1995	Camponotus	nigripes				Formicinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	paratype of Camponotus nigripes

--- a/spec/models/dataset_record/darwin_core/occurrence_spec.rb
+++ b/spec/models/dataset_record/darwin_core/occurrence_spec.rb
@@ -62,7 +62,7 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/intermediate_protonym.tsv'), 'text/plain'),
         description: 'Missing Ancestor Protonym',
-        metadata: { 'import_settings' => { 'restrict_to_existing_nomenclature' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true}
       ).tap { |i| i.stage }
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
@@ -99,9 +99,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/type_material.tsv'), 'text/plain'),
         description: 'Type Material',
-        metadata: { 'import_settings' =>
-                      { 'restrict_to_existing_nomenclature' => true,
-                        'require_type_material_success' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true,
+                           'require_type_material_success' => true }
       ).tap { |i| i.stage }
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
@@ -155,9 +154,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/typeStatus_original_misspelling.tsv'), 'text/plain'),
         description: 'Type Material Synonym',
-        metadata: { 'import_settings' =>
-                      { 'restrict_to_existing_nomenclature' => true,
-                        'require_type_material_success' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true,
+                           'require_type_material_success' => true }
       ).tap { |i| i.stage }
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
@@ -215,9 +213,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/typeStatus_combination_misspelling.tsv'), 'text/plain'),
         description: 'Type Material Obsolete Combination Misspelling',
-        metadata: { 'import_settings' =>
-                      { 'restrict_to_existing_nomenclature' => true,
-                        'require_type_material_success' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true,
+                           'require_type_material_success' => true }
       ).tap { |i| i.stage }
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
@@ -272,9 +269,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/typeStatus_synonym_misspelling.tsv'), 'text/plain'),
         description: 'Type Material Synonym Misspelling',
-        metadata: { 'import_settings' =>
-                      { 'restrict_to_existing_nomenclature' => true,
-                        'require_type_material_success' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true,
+                           'require_type_material_success' => true }
       ).tap { |i| i.stage }
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
@@ -345,9 +341,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/typeStatus_subsequent_combination.tsv'), 'text/plain'),
         description: 'Type Material Subsequent Combination',
-        metadata: { 'import_settings' =>
-                      { 'restrict_to_existing_nomenclature' => true,
-                        'require_type_material_success' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true,
+                           'require_type_material_success' => true }
       ).tap { |i| i.stage }
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
@@ -414,9 +409,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/typeStatus_wildcard_subgenus.tsv'), 'text/plain'),
         description: 'Type Material Wildcard Subgenus',
-        metadata: { 'import_settings' =>
-                      { 'restrict_to_existing_nomenclature' => true,
-                        'require_type_material_success' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true,
+                           'require_type_material_success' => true }
       ).tap { |i| i.stage }
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
@@ -468,15 +462,10 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @import_dataset = ImportDataset::DarwinCore::Occurrences.create!(
         source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/occurrences/typeStatus_unresolved_homonym.tsv'), 'text/plain'),
         description: 'Type Material Homonym',
-        metadata: { 'import_settings' =>
-                      { 'restrict_to_existing_nomenclature' => true,
-                        'require_type_material_success' => true } }
+        import_settings: { 'restrict_to_existing_nomenclature' => true,
+                           'require_type_material_success' => true }
       ).tap { |i| i.stage }
 
-      @import_dataset.metadata.merge!({ 'import_settings' =>
-                                          { 'restrict_to_existing_nomenclature' => true,
-                                            'require_type_material_success' => true } })
-      @import_dataset.save!
 
       kingdom = Protonym.create(parent: @root, name: "Animalia", rank_class: Ranks.lookup(:iczn, :kingdom))
       phylum = Protonym.create(parent: kingdom, name: "Arthropoda", rank_class: Ranks.lookup(:iczn, :phylum))


### PR DESCRIPTION
Default behavior was to return the parent when multiple protonyms returned when searching with ignored intermediate parent. Instead, authorship information should be used to select the correct name (if available).