### PR TITLE
Handle parentheses in authorship matching

### DIFF
--- a/spec/files/import_datasets/occurrences/authorship_missing_subgenus.tsv
+++ b/spec/files/import_datasets/occurrences/authorship_missing_subgenus.tsv
@@ -1,0 +1,2 @@
+occurrenceID	scientificName	scientificNameAuthorship	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Camponotus maculatus	(Fabricius, 1782)	species	Camponotus	maculatus		Tanaemyrmex			Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen

--- a/spec/files/import_datasets/occurrences/homonym_name.tsv
+++ b/spec/files/import_datasets/occurrences/homonym_name.tsv
@@ -1,0 +1,3 @@
+occurrenceID	scientificName	scientificNameAuthorship	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+ebf21354-02a6-497a-896f-1f2b3a6fb0e1	Carebara arnoldi	(Forel, 1913)	species	Camponotus	maculatus				Myrmicinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	syntype of Oligomyrmex arnoldi
+ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Tetraponera insularis	Ward 2022	species	Tetraponera	insularis				Pseudomyrmecinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen

--- a/spec/files/import_datasets/occurrences/homonym_same_author.tsv
+++ b/spec/files/import_datasets/occurrences/homonym_same_author.tsv
@@ -1,0 +1,3 @@
+occurrenceID	scientificName	scientificNameAuthorship	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Pseudomyrmex unicolor	(Smith, 1855)	species	Pseudomyrmex	unicolor				Pseudomyrmecinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	syntype of Pseudomyrma mutilloides
+ebf21354-02a6-497a-896f-1f2b3a6fb0e3	Pseudomyrmex unicolor	(Smith, 1856)	species	Pseudomyrmex	unicolor				Pseudomyrmecinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen

--- a/spec/files/import_datasets/occurrences/missing_subgenus.tsv
+++ b/spec/files/import_datasets/occurrences/missing_subgenus.tsv
@@ -1,0 +1,2 @@
+occurrenceID	scientificName	scientificNameAuthorship	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Camponotus vestitus bombycinus	Santschi, 1930	subspecies	Camponotus	vestitus	bombycinus			Formicinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen

--- a/spec/files/import_datasets/occurrences/missing_subgenus.tsv
+++ b/spec/files/import_datasets/occurrences/missing_subgenus.tsv
@@ -1,2 +1,3 @@
 occurrenceID	scientificName	scientificNameAuthorship	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
 ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Camponotus vestitus bombycinus	Santschi, 1930	subspecies	Camponotus	vestitus	bombycinus			Formicinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen
+ebf21354-02a6-497a-896f-1f2b3a6fb0e3	Camponotus cruentatus	(Latreille, 1802)	species	Camponotus	cruentatus				Formicinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen

--- a/spec/models/dataset_record/darwin_core/occurrence_spec.rb
+++ b/spec/models/dataset_record/darwin_core/occurrence_spec.rb
@@ -1047,6 +1047,8 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
 
       genus_formica = Protonym.create!(parent: subfamily, name: 'Formica', rank_class: Ranks.lookup(:iczn, :genus),
                                        verbatim_author: 'Linnaeus', year_of_publication: 1758)
+      genus_formica.taxon_name_classifications.create!(type: 'TaxonNameClassification::Latinized::Gender::Feminine')
+
 
       subgenus = Protonym.create!(parent: genus, name: 'Myrmosericus', rank_class: Ranks.lookup(:iczn, :subgenus),
                                   verbatim_author: 'Forel', year_of_publication: 1912)
@@ -1057,19 +1059,23 @@ describe 'DatasetRecord::DarwinCore::Occurrence', type: :model do
       @subspecies = Protonym.create!(parent: species, name: 'bombycinus', rank_class: Ranks.lookup(:iczn, :subspecies),
                                   verbatim_author: 'Santschi', year_of_publication: 1930, also_create_otu: true)
 
-      
       make_original_combination_from_current!(genus)
       make_original_combination_from_current!(subgenus)
       create_original_combination!(species, { genus: genus_formica, species: species})
       make_original_combination_from_current!(@subspecies)
+
+      s_cruentatus = Protonym.create!(parent: subgenus, name: 'cruentata', rank_class: Ranks.lookup(:iczn, :species),
+                                     verbatim_author: '(Latreille)', year_of_publication: 1802, also_create_otu: true)
+      s_cruentatus.taxon_name_classifications.create!(type: 'TaxonNameClassification::Latinized::PartOfSpeech::Adjective')
+      create_original_combination!(s_cruentatus, {genus: genus_formica, species: s_cruentatus})
 
       @imported = @import_dataset.import(5000, 100)
     end
 
     let!(:results) { @imported }
 
-    it 'should import the record without failing' do
-      expect(results.length).to eq(1)
+    it 'should import the 2 records without failing' do
+      expect(results.length).to eq(2)
       expect(results.map { |row| row.status }).to all(eq('Imported'))
     end
   end


### PR DESCRIPTION
`cached_author` doesn't have parentheses, so they must be stripped from verbatim field before searching.
