### PR TITLE
Allow checklist import to match existing name for parent instead of Root

### DIFF
--- a/app/controllers/tasks/dwca_import/dwca_import_controller.rb
+++ b/app/controllers/tasks/dwca_import/dwca_import_controller.rb
@@ -20,7 +20,7 @@ class Tasks::DwcaImport::DwcaImportController < ApplicationController
 
   # POST
   def set_import_settings
-    import_dataset = ImportDataset::DarwinCore::Occurrences.find(params[:import_dataset_id])
+    import_dataset = ImportDataset::DarwinCore.find(params[:import_dataset_id])
     settings = import_dataset.set_import_settings(params[:import_settings])
     import_dataset.save!
 

--- a/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/Settings.vue
@@ -16,12 +16,17 @@
       }"
     >
       <template #header>
-        <h3>Settings</h3>
+        <h2>Settings</h2>
       </template>
       <template #body>
         <div>
-          <nomenclature-code class="margin-medium-bottom" />
+          <nomenclature-code/>
+          <h3>DwC Checklist Import Settings</h3>
+          <div class="field">
+            <use-existing-taxon-hierarchy />
+          </div>
 
+          <h3>DwC Occurrence Import Settings</h3>
           <div class="field">
             <containerize-checkbox />
             <restrict-to-nomenclature-checkbox />
@@ -31,7 +36,7 @@
             <enable-organization-determiners />
           </div>
 
-          <h3>Geographic Areas</h3>
+          <h4>Geographic Areas</h4>
           <div class="field">
             <geographic-area-data-origin class="margin-medium-bottom" />
             <require-geographic-area-has-shape-checkbox />
@@ -61,6 +66,7 @@ import RequireGeographicAreaHasShapeCheckbox from './RequireGeographicAreaHasSha
 import RequireGeographicAreaExactMatch from './RequireGeographicAreaExactMatch.vue'
 import RequireGeographicAreaExists from './RequireGeographicAreaExists.vue'
 import CatalogNumberMain from './CatalogNumber/CatalogNumberMain.vue'
+import UseExistingTaxonHierarchy from './UseExistingTaxonHierarchy.vue'
 
 const showModal = ref(false)
 

--- a/app/javascript/vue/tasks/dwca_import/components/settings/UseExistingTaxonHierarchy.vue
+++ b/app/javascript/vue/tasks/dwca_import/components/settings/UseExistingTaxonHierarchy.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="label-above">
+    <label>
+      <input
+        type="checkbox"
+        v-model="useExistingTaxonHierarchy">
+      Taxon names without parentNameUsageID will match existing nomenclature instead of being children of Root
+    </label>
+  </div>
+</template>
+
+<script>
+
+import { ActionNames } from '../../store/actions/actions'
+import { GetterNames } from '../../store/getters/getters'
+import { UpdateImportSettings } from '../../request/resources'
+
+export default {
+  computed: {
+    useExistingTaxonHierarchy: {
+      get () {
+        return this.$store.getters[GetterNames.GetDataset].metadata?.import_settings?.use_existing_taxon_hierarchy
+      },
+      set (value) {
+        UpdateImportSettings({
+          import_dataset_id: this.dataset.id,
+          import_settings: {
+            use_existing_taxon_hierarchy: value
+          }
+        }).then(response => {
+          this.$store.dispatch(ActionNames.LoadDataset, this.dataset.id)
+        })
+      }
+    },
+    dataset () {
+      return this.$store.getters[GetterNames.GetDataset]
+    }
+  }
+}
+</script>

--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -90,7 +90,30 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
         is_hybrid = metadata['is_hybrid'] # TODO: NO...
 
         if metadata['parent'].nil?
-          parent = project.root_taxon_name
+          if self.import_dataset.use_existing_hierarchy?
+            protonym_attributes = { name: name,
+                                  cached: get_field_value(:scientificName),
+                                  rank_class: Ranks.lookup(nomenclature_code, rank),
+                                  verbatim_author: author_name,
+                                  year_of_publication: year,
+                                  project: project}
+            potential_protonyms = TaxonName.where(protonym_attributes)
+
+            if potential_protonyms.count == 1
+              parent = potential_protonyms.first.parent
+            elsif potential_protonyms.count > 1
+              matching_protonyms = potential_protonyms.map { |proto| "[id: #{proto.id} #{proto.cached_html_name_and_author_year}]" }.join(', ')
+              raise DarwinCore::InvalidData.new(
+                { "parentNameUsageID": ["parent ID is blank, 'use existing taxon hierarchy' is enabled in settings, " \
+                                          "and multiple TaxonNames matched #{protonym_attributes}: #{matching_protonyms}"] })
+            else
+              raise DarwinCore::InvalidData.new(
+                { "parentNameUsageID": ["parent ID is blank, 'use existing taxon hierarchy' is enabled in settings, " \
+                                          "and no TaxonNames matched #{protonym_attributes}"] })
+            end
+          else
+            parent = project.root_taxon_name
+          end
         else
           parent = TaxonName.find(get_parent.metadata['imported_objects']['taxon_name']['id'])
         end
@@ -115,11 +138,11 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
             rank_class: Ranks.lookup(nomenclature_code, rank),
             # also_create_otu: false,
             verbatim_author: author_name,
-            year_of_publication: year
+            year_of_publication: year,
+            project: project
           }
 
-          taxon_name = Protonym.create_with(project: project)
-                               .find_or_initialize_by(protonym_attributes)
+          taxon_name = Protonym.find_or_initialize_by(protonym_attributes)
 
           unless taxon_name.persisted?
             taxon_name.taxon_name_classifications.build(type: TaxonNameClassification::Icn::Hybrid) if is_hybrid
@@ -133,7 +156,7 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
           end
 
           # make OC relationships to OC ancestors
-          unless parent == project.root_taxon_name # can't make original combination with Root
+          unless metadata['parent'].nil? # can't make original combination with Root or if matching pre-existing taxon name
 
             # loop through parents of original combination based on parentNameUsageID, not TW parent
             # this way we get the name as intended, not with any valid/current names
@@ -207,7 +230,7 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
             # detect if current name rank is genus and original combination is with self at subgenus level, eg Aus (Aus)
             # if so, generate OC relationship with genus (since oc_protonym_rank will be subgenus)
             if oc_protonym_rank == :subgenus && get_field_value('taxonRank').downcase == "genus" &&
-              (get_original_combination.metadata['parent'] == get_field_value('taxonID'))
+              (get_original_combination&.metadata['parent'] == get_field_value('taxonID'))
               TaxonNameRelationship.create_with(subject_taxon_name: taxon_name).find_or_create_by!(
                 type: ORIGINAL_COMBINATION_RANKS[:genus],
                 object_taxon_name: taxon_name)
@@ -502,7 +525,12 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
   # Create a hash of parents from checklist
   # @return [Hash{Symbol => TaxonName}] hash of ranks and TaxonNames of genus and species rank parents
   def create_parent_element_hash
-    parents = [get_parent]
+    parent = get_parent
+
+    # if parent is root, return empty hash
+    return {} unless parent
+
+    parents = [parent]
 
     while (next_parent = find_by_taxonID(parents[-1].metadata['parent']))
       parents << next_parent

--- a/app/models/import_dataset/darwin_core/checklist.rb
+++ b/app/models/import_dataset/darwin_core/checklist.rb
@@ -30,10 +30,12 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
   def perform_staging
     records, headers = get_records(source)
 
-    update!(metadata: {
-      core_headers: headers[:core],
+    update!(metadata:
+      metadata.merge({
+         core_headers: headers[:core],
       extensions_headers: headers[:extensions]
-    })
+       })
+    )
 
     parse_results_ary = Biodiversity::Parser.parse_ary(records[:core].map { |r| r['scientificName'] || '' })
 
@@ -279,6 +281,10 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
 
   end
 
+  def use_existing_hierarchy?
+    !!self.metadata.dig("import_settings", "use_existing_taxon_hierarchy")
+  end
+
   private
 
   # @param [String, Symbol] column_name
@@ -294,4 +300,4 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
     end
   end
 
-end
+  end

--- a/spec/files/import_datasets/checklists/two_part_upload/two_part_upload_1.tsv
+++ b/spec/files/import_datasets/checklists/two_part_upload/two_part_upload_1.tsv
@@ -1,0 +1,2 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	lass	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender	TW:TaxonNameClassification:Latinized:PartOfSpeech	TW:TaxonNameRelationship:incertae_sedis_in_rank	TW:TaxonNameClassification:Iczn:Fossil
+429011		429011	Formicidae	Animalia	Insecta	Hymenoptera	Formicidae					Family	Latreille, 1802	valid	429011	1802	ICZN

--- a/spec/files/import_datasets/checklists/two_part_upload/two_part_upload_2.tsv
+++ b/spec/files/import_datasets/checklists/two_part_upload/two_part_upload_2.tsv
@@ -1,0 +1,3 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	lass	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode	TW:TaxonNameClassification:Latinized:Gender	TW:TaxonNameClassification:Latinized:PartOfSpeech	TW:TaxonNameRelationship:incertae_sedis_in_rank	TW:TaxonNameClassification:Iczn:Fossil
+429011		429011	Formicidae	Animalia	Insecta	Hymenoptera	Formicidae					Family	Latreille, 1802	valid	429011	1802	ICZN
+429149	429011	429149	Formicinae	Animalia	Insecta	Hymenoptera	Formicidae					Subfamily	Latreille, 1802	valid	429149	1802	ICZN

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -1076,6 +1076,45 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
 
   end
 
+
+  context 'when importing a second time that builds off the first import' do
+    before(:all) do
+      DatabaseCleaner.start
+      import_dataset = ImportDataset::DarwinCore::Checklist.create!(
+        source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/checklists/' + 'two_part_upload/two_part_upload_1.tsv'), 'text/plain'),
+        description: "part 1",
+        import_settings: {'use_existing_taxon_hierarchy' => false}
+      ).tap { |i| i.stage }
+
+      1.times { |_|
+        import_dataset.import(5000, 100)
+      }
+
+      import_dataset2 = ImportDataset::DarwinCore::Checklist.create!(
+        source: fixture_file_upload((Rails.root + 'spec/files/import_datasets/checklists/' + 'two_part_upload/two_part_upload_2.tsv'), 'text/plain'),
+        description: "part 2",
+        import_settings: {'use_existing_taxon_hierarchy' => true}
+      ).tap { |i| i.stage }
+
+      2.times { |_|
+        import_dataset2.import(5000, 100)
+      }
+    end
+
+    after :all do
+      DatabaseCleaner.clean
+    end
+
+    it 'should import 3 records' do
+      verify_all_records_imported(3)
+    end
+
+    it 'only two protonyms should be created' do
+      expect(TaxonName.where.not(name: 'Root').count).to eq 2
+    end
+
+  end
+
   # TODO test missing parent
   #
   # TODO test protonym is unavailable --- set classification on unsaved TaxonName


### PR DESCRIPTION
When `parentNameUsageID` is blank, importer can now try to match the name against existing TaxonNames in the project.

This allows users to make fixes to errored rows and re-upload for import. Previously, re-importing the same rows in a new checklist would create duplicate entries if the top-level name's parent was changed from Root, as the new top-level name would have parent Root and no names would match.

Now, when the setting is enabled, the importer will re-use the existing "top-level" name, allowing its children to also match existing names if they haven't changed.
