### PR TITLE
Some bibtex cleanup

### DIFF
--- a/app/models/source/bibtex.rb
+++ b/app/models/source/bibtex.rb
@@ -758,14 +758,6 @@ class Source::Bibtex < Source
 
     unless serial.nil?
       b[:journal] = serial.name
-      issns  = serial.identifiers.where(type: 'Identifier::Global::Issn')
-      unless issns.empty?
-        b[:issn] = issns.first.identifier # assuming the serial has only 1 ISSN
-      end
-    end
-
-    unless serial.nil?
-      b[:journal] = serial.name
       issns = serial.identifiers.where(type: 'Identifier::Global::Issn')
       unless issns.empty?
         b[:issn] = issns.first.identifier # assuming the serial has only 1 ISSN

--- a/app/models/source/bibtex.rb
+++ b/app/models/source/bibtex.rb
@@ -847,8 +847,6 @@ class Source::Bibtex < Source
   def render_with_style(style = 'vancouver', format = 'text', normalize_names = true)
     s = ::TaxonWorks::Vendor::BibtexRuby.get_style(style)
     cp = CiteProc::Processor.new(style: s, format:)
-    b = to_bibtex
-    ::TaxonWorks::Vendor::BibtexRuby.namecase_bibtex_entry(b) if normalize_names
     cp.import( [to_citeproc(normalize_names)] )
     cp.render(:bibliography, id: cp.items.keys.first).first.strip
   end


### PR DESCRIPTION
I hope these aren't just the confusions of a new Ruby user ... apologies in advance if they are!

One note on the 'remove unused lines' commit, where I claim that `to_bibtex` doesn't alter its caller: I think that's what the comment here is saying: https://github.com/SpeciesFileGroup/taxonworks/blob/190d33aba7659b368eaeabf438f047be58aaffee/app/models/source/bibtex.rb#L743-L744
Looking at the code, it looks like calls to a lot of what I think are rails-generated model accessors, which I assume do not have side effects, but I guess I don't know if it's possible to override those accessors and write them to have side effects? I haven't checked to see if that has happened for any of the accessors being called.
In any case, looking at the history of this code, I don't think `b = to_bibtex` is being called there to have a side effect, instead it looks like it used to be used to create a citeproc, whereas now `to_citeproc` calls `b = to_bibtex` on its own to do that - compare https://github.com/SpeciesFileGroup/taxonworks/commit/7585c33b8fce2fd063f4cdab147787a0b32ff0c1#diff-1994dc6848441192ddc46137769929f8cb4f84edad269fb9688bf5974c601fff 
