### PR TITLE
Create CO index on current_repository_id

### DIFF
--- a/db/migrate/20231215011844_add_index_on_current_repository_id.rb
+++ b/db/migrate/20231215011844_add_index_on_current_repository_id.rb
@@ -1,0 +1,5 @@
+class AddIndexOnCurrentRepositoryId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :collection_objects, :current_repository_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_14_184428) do
+ActiveRecord::Schema.define(version: 2023_12_15_011844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -378,6 +378,7 @@ ActiveRecord::Schema.define(version: 2023_12_14_184428) do
     t.index ["collecting_event_id"], name: "index_collection_objects_on_collecting_event_id"
     t.index ["created_at"], name: "index_collection_objects_on_created_at"
     t.index ["created_by_id"], name: "index_collection_objects_on_created_by_id"
+    t.index ["current_repository_id"], name: "index_collection_objects_on_current_repository_id"
     t.index ["preparation_type_id"], name: "index_collection_objects_on_preparation_type_id"
     t.index ["project_id"], name: "index_collection_objects_on_project_id"
     t.index ["ranged_lot_category_id"], name: "index_collection_objects_on_ranged_lot_category_id"


### PR DESCRIPTION
Significantly speeds up repository search times. 

Each matching repository has a usage label that requires counting the number of COs with that`current_repository_id`. Consequently, search time scales with O(#of matching repositories * #of COs in project).