### PR TITLE
#3366 Respect the Combinations checkbox when displaying the Nomenclat…

### DIFF
--- a/lib/queries/taxon_name/tabular.rb
+++ b/lib/queries/taxon_name/tabular.rb
@@ -307,7 +307,9 @@ module Queries
           end
         end
 
-        nomenclature_stats_column(query, 'combination', nil, i)
+        if combinations
+          nomenclature_stats_column(query, 'combination', nil, i)
+        end
 
         query
       end


### PR DESCRIPTION
…ure Stats table

We now display the Combinations column in the Nomenclature Stats table only when the Combinations checkbox is checked.