### PR TITLE
Make DwC export use  "First Prefix Last Suffix" order for names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 ### Changed
 
 - DwC Occurrence Importer: Parse authorship information in typeStatus field
+- DwC Exporter: `recordedBy` and `identifiedBy` fields use `First Prefix Last Suffix` order
 
 ### Fixed
 
@@ -24,7 +25,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 
 - DwC `verbatimLabel` support [#2749]
 - Preview option and results reports for filter based batch updates [#3690]
-- Freeform digtization, draw shapes to stub CollectionObjects [#3113]
+- Freeform digitization, draw shapes to stub CollectionObjects [#3113]
 - `superfamily`, `tribe` and `subtribe` DwC terms now supported in occurrences importer [#3705]
 
 ### Changed

--- a/app/models/collection_object/dwc_extensions.rb
+++ b/app/models/collection_object/dwc_extensions.rb
@@ -421,7 +421,7 @@ module CollectionObject::DwcExtensions
     if collecting_event
       v = collecting_event.collectors
         .order('roles.position')
-        .pluck(:cached)
+        .map(&:name)
         .join(CollectionObject::DWC_DELIMITER)
         .presence
       v = collecting_event.verbatim_collectors.presence if v.blank?
@@ -444,7 +444,7 @@ module CollectionObject::DwcExtensions
 
   def dwc_identified_by
     # TaxonWorks allows for groups of determiners to collaborate on a single determination if they collectively came to a conclusion.
-    current_taxon_determination&.determiners&.map(&:cached)&.join(CollectionObject::DWC_DELIMITER).presence
+    current_taxon_determination&.determiners&.map(&:name)&.join(CollectionObject::DWC_DELIMITER).presence
   end
 
   def dwc_identified_by_id

--- a/spec/models/collection_object/dwc_extensions_spec.rb
+++ b/spec/models/collection_object/dwc_extensions_spec.rb
@@ -71,7 +71,7 @@ describe CollectionObject::DwcExtensions, type: :model, group: [:collection_obje
   context '#dwc_occurrence' do
     let!(:ce) { CollectingEvent.create!(start_date_year: '2010') }
     let!(:s) { Specimen.create!(collecting_event: ce) }
-    let(:p) { Person.create!(last_name: 'Smith', first_name: 'Sue') }
+    let(:p) { Person.create!(last_name: 'Smith', first_name: 'Sue', suffix: 'Jr.') }
     let(:o) { Otu.create!(name: 'Barney') }
 
     let(:root) { Project.find(Current.project_id).send(:create_root_taxon_name) }
@@ -185,7 +185,7 @@ describe CollectionObject::DwcExtensions, type: :model, group: [:collection_obje
     specify '#dwc_identified_by' do
       TaxonDetermination.create!(biological_collection_object: s, otu: o, determiners: [p]) # Bad mix of object/attributes now: roles_attributes: [{person: p, type: 'Determiner'}]
       s.reload
-      expect(s.dwc_identified_by).to eq('Smith, Sue')
+      expect(s.dwc_identified_by).to eq('Sue Smith Jr.')
     end
 
     specify '#dwc_date_identified' do
@@ -431,12 +431,12 @@ describe CollectionObject::DwcExtensions, type: :model, group: [:collection_obje
         parent: root
       )
 
-      ce.update!(collectors_attributes: [{last_name: 'Doe', first_name: 'John'}])
+      ce.update!(collectors_attributes: [{last_name: 'Doe', first_name: 'John', prefix: 'von'}])
       TaxonDetermination.create!(biological_collection_object: s, otu: Otu.create!(taxon_name: p1), determiner_roles_attributes: [{person: p}] )
 
       s.reload
 
-      expect(s.dwc_recorded_by).to eq('Doe, John')
+      expect(s.dwc_recorded_by).to eq('John von Doe')
     end
 
     specify '#dwc_other_catalog_numbers' do


### PR DESCRIPTION
Affects `recordedBy` and `identifiedBy` fields.