### PR TITLE
Fix bug when creating subsequent combinations for synonyms in importer

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -259,10 +259,10 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
                   ORIGINAL_COMBINATION_RANKS.has_key?(old_rank.downcase.to_sym)
 
                   # save taxon so we can create a combination
-                  taxon_name.save
+                  taxon_name.save!
 
                   # stolen from combination handling portion of code
-                  parent_elements = create_parent_element_hash
+                  parent_elements = create_parent_element_hash.transform_values {|v| v.is_a?(Combination) ? v.finest_protonym : v}
 
                   combination_attributes = { **parent_elements }
                   combination_attributes[old_rank.downcase] = taxon_name if old_rank

--- a/spec/files/import_datasets/checklists/synonym_combination_parent.tsv
+++ b/spec/files/import_datasets/checklists/synonym_combination_parent.tsv
@@ -1,0 +1,12 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	lass	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender	TW:TaxonNameClassification:Latinized:PartOfSpeech	TW:TaxonNameRelationship:incertae_sedis_in_rank	TW:TaxonNameClassification:Iczn:Fossil
+429869		429869	Crematogastrini	Animalia	Insecta	Hymenoptera	Formicidae					Tribe	Forel, 1893	valid	429869	1893	ICZN
+429795	429869	429802	Rhoptromyrmex	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Mayr, 1901	synonym	429795	1901	ICZN	masculine
+429802	429869	429802	Tetramorium	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Mayr, 1855	valid	429802	1855	ICZN	neuter
+447276	429802	447282	Tetramorium rothneyi	Animalia	Insecta	Hymenoptera	Formicidae	Tetramorium		rothneyi		Species	(Forel, 1902)	obsolete combination	510992	1902	ICZN
+447282	429802	447282	Tetramorium wroughtonii	Animalia	Insecta	Hymenoptera	Formicidae	Tetramorium		wroughtonii		Species	(Forel, 1902)	valid	510348	1902	ICZN
+508355	429795	447282	Rhoptromyrmex rothneyi	Animalia	Insecta	Hymenoptera	Formicidae	Rhoptromyrmex		rothneyi		Species	Forel, 1902	obsolete combination	510992	1902	ICZN
+509235	447282	447282	Tetramorium wroughtonii rothneyi	Animalia	Insecta	Hymenoptera	Formicidae	Tetramorium		wroughtonii	rothneyi	Subspecies	(Forel, 1902)	synonym	510992	1902	ICZN
+510348	429795	447282	Rhoptromyrmex wroughtonii	Animalia	Insecta	Hymenoptera	Formicidae	Rhoptromyrmex		wroughtonii		Species	Forel, 1902	obsolete combination	510348	1902	ICZN
+510992	510348	447282	Rhoptromyrmex wroughtonii rothneyi	Animalia	Insecta	Hymenoptera	Formicidae	Rhoptromyrmex		wroughtonii	rothneyi	Subspecies	Forel, 1902	obsolete combination	510992	1902	ICZN
+513056	447276	447282	Tetramorium rothneyi longi	Animalia	Insecta	Hymenoptera	Formicidae	Tetramorium		rothneyi	longi	Subspecies	(Chapman & Capco, 1951)	synonym	513057	1951	ICZN
+513057	508355	447282	Rhoptromyrmex rothneyi longi	Animalia	Insecta	Hymenoptera	Formicidae	Rhoptromyrmex		rothneyi	longi	Subspecies	Chapman & Capco, 1951	obsolete combination	513057	1951	ICZN

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -1076,6 +1076,40 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
 
   end
 
+  context 'when importing a synonym with a combination parent' do
+    before(:all) { import_checklist_tsv('synonym_combination_parent.tsv', 9) }
+
+    # Tetramorium rothneyi longi is a synonym of Tetramorium wroughtonii and has a different
+    # original combination (Rhoptromyrmex rothneyi longi). Because the valid rank is different and it is not the
+    # original combination, we need to create a subsequent combination for it.
+    # However, Tetramorium rothneyi is a subsequent combination (not a protonym) of Tetramorium wroughtonii rothneyi.
+    # This revealed a bug that subsequent combination generation for synonyms did not use the
+    # finest protonym for Combination ancestors.
+
+    after :all do
+      DatabaseCleaner.clean
+    end
+
+    let(:synonym_protonym) { Protonym.find_by(name: 'longi') }
+
+    it 'should create and import 11 records' do
+      verify_all_records_imported(11)
+    end
+
+    it 'the synonym should have species rank' do
+      expect(synonym_protonym.rank).to eq('species')
+    end
+
+    it 'the synonym should have the correct cached original combination' do
+      expect(synonym_protonym.cached_original_combination).to eq('Rhoptromyrmex rothneyi longi')
+    end
+
+    it 'the synonym subsequent combination should exist' do
+      expect(Combination.find_by(cached: 'Tetramorium rothneyi longi')).to be_truthy
+    end
+
+  end
+
   # TODO test missing parent
   #
   # TODO test protonym is unavailable --- set classification on unsaved TaxonName


### PR DESCRIPTION
When a subsequent combination is a synonym whose parent is a synonym, the importer would attempt to create a combination with a Combination ancestor instead of Protonym ancestors.
