### PR TITLE
Show radials for selected person in Uniquify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 ### Fixed
 
 - Update DwcOccurence index endpoint
+- Uniquify people: Always show radials for selected person
 
 ## [0.37.0] - 2023-12-14
 

--- a/app/javascript/vue/tasks/uniquify/people/components/CompareTable.vue
+++ b/app/javascript/vue/tasks/uniquify/people/components/CompareTable.vue
@@ -52,7 +52,7 @@
               >
                 {{ selected.cached }}
               </a>
-              <template v-if="selectedMergePerson.global_id">
+              <template v-if="selected.global_id">
                 <RadialAnnotator :global-id="selected.global_id" />
                 <RadialNavigation
                   :global-id="selected.global_id"


### PR DESCRIPTION
The navigation and annotation radials for the `Selected person` were hidden until at least one `Person to merge` was selected.

Before            |  Fixed
:-------------------------:|:-------------------------:
<img width="712" alt="image" src="https://github.com/SpeciesFileGroup/taxonworks/assets/33206210/4655e9ad-b4ef-4a0f-811a-65185a140df9">  |  <img width="710" alt="image" src="https://github.com/SpeciesFileGroup/taxonworks/assets/33206210/8ba8506d-5c30-4030-a01f-1360e6de77a1">
<img width="710" alt="image" src="https://github.com/SpeciesFileGroup/taxonworks/assets/33206210/959643f2-3765-42f1-8634-b69369db9ed3"> | <img width="707" alt="image" src="https://github.com/SpeciesFileGroup/taxonworks/assets/33206210/9b69cfc5-ef48-49c6-926a-9dfcda913d82">



