### PR TITLE
Support "invalid" status as relationship DwC Checklist importer

### DIFF
--- a/spec/files/import_datasets/checklists/invalid_as_classification.tsv
+++ b/spec/files/import_datasets/checklists/invalid_as_classification.tsv
@@ -1,0 +1,2 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	originalNameUsageID	scientificNameID	datasetID	taxonomicStatus	taxonRank	scientificName	scientificNameAuthorship	col:notho	genericName	infragenericEpithet	specificEpithet	infraspecificEpithet	cultivarEpithet	nameAccordingTo	namePublishedIn	nomenclaturalCode	nomenclaturalStatus	taxonRemarks	dcterms:references
+4339		4339	4339	4339		invalid	family	Cynipidae										ICZN

--- a/spec/files/import_datasets/checklists/invalid_as_relationship.tsv
+++ b/spec/files/import_datasets/checklists/invalid_as_relationship.tsv
@@ -1,0 +1,4 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	originalNameUsageID	scientificNameID	datasetID	taxonomicStatus	taxonRank	scientificName	scientificNameAuthorship	col:notho	genericName	infragenericEpithet	specificEpithet	infraspecificEpithet	cultivarEpithet	nameAccordingTo	namePublishedIn	nomenclaturalCode	nomenclaturalStatus	taxonRemarks	dcterms:references
+4339		4339	4339	4339		valid	family	Cynipidae										ICZN
+1309638	4339	1309638	1309638	1309638		valid	genus	Biorhiza Westwood, 1840	Westwood, 1840		Biorhiza						Introd. class. Insect., 2, Syn.	ICZN
+4679634	4339	1309638	4679634	4679634		invalid	genus	Biorhyza Giraud, 1859	Giraud, 1859		Biorhyza						Verh. Zool.-bot. Ges. Wien, 9, Abh.	ICZN


### PR DESCRIPTION
"invalid" can be either a TaxonNameClassification or a TaxonNameRelationship, this adds support for `invalid` as a generic relationship between two protonyms (perhaps when the real relationship is too complicated or not implemented yet).

Resolves a secondary issue mentioned in https://github.com/SpeciesFileGroup/taxonworks/issues/3660#issuecomment-1823488776