### PR TITLE
Parse authorship in typeStatus field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 
 ## [unreleased]
 
-\-
+### Changed
+
+- DwC Occurrence Importer: Parse authorship information in typeStatus field
 
 ## [0.37.0] - 2023-12-14
 

--- a/spec/files/import_datasets/occurrences/type_material_authorship.tsv
+++ b/spec/files/import_datasets/occurrences/type_material_authorship.tsv
@@ -1,0 +1,3 @@
+occurrenceID	scientificName	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+ebf21354-02a6-497a-896f-1f2b3a6fb0e2	Bothroponera cambouei	species	Bothroponera	cambouei				Ponerinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	Lectotype of Bothroponera cambouei
+7d228469-b66b-4bef-b3a5-65d3e2bc4b50	Euponera agnivo	species	Euponera	agnivo				Ponerinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	Holotype of Pachycondyla agnivo

--- a/spec/files/import_datasets/occurrences/type_material_authorship_homonym.tsv
+++ b/spec/files/import_datasets/occurrences/type_material_authorship_homonym.tsv
@@ -1,0 +1,2 @@
+occurrenceID	scientificName	taxonRank	genus	specificEpithet	infraspecificEpithet	subgenus	speciesgroup	subfamily	family	order	class	phylum	kingdom	basisOfRecord	typeStatus
+7d228469-b66b-4bef-b3a5-65d3e2bc4b50	Pseudomyrmex triplaridis	species	Pseudomyrmex	triplaridis				Pseudomyrmecinae	Formicidae	Hymenoptera	Insecta	Arthropoda	Animalia	PreservedSpecimen	syntype of Pseudomyrma triplaridis boxi Wheeler, 1942


### PR DESCRIPTION
Parsing authorship makes it easier to manually set the protonym for type materials, as well as resolving homonym situations.