### PR TITLE
Handle missing originalNameUsageID in checklist import

### DIFF
--- a/app/models/dataset_record/darwin_core/taxon.rb
+++ b/app/models/dataset_record/darwin_core/taxon.rb
@@ -158,7 +158,9 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
           end
 
           # make OC relationships to OC ancestors
-          unless metadata['parent'].nil? # can't make original combination with Root or if matching pre-existing taxon name
+          # can't make original combination with Root or if matching pre-existing taxon name
+          # Do not make original combination if we assumed the value.
+          if metadata['parent'].present? && (metadata.fetch('create_original_combination', true) == true)
 
             # loop through parents of original combination based on parentNameUsageID, not TW parent
             # this way we get the name as intended, not with any valid/current names
@@ -209,35 +211,40 @@ class DatasetRecord::DarwinCore::Taxon < DatasetRecord::DarwinCore
             end
           end
 
-          # when creating the OC record pointing to self,
-          # can't assume OC rank is same as valid rank, need to look at OC row to find real rank
-          # This is easier for the end-user than adding OC to protonym when importing the OC row,
-          # but might be more complex to code
+          # don't create OC relationship with self if OC was assumed, default to true for any datasets
+          # created before this feature existed (since creating OC was always expected then)
+          if metadata.fetch('create_original_combination', true)
 
-          # get OC dataset_record_id so we can pull the taxonRank from it.
-          oc_dataset_record_id = import_dataset.core_records_fields
-                                               .at(get_field_mapping(:taxonID))
-                                               .with_value(get_field_value(:originalNameUsageID))
-                                               .pick(:dataset_record_id)
+            # when creating the OC record pointing to self,
+            # can't assume OC rank is same as valid rank, need to look at OC row to find real rank
+            # This is easier for the end-user than adding OC to protonym when importing the OC row,
+            # but might be more complex to code
 
-          oc_protonym_rank = import_dataset.core_records_fields
-                                           .where(dataset_record_id: oc_dataset_record_id)
-                                           .at(get_field_mapping(:taxonRank))
-                                           .pick(:value)
-                                           .downcase.to_sym
+            # get OC dataset_record_id so we can pull the taxonRank from it.
+            oc_dataset_record_id = import_dataset.core_records_fields
+                                                 .at(get_field_mapping(:taxonID))
+                                                 .with_value(get_field_value(:originalNameUsageID))
+                                                 .pick(:dataset_record_id)
 
-          if ORIGINAL_COMBINATION_RANKS.has_key?(oc_protonym_rank)
-            TaxonNameRelationship.create_with(subject_taxon_name: taxon_name).find_or_create_by!(
-              type: ORIGINAL_COMBINATION_RANKS[oc_protonym_rank],
-              object_taxon_name: taxon_name)
+            oc_protonym_rank = import_dataset.core_records_fields
+                                             .where(dataset_record_id: oc_dataset_record_id)
+                                             .at(get_field_mapping(:taxonRank))
+                                             .pick(:value)
+                                             .downcase.to_sym
 
-            # detect if current name rank is genus and original combination is with self at subgenus level, eg Aus (Aus)
-            # if so, generate OC relationship with genus (since oc_protonym_rank will be subgenus)
-            if oc_protonym_rank == :subgenus && get_field_value('taxonRank').downcase == "genus" &&
-              (get_original_combination&.metadata['parent'] == get_field_value('taxonID'))
+            if ORIGINAL_COMBINATION_RANKS.has_key?(oc_protonym_rank)
               TaxonNameRelationship.create_with(subject_taxon_name: taxon_name).find_or_create_by!(
-                type: ORIGINAL_COMBINATION_RANKS[:genus],
+                type: ORIGINAL_COMBINATION_RANKS[oc_protonym_rank],
                 object_taxon_name: taxon_name)
+
+              # detect if current name rank is genus and original combination is with self at subgenus level, eg Aus (Aus)
+              # if so, generate OC relationship with genus (since oc_protonym_rank will be subgenus)
+              if oc_protonym_rank == :subgenus && get_field_value('taxonRank').downcase == "genus" &&
+                (get_original_combination&.metadata['parent'] == get_field_value('taxonID'))
+                TaxonNameRelationship.create_with(subject_taxon_name: taxon_name).find_or_create_by!(
+                  type: ORIGINAL_COMBINATION_RANKS[:genus],
+                  object_taxon_name: taxon_name)
+              end
             end
           end
 

--- a/app/models/import_dataset/darwin_core/checklist.rb
+++ b/app/models/import_dataset/darwin_core/checklist.rb
@@ -56,6 +56,7 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
         is_synonym: nil,
         has_external_accepted_name: nil, # could be homonym or synonym, either way protonym is not valid. will use taxonomicStatus to determine the kind of relationship
         original_combination: nil, # taxonID of original combination
+        create_original_combination: true,    # default to creating an original combination, is set to false if missing
         protonym_taxon_id: nil,
         parent: record['parentNameUsageID'],
         src_data: record
@@ -84,7 +85,8 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
       # TODO handle when originalNameUsageID is not present
 
       if record[:src_data]['originalNameUsageID'].blank?
-        add_error_message(record, :originalNameUsageID, 'originalNameUsageID must not be blank')
+        record[:src_data]['originalNameUsageID'] = record[:src_data]['taxonID']
+        record[:create_original_combination] = false # we assumed, don't make the relationship during import
       end
 
       if records_lut[record[:src_data]['originalNameUsageID']].nil?

--- a/spec/files/import_datasets/checklists/missing_original_name.tsv
+++ b/spec/files/import_datasets/checklists/missing_original_name.tsv
@@ -1,0 +1,3 @@
+taxonID	parentNameUsageID	acceptedNameUsageID	scientificName	kingdom	class	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsageID	namePublishedInYear	nomenclaturalCode
+429011		429011	Formicidae	Animalia	Insecta	Hymenoptera	Formicidae					Family	Latreille, 1809	valid		1809	ICZN
+429012	429011	429012	Calyptites	Animalia	Insecta	Hymenoptera	Formicidae					Genus	Scudder, 1877	valid	429012	1877	ICZN

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -1254,7 +1254,30 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
       expect_relationship(original_genus, valid_protonym, 'TaxonNameRelationship::OriginalCombination::OriginalGenus')
     end
   end
-  
+
+  context 'when importing a taxon without originalNameUsageID' do
+    before(:all) do
+      import_checklist_tsv('missing_original_name.tsv', 4)
+
+      TaxonName.find_each {|t| t.send(:set_cached)}
+
+    end
+    after(:all) { DatabaseCleaner.clean }
+
+    it 'should import the 2 rows' do
+      verify_all_records_imported(2)
+    end
+
+    it 'should not create an original combination if missing originalNameUsageID' do
+      expect(Protonym.find_by(name: 'Formicidae').cached_original_combination).to be_nil
+    end
+
+    it 'should create an original combination when originalNameUsageID is present' do
+      expect(Protonym.find_by(name: 'Calyptites').cached_original_combination).to eq 'Calyptites'
+    end
+
+  end
+
   # TODO test protonym is unavailable --- set classification on unsaved TaxonName
   #
   # TODO test importing multiple times


### PR DESCRIPTION
Resolves #3680

Protonyms without `originalNameUsageID` will not have an original combination created. Subsequent combinations may not work without it, as `originalNameUsageID` is used to determine the protonym for combinations.


**TODO**: 
- [x]  add tests