### PR TITLE
Add person/123.json `role_counts` extension to make Uniquify People task faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 - BiologicalAssociations as raw TaxonWorks data`/api/v1/biological_associations.csv`
 - BiologicalRelationships as raw TaxonWorks data`/api/v1/biological_relationships.csv`
 - DwC ResourceRelationship extension (preview) [#2554]
-- Taxonmy summary to CollectionObject summary report
+- Taxonomy summary to CollectionObject summary report
 - Metadata summary report from Filter BiologicalAssociations
 - Biological associations simple table preview, sortable columns [#1946]
 - GLOBI format table from Filter BiologicalAssociations (preliminary)
@@ -25,11 +25,12 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 - "Ancestrify" option to TaxonName filter (adds ancestors of filter result)
 - Auto UUIDs as new Identifier::Global::Uuid::Auto for models
 - Auto UUIDs are created for BiologicalAssociations and OTUs
-- Maintainence Task to add UUIDs to objects that can have them but don't
+- Maintenance Task to add UUIDs to objects that can have them but don't
 - TaxonName model to customize attributes
 - TaxonNameRelationship model, added validation for the rank of type species and type genus.
 - New source task: Person source
 - Index view to API for /depictions
+- Added extend[]=role_counts to /person/123.json
 
 ### Changed
 

--- a/app/javascript/vue/tasks/uniquify/people/components/FoundPeople.vue
+++ b/app/javascript/vue/tasks/uniquify/people/components/FoundPeople.vue
@@ -65,10 +65,10 @@
               </td>
               <td>
                 <span class="feedback feedback-thin feedback-primary">{{
-                  person.roles ? person.roles.length : 0
+                  person.role_counts ? countUses(person) : 0
                 }}</span>
               </td>
-              <td>{{ getRoles(person) }}</td>
+              <td>{{ getRoleNames(person) }}</td>
             </tr>
           </template>
         </tbody>
@@ -82,7 +82,8 @@ import { ActionNames } from '../store/actions/actions'
 import { MutationNames } from '../store/mutations/mutations'
 import Autocomplete from '@/components/ui/Autocomplete.vue'
 import DefaultPin from '@/components/getDefaultPin.vue'
-import getRoles from '../utils/getRoles'
+import getRoleNames from '../utils/getRoleNames'
+import countUses from '../utils/countUses'
 
 export default {
   components: {
@@ -126,7 +127,9 @@ export default {
       return value || '?'
     },
 
-    getRoles
+    getRoleNames,
+
+    countUses,
   }
 }
 </script>

--- a/app/javascript/vue/tasks/uniquify/people/components/FoundPeople.vue
+++ b/app/javascript/vue/tasks/uniquify/people/components/FoundPeople.vue
@@ -65,7 +65,7 @@
               </td>
               <td>
                 <span class="feedback feedback-thin feedback-primary">{{
-                  person.role_counts ? countUses(person) : 0
+                  person?.roles?.length ?? countUses(person)
                 }}</span>
               </td>
               <td>{{ getRoleNames(person) }}</td>

--- a/app/javascript/vue/tasks/uniquify/people/components/MatchPeople.vue
+++ b/app/javascript/vue/tasks/uniquify/people/components/MatchPeople.vue
@@ -60,10 +60,10 @@
               </td>
               <td>
                 <span class="feedback feedback-thin feedback-primary">
-                  {{ person.roles ? person.roles.length : '?' }}
+                  {{ countUses(person) || '?'}}
                 </span>
               </td>
-              <td>{{ getRoles(person) }}</td>
+              <td>{{ getRoleNames(person) }}</td>
             </tr>
           </template>
         </tbody>
@@ -76,7 +76,8 @@ import { GetterNames } from '../store/getters/getters'
 import { MutationNames } from '../store/mutations/mutations'
 import { ActionNames } from '../store/actions/actions'
 import Autocomplete from '@/components/ui/Autocomplete'
-import getRoles from '../utils/getRoles.js'
+import getRoleNames from '../utils/getRoleNames.js'
+import countUses from '../utils/countUses.js'
 
 export default {
   components: { Autocomplete },
@@ -126,7 +127,7 @@ export default {
       this.$store.dispatch(ActionNames.AddMatchPerson, person)
     },
 
-    getRoles,
+    getRoleNames,
 
     yearValue(value) {
       return value || '?'
@@ -134,7 +135,9 @@ export default {
 
     isSelectedPerson(id) {
       return this.selectedPerson.id === id
-    }
+    },
+
+    countUses
   }
 }
 </script>

--- a/app/javascript/vue/tasks/uniquify/people/components/MatchPeople.vue
+++ b/app/javascript/vue/tasks/uniquify/people/components/MatchPeople.vue
@@ -60,7 +60,7 @@
               </td>
               <td>
                 <span class="feedback feedback-thin feedback-primary">
-                  {{ countUses(person) || '?'}}
+                  {{ (person?.roles?.length ?? countUses(person)) || '?'}}
                 </span>
               </td>
               <td>{{ getRoleNames(person) }}</td>

--- a/app/javascript/vue/tasks/uniquify/people/store/actions/addMatchPerson.js
+++ b/app/javascript/vue/tasks/uniquify/people/store/actions/addMatchPerson.js
@@ -8,7 +8,7 @@ export default ({ state }, person) => {
   if (!isAlreadyInList) {
     person.cached = person.label
     state.requestState.isLoading = true
-    People.find(person.id, { extend: ['roles'] })
+    People.find(person.id, { extend: ['roles', 'role_counts'] })
       .then((response) => {
         state.matchPeople.push(response.body)
         state.mergeList.push(response.body)

--- a/app/javascript/vue/tasks/uniquify/people/store/actions/addSelectPerson.js
+++ b/app/javascript/vue/tasks/uniquify/people/store/actions/addSelectPerson.js
@@ -4,7 +4,7 @@ import ActionNames from './actionNames'
 
 export default ({ commit, dispatch, state }, personId) => {
   state.requestState.isLoading = true
-  People.find(personId, { extend: ['roles'] })
+  People.find(personId, { extend: ['roles', 'role_counts'] })
     .then(({ body }) => {
       commit(MutationNames.SetSelectedPerson, body)
       commit(MutationNames.AddPersonToFoundList, body)

--- a/app/javascript/vue/tasks/uniquify/people/store/actions/findMatchPeople.js
+++ b/app/javascript/vue/tasks/uniquify/people/store/actions/findMatchPeople.js
@@ -5,7 +5,7 @@ export default ({ state, commit }, params) => {
   state.requestState.isLoading = true
   state.mergeList = []
 
-  People.where({ ...params, extend: ['roles'] })
+  People.where({ ...params, extend: ['roles', 'role_counts'] })
     .then((response) => {
       commit(
         MutationNames.SetMatchPeople,

--- a/app/javascript/vue/tasks/uniquify/people/store/actions/findPeople.js
+++ b/app/javascript/vue/tasks/uniquify/people/store/actions/findPeople.js
@@ -7,7 +7,7 @@ export default ({ state, commit }, params) => {
   state.matchPeople = []
   state.mergeList = []
 
-  People.where({ ...params, extend: ['roles'] })
+  People.where({ ...params, extend: ['role_counts'] })
     .then((response) => {
       commit(MutationNames.SetFoundPeople, response.body)
       state.URLRequest = response.request.responseURL

--- a/app/javascript/vue/tasks/uniquify/people/store/actions/processMerge.js
+++ b/app/javascript/vue/tasks/uniquify/people/store/actions/processMerge.js
@@ -12,7 +12,7 @@ export default ({ state, commit }) => {
 
     People.merge(selectedPerson.id, {
       person_to_destroy: mergePerson.id,
-      extend: ['roles']
+      extend: ['role_counts']
     })
       .then(({ body }) => {
         const personIndex = foundPeople.findIndex(
@@ -36,7 +36,7 @@ export default ({ state, commit }) => {
         if (mergeList.length) {
           processMerge(mergeList)
         } else {
-          People.find(selectedPerson.id, { extend: ['roles'] }).then(
+          People.find(selectedPerson.id, { extend: ['roles', 'role_counts'] }).then(
             ({ body }) => {
               commit(MutationNames.SetSelectedPerson, body)
               commit(MutationNames.SetFoundPeople, foundPeople)

--- a/app/javascript/vue/tasks/uniquify/people/utils/countUses.js
+++ b/app/javascript/vue/tasks/uniquify/people/utils/countUses.js
@@ -1,0 +1,11 @@
+export default ({ role_counts }) => {
+  let total = 0
+  if (role_counts === undefined) {
+    return total;
+  }
+  // loop through in_project, not_in_project, community
+  Object.values(role_counts).forEach(group => {
+    total += Object.values(group).reduce((a, b) => a + b, 0);
+  });
+  return total
+}

--- a/app/javascript/vue/tasks/uniquify/people/utils/getRoleNames.js
+++ b/app/javascript/vue/tasks/uniquify/people/utils/getRoleNames.js
@@ -1,0 +1,2 @@
+export default ({ role_counts }) =>
+  [...new Set(Object.values(role_counts || {}).map((v) => Object.keys(v)).flat())].join(', ') || '?'

--- a/app/javascript/vue/tasks/uniquify/people/utils/getRoles.js
+++ b/app/javascript/vue/tasks/uniquify/people/utils/getRoles.js
@@ -1,2 +1,0 @@
-export default ({ roles }) =>
-  [...new Set(roles?.map(r => r.role_object_type))].join(', ') || '?'

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -433,6 +433,15 @@ class Person < ApplicationRecord
     collector_roles.any?
   end
 
+
+  def role_counts(project_id)
+    {
+      in_project: self.roles.where(project_id:).group(:type).count,
+      not_in_project: self.roles.where.not(project_id:).where.not(project_id: nil).group(:type).count,
+      community: self.roles.where(project_id: nil).group(:type).count
+    }
+  end
+
   # @param [String] name_string
   # @return [Array] of Hashes
   #   use citeproc to parse strings

--- a/app/views/people/_attributes.json.jbuilder
+++ b/app/views/people/_attributes.json.jbuilder
@@ -7,4 +7,6 @@ if extend_response_with('roles')
       json.partial! '/roles/attributes', role: role
     end
   end
+elsif extend_response_with('role_counts')
+  json.role_counts person.role_counts(sessions_current_project_id)
 end

--- a/app/views/people/_attributes.json.jbuilder
+++ b/app/views/people/_attributes.json.jbuilder
@@ -7,6 +7,7 @@ if extend_response_with('roles')
       json.partial! '/roles/attributes', role: role
     end
   end
-elsif extend_response_with('role_counts')
+end
+if extend_response_with('role_counts')
   json.role_counts person.role_counts(sessions_current_project_id)
 end

--- a/app/views/roles/_attributes.json.jbuilder
+++ b/app/views/roles/_attributes.json.jbuilder
@@ -2,7 +2,7 @@ json.extract! role, :id, :person_id, :role_object_id, :role_object_type, :type, 
 json.partial! '/shared/data/all/metadata', object: role, url_base: 'role'
 
 # Ugh, expensive, add a virtual attribute with coalesce etc.
-json.in_project Role.exists?(project_id: sessions_current_project_id, id: role.id)
+json.in_project role.project_id == sessions_current_project_id ? true : false
 
 if extend_response_with('role_object')
   json.role_object do


### PR DESCRIPTION
The new `role_counts` extension for `/people/:id.json` returns information about the number of roles a Person has, grouped by type (Collector, Determiner, etc) and split by in-project usage, non-project usage, and community uses.

Sample:
```
{
  "in_project": {
    "Collector": 6
  },
  "not_in_project": {
    "Collector": 18
    "Determiner": 3
  },
  "community": {}
}
```

With this data, the Uniquify People task can be optimized, by querying for number of roles instead of getting all roles for a Person and counting them.

The only place where the actual role ids are needed is in `RoleDescription`, which renders the list of roles (for a specific type). 

Getting the list of role ids can be performed by `addSelectPerson`, which means we can move it out of `findPeople`. As a result, executing the "Selected people" action is significantly faster. 

I think it's safe to remove `roles` from the first part of `processMerge()`, since those people are being deleted anyways, and the "selected person" has its attributes re-fetched once the merge is complete.

Ideally, we could postpone the fetch for role ids until the user marks the person as "to be merged" with the checkbox in the `Match People` section, but I don't know enough about Vue to make that happen. Instead, I've left the behavior as-is (fetching roles for all matched people).

In places where the Person objects are extended with `roles`, it's faster to use `role_counts` to get role names, particularly when there are many roles (1k+).

After Gitter discussion, I also removed explicit database `exists?` query when checking if role is in project, which should make the remaining role queries much faster.