### PR TITLE
Refactor TW extensions in DwC export to support plucking direct from tables

### DIFF
--- a/app/controllers/tasks/dwc/dashboard_controller.rb
+++ b/app/controllers/tasks/dwc/dashboard_controller.rb
@@ -60,7 +60,7 @@ class Tasks::Dwc::DashboardController < ApplicationController
   end
 
   def taxonworks_extension_methods
-    render json: ::CollectionObject::DwcExtensions::TaxonworksExtensions::EXTENSION_FIELDS_MAP.keys, status: :ok
+    render json: ::CollectionObject::DwcExtensions::TaxonworksExtensions::EXTENSION_FIELDS, status: :ok
   end
 
   private

--- a/app/models/collection_object/dwc_extensions/taxonworks_extensions.rb
+++ b/app/models/collection_object/dwc_extensions/taxonworks_extensions.rb
@@ -3,13 +3,16 @@ module CollectionObject::DwcExtensions::TaxonworksExtensions
   extend ActiveSupport::Concern
 
   included do
-    EXTENSION_FIELDS_MAP = {
-      otu_name: :otu_name,  # delegated to OTU through BiologicalExtensions
-      elevation_precision: :extension_elevation_precision,
-    }.freeze
-  end
+    EXTENSION_CO_FIELDS = [].freeze
 
-  def extension_elevation_precision
-    collecting_event&.elevation_precision
+    EXTENSION_CE_FIELDS = [
+      :elevation_precision
+    ].freeze
+
+    EXTENSION_COMPUTED_FIELDS = {
+      otu_name: :otu_name,  # delegated to OTU through BiologicalExtensions
+    }.freeze
+
+    EXTENSION_FIELDS = (EXTENSION_CO_FIELDS + EXTENSION_CE_FIELDS + EXTENSION_COMPUTED_FIELDS.keys).freeze
   end
 end

--- a/app/models/collection_object/dwc_extensions/taxonworks_extensions.rb
+++ b/app/models/collection_object/dwc_extensions/taxonworks_extensions.rb
@@ -4,7 +4,12 @@ module CollectionObject::DwcExtensions::TaxonworksExtensions
 
   included do
     EXTENSION_FIELDS_MAP = {
-      otu_name: :otu_name   # delegated to OTU through BiologicalExtensions
+      otu_name: :otu_name,  # delegated to OTU through BiologicalExtensions
+      elevation_precision: :extension_elevation_precision,
     }.freeze
+  end
+
+  def extension_elevation_precision
+    collecting_event&.elevation_precision
   end
 end

--- a/app/models/collection_object/dwc_extensions/taxonworks_extensions.rb
+++ b/app/models/collection_object/dwc_extensions/taxonworks_extensions.rb
@@ -3,16 +3,20 @@ module CollectionObject::DwcExtensions::TaxonworksExtensions
   extend ActiveSupport::Concern
 
   included do
-    EXTENSION_CO_FIELDS = [].freeze
+    # hash of api_method_name => column_name
+    EXTENSION_CO_FIELDS = {
+      collection_object_id: :id
+    }.freeze
 
-    EXTENSION_CE_FIELDS = [
-      :elevation_precision
-    ].freeze
+    EXTENSION_CE_FIELDS = {
+      collecting_event_id: :id,
+      elevation_precision: :elevation_precision
+    }.freeze
 
     EXTENSION_COMPUTED_FIELDS = {
       otu_name: :otu_name,  # delegated to OTU through BiologicalExtensions
     }.freeze
 
-    EXTENSION_FIELDS = (EXTENSION_CO_FIELDS + EXTENSION_CE_FIELDS + EXTENSION_COMPUTED_FIELDS.keys).freeze
+    EXTENSION_FIELDS = (EXTENSION_CO_FIELDS.keys + EXTENSION_CE_FIELDS.keys + EXTENSION_COMPUTED_FIELDS.keys).freeze
   end
 end

--- a/lib/export/dwca/data.rb
+++ b/lib/export/dwca/data.rb
@@ -148,24 +148,27 @@ module Export::Dwca
       collection_object_ids = core_scope.select(:dwc_occurrence_object_id).pluck(:dwc_occurrence_object_id)
       collection_objects = CollectionObject.joins(:dwc_occurrence).where(id: core_scope.select(:dwc_occurrence_object_id))
 
+      # hash of internal method name => csv header name
       methods = {}
+
+      # hash of column_name => csv header name
       ce_fields = {}
       co_fields = {}
 
       # select valid methods, generate frozen name string ahead of time
       # add TW prefix to names
       @taxonworks_extension_methods.each do |sym|
-        name = ('TW:Internal:' + sym.name).freeze
+        csv_header_name = ('TW:Internal:' + sym.name).freeze
         if (method = ::CollectionObject::EXTENSION_COMPUTED_FIELDS[sym])
-          methods[method] = name
-        elsif ::CollectionObject::EXTENSION_CE_FIELDS.include?(sym)
-          ce_fields[sym] = name
-        elsif ::CollectionObject::EXTENSION_CO_FIELDS.include?(sym)
-          co_fields[sym] = name
+          methods[method] = csv_header_name
+        elsif (column_name = ::CollectionObject::EXTENSION_CE_FIELDS[sym])
+          ce_fields[column_name] = csv_header_name
+        elsif (column_name =::CollectionObject::EXTENSION_CO_FIELDS[sym])
+          co_fields[column_name] = csv_header_name
         end
       end
 
-      used_extensions = methods.values + ce_fields.keys + co_fields.keys
+      used_extensions = methods.values + ce_fields.values + co_fields.values
 
       # if no predicate data found, return empty file
       if used_extensions.empty?

--- a/lib/export/dwca/data.rb
+++ b/lib/export/dwca/data.rb
@@ -112,7 +112,7 @@ module Export::Dwca
         core_scope.computed_columns,
         # TODO: check to see if we nee dthis
         exclude_columns: ::DwcOccurrence.excluded_columns,
-        column_order: ::CollectionObject::DWC_OCCURRENCE_MAP.keys + ::CollectionObject::EXTENSION_FIELDS_MAP.keys, # TODO: add other maps here
+        column_order: ::CollectionObject::DWC_OCCURRENCE_MAP.keys + ::CollectionObject::EXTENSION_FIELDS, # TODO: add other maps here
         trim_columns: true, # going to have to be optional
         trim_rows: false,
         header_converters: [:dwc_headers]
@@ -148,15 +148,24 @@ module Export::Dwca
       collection_object_ids = core_scope.select(:dwc_occurrence_object_id).pluck(:dwc_occurrence_object_id)
       collection_objects = CollectionObject.joins(:dwc_occurrence).where(id: core_scope.select(:dwc_occurrence_object_id))
 
+      methods = {}
+      ce_fields = {}
+      co_fields = {}
+
       # select valid methods, generate frozen name string ahead of time
       # add TW prefix to names
-      methods = @taxonworks_extension_methods.filter_map { |sym|
-        if (method = ::CollectionObject::EXTENSION_FIELDS_MAP[sym])
-          [('TW:Internal:' + sym.name).freeze, method]
+      @taxonworks_extension_methods.each do |sym|
+        name = ('TW:Internal:' + sym.name).freeze
+        if (method = ::CollectionObject::EXTENSION_COMPUTED_FIELDS[sym])
+          methods[method] = name
+        elsif ::CollectionObject::EXTENSION_CE_FIELDS.include?(sym)
+          ce_fields[sym] = name
+        elsif ::CollectionObject::EXTENSION_CO_FIELDS.include?(sym)
+          co_fields[sym] = name
         end
-      }.to_h
+      end
 
-      used_extensions = methods.keys
+      used_extensions = methods.values + ce_fields.keys + co_fields.keys
 
       # if no predicate data found, return empty file
       if used_extensions.empty?
@@ -167,8 +176,23 @@ module Export::Dwca
       extension_data = []
 
       collection_objects.find_each do |object|
-        methods.each_pair { |name, method| extension_data << [object.id, name, object.send(method)] }
+        methods.each_pair { |method, name| extension_data << [object.id, name, object.send(method)] }
       end
+
+      # extract to ensure consistent order
+      co_columns = co_fields.keys
+      co_csv_names = co_columns.map { |sym| co_fields[sym] }
+      co_column_count = co_columns.size
+      # get all CO fields in one query, then split into triplets of [id, CSV column name, value]
+      extension_data += collection_objects.pluck(:id, *co_columns)
+                                          .flat_map { |id, *values| ([id] * co_column_count).zip(co_csv_names, values) }
+
+      ce_columns = ce_fields.keys
+      ce_csv_names = ce_columns.map { |sym| ce_fields[sym] }
+      ce_column_count = ce_columns.size
+      extension_data += collection_objects.joins(:collecting_event) # no point using left outer join, no event means all data is nil
+                                          .pluck(:id, *ce_columns)
+                                          .flat_map { |id, *values| ([id] * ce_column_count).zip(ce_csv_names, values) }
 
       # Create hash with key: co_id, value: [[extension_name, extension_value], ...]
       # prefill with empty values so we have the same number of rows as the main csv, even if some rows don't have

--- a/spec/lib/export/dwca/data_spec.rb
+++ b/spec/lib/export/dwca/data_spec.rb
@@ -106,6 +106,25 @@ describe Export::Dwca::Data, type: :model, group: :darwin_core do
           end
         end
 
+        context 'exporting elevation_precision' do
+          let(:d) { Export::Dwca::Data.new(core_scope: scope, taxonworks_extensions: [:elevation_precision]) }
+          let(:ce) { FactoryBot.create(:valid_collecting_event, minimum_elevation: 100, elevation_precision: '10 m') }
+
+          before do
+            co = CollectionObject.last
+            co.collecting_event_id = ce.id
+            co.save!
+          end
+
+          specify 'should have the elevation precision in the correct extension file row' do
+            expect(File.readlines(d.taxonworks_extension_data).last&.strip).to eq(ce.elevation_precision)
+          end
+
+          specify 'should have the elevation precision in the combined file' do
+            expect(File.readlines(d.all_data).last).to include(ce.elevation_precision)
+          end
+        end
+
         context 'when no extensions are selected' do
           let(:empty_extension) { Export::Dwca::Data.new(core_scope: scope, taxonworks_extensions: []) }
 

--- a/spec/lib/export/dwca/data_spec.rb
+++ b/spec/lib/export/dwca/data_spec.rb
@@ -106,6 +106,23 @@ describe Export::Dwca::Data, type: :model, group: :darwin_core do
           end
         end
 
+        context 'exporting header with different api column name' do
+          let(:d) { Export::Dwca::Data.new(core_scope: scope, taxonworks_extensions: [:collection_object_id]) }
+
+          specify 'should have the correct headers' do
+            headers = %w[basisOfRecord individualCount occurrenceID occurrenceStatus TW:Internal:collection_object_id]
+            expect(d.meta_fields).to contain_exactly(*headers)
+          end
+
+          specify 'should have the collection_object_id in the correct extension file row' do
+            expect(File.readlines(d.taxonworks_extension_data).last&.strip).to eq(CollectionObject.last.id.to_s)
+          end
+
+          specify 'should have the collection_object_id in the combined file' do
+            expect(File.readlines(d.all_data).last).to include(CollectionObject.last.id.to_s)
+          end
+        end
+
         context 'exporting elevation_precision' do
           let(:d) { Export::Dwca::Data.new(core_scope: scope, taxonworks_extensions: [:elevation_precision]) }
           let(:ce) { FactoryBot.create(:valid_collecting_event, minimum_elevation: 100, elevation_precision: '10 m') }


### PR DESCRIPTION
Plucking from the database is faster than calling a method on each CO when the data do not require any processing.

The change is transparent to the API consumer, all extension fields are still provided as a single list.

Included `elevation_precision` as a sample of an exposed field.

Other internal CE and CO fields can be added as needed, resolving #3724.