### PR TITLE
Mark staged rows with errors as Failed

### DIFF
--- a/app/models/import_dataset/darwin_core/checklist.rb
+++ b/app/models/import_dataset/darwin_core/checklist.rb
@@ -262,7 +262,11 @@ class ImportDataset::DarwinCore::Checklist < ImportDataset::DarwinCore
     core_records.each do |record|
       dwc_taxon = DatasetRecord::DarwinCore::Taxon.new(import_dataset: self)
       dwc_taxon.initialize_data_fields(record[:src_data].map { |_, v| v })
-      dwc_taxon.status = !record[:error_data] && record[:dependencies] == [] && record[:parent].nil? ? 'Ready' : 'NotReady'
+      if record[:error_data]
+        dwc_taxon.status = 'Failed'
+      else
+        dwc_taxon.status = record[:dependencies] == [] && record[:parent].nil? ? 'Ready' : 'NotReady'
+      end
       record.delete(:src_data)
       dwc_taxon.metadata = record
 

--- a/spec/files/import_datasets/checklists/error_tests/invalid_parent_id.tsv
+++ b/spec/files/import_datasets/checklists/error_tests/invalid_parent_id.tsv
@@ -1,0 +1,2 @@
+taxonID	parentNameUsageID	parentNameUsage	acceptedNameUsageID	acceptedNameUsage	scientificName	kingdom	class	order	family	genus	subgenus	specificEpithet	infraspecificEpithet	taxonRank	scientificNameAuthorship	taxonomicStatus	originalNameUsage	originalNameUsageID	namePublishedInYear	nomenclaturalCode
+429011	0		429011	Formicidae Latreille, 1809	Formicidae	Animalia	Insecta	Hymenoptera	Formicidae					Family	Latreille, 1809	valid		429011	1809	ICZN

--- a/spec/models/dataset_record/darwin_core/taxon_spec.rb
+++ b/spec/models/dataset_record/darwin_core/taxon_spec.rb
@@ -1238,6 +1238,21 @@ describe 'DatasetRecord::DarwinCore::Taxon', type: :model do
 
   end
 
+  context 'when staging a record with invalid parentNameUsageID' do
+    before(:all) { import_checklist_tsv('error_tests/invalid_parent_id.tsv', 1) }
+    after(:all) { DatabaseCleaner.clean }
+
+    let(:record) {DatasetRecord.first}
+
+    it 'the row should be marked as Failed' do
+      expect(record.status).to eq('Failed')
+    end
+
+    it 'the row should have the correct error message' do
+      expect(record[:metadata].dig('error_data', 'messages', 'parentNameUsageID')).to include 'parentNameUsageID not found in dataset'
+    end
+  end
+
   # TODO test missing parent
   #
   # TODO test protonym is unavailable --- set classification on unsaved TaxonName


### PR DESCRIPTION
Errors that occur during staging are  because we don't support re-staging, so we should mark them as `Failed` instead of `NotReady`
