### PR TITLE
Don't show already selected people in Uniquify match autocomplete

### DIFF
--- a/app/javascript/vue/components/ui/Autocomplete.vue
+++ b/app/javascript/vue/components/ui/Autocomplete.vue
@@ -136,6 +136,11 @@ export default {
       default: undefined
     },
 
+    excludedIds: {
+      type: Array,
+      default: undefined
+    },
+
     min: {
       type: [String, Number],
       default: 1
@@ -341,6 +346,9 @@ export default {
         })
           .then(({ body }) => {
             this.json = this.getNested(body, this.nested)
+            if (this.excludedIds) {
+              this.json = this.json.filter((item) => !this.excludedIds.includes(item.id))
+            }
             this.showList = this.json.length > 0
             this.searchEnd = true
             this.$emit('found', this.showList)

--- a/app/javascript/vue/tasks/uniquify/people/components/MatchPeople.vue
+++ b/app/javascript/vue/tasks/uniquify/people/components/MatchPeople.vue
@@ -8,6 +8,7 @@
         param="term"
         label="label_html"
         placeholder="Search a person..."
+        :excluded-ids="involvedIds"
         clear-after
         @get-item="addToList"
       />
@@ -119,6 +120,17 @@ export default {
           ? this.matchList.filter((item) => item.id !== this.selectedPerson.id)
           : []
       }
+    },
+
+    // IDs to hide in autocomplete, since they're already selected
+    involvedIds() {
+      const selectedIds = this.mergeList.map((p) => p.id)
+      if (this.selectedPerson?.id) selectedIds.push(this.selectedPerson.id)
+      return selectedIds
+    },
+
+    mergeList() {
+      return this.$store.getters[GetterNames.GetMergePeople]
     }
   },
 


### PR DESCRIPTION
This is a small QoL improvement that prevents people you've already selected for merging from appearing in the autocomplete dropdown. 

If you clicked on one of the people already selected for merging, nothing would change since they were already in the list.
Hiding these people prevents that from happening.


Before            | After
:------------:|:-------------------------:
<img width="549" alt="image" src="https://github.com/SpeciesFileGroup/taxonworks/assets/33206210/3162187f-bf48-4c2d-a355-85429cb5a346">  |  <img width="551" alt="image" src="https://github.com/SpeciesFileGroup/taxonworks/assets/33206210/eaa4d73e-0cc2-4489-a9f3-f68fd72b8ca4">


However, it also changes the `Autocomplete` component to receive a list of ids to hide from the results list. This feature isn't very important, so it's ok to close the PR if you don't want to make that change to the component.