### PR TITLE
Add "Append collectors" slice to CE batch update radial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 - `epithet_only` parameter and facet to taxon name filter [#3589]
 - Links for users profiles on project members list (only for administrators)
 - Cursor and text to reveal project preference predicates can be reordered [#3736]
+- Batch append collectors to Collecting Events within CE filter
 
 ### Changed
 

--- a/app/javascript/vue/components/radials/ce/components/CollectorSlice.vue
+++ b/app/javascript/vue/components/radials/ce/components/CollectorSlice.vue
@@ -122,8 +122,8 @@ const payload = computed(() => ({
 
 function updateMessage(data) {
   const message = data.sync
-    ? `${data.updated.length} collection objects queued for updating.`
-    : `${data.updated.length} collection objects were successfully updated.`
+    ? `${data.updated.length} collecting events queued for updating.`
+    : `${data.updated.length} collecting events were successfully updated.`
 
   TW.workbench.alert.create(message, 'notice')
 }

--- a/app/javascript/vue/components/radials/ce/radial.vue
+++ b/app/javascript/vue/components/radials/ce/radial.vue
@@ -59,13 +59,15 @@ import VModal from '@/components/ui/Modal.vue'
 import VIcon from '@/components/ui/VIcon/index.vue'
 import VBtn from '@/components/ui/VBtn/index.vue'
 import AssignSlice from './components/AssignSlice.vue'
+import CollectorSlice from './components/CollectorSlice.vue'
 
 import { computed, ref } from 'vue'
 import { removeEmptyProperties } from '@/helpers/objects.js'
 
 const EXCLUDE_PARAMETERS = ['per', 'page', 'extend']
 const SLICES = {
-  'Assign/Move': AssignSlice
+  'Assign/Move': AssignSlice,
+  'Append New Collectors' : CollectorSlice
 }
 
 const props = defineProps({


### PR DESCRIPTION
Related to #3735, this is the "barebones" way to assign collectors to multiple CEs at once. 

It appends collectors to the end of the existing list. If you try to add a collector that is already present in a CE, the row will error no collectors will be added to that CE.

Order of names in the role picker input is respected.