### PR TITLE
Allow Uniquify autocomplete to select (unselected) people in match list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 - DwC Checklist importer: empty `scientificNameAuthorship` field would cause row to error [#3660]
 - DwC Checklist importer: subsequent combinations with synonym status whose parents are synonyms would cause row to error
 - Could not set Repository Index Herbariorum flag in interface
+- Uniquify People: autocomplete would not select people for merging if already present in Match people table
 
 ### Changed
 

--- a/app/javascript/vue/tasks/uniquify/people/store/actions/addMatchPerson.js
+++ b/app/javascript/vue/tasks/uniquify/people/store/actions/addMatchPerson.js
@@ -1,11 +1,18 @@
 import { People } from '@/routes/endpoints'
 
 export default ({ state }, person) => {
-  const isAlreadyInList =
-    state.matchPeople.find((p) => p.id === person.id) ||
-    state.selectedPerson.id === person.id
+  if (state.selectedPerson.id === person.id) {
+    return;
+  }
 
-  if (!isAlreadyInList) {
+  const matchedPerson = state.matchPeople.find((p) => p.id === person.id)
+
+  if (matchedPerson) {
+    const personInMergeList = state.mergeList.includes((p) => p.id === person.id)
+    if (!personInMergeList) {
+      state.mergeList.push(matchedPerson)
+    }
+  } else {
     person.cached = person.label
     state.requestState.isLoading = true
     People.find(person.id, { extend: ['roles', 'role_counts'] })


### PR DESCRIPTION
Fixes a bug that prevented you from using the autocomplete to select a person that was already present in the Match people list.