### PR TITLE
Validate that a loan that is no longer a gift has an expected return…

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -261,7 +261,7 @@ class Loan < ApplicationRecord
   end
 
   def gift_or_date_expected_required
-    errors.add(:date_return_expected, ' or gift status is required') if is_gift.nil? && date_return_expected.nil?
+    errors.add(:date_return_expected, ' or gift status is required') if is_gift.blank? && date_return_expected.nil?
   end
 
   def requested_after_sent

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -10,6 +10,14 @@ describe Loan, type: :model, group: :loans do
     expect(loan.valid?).to be_truthy
   end
 
+  specify 'cancelled gift must have date_return_expected' do
+    loan.lender_address = '123 N. South'
+    loan.date_return_expected = nil
+    loan.is_gift = true
+    loan.is_gift = false
+    expect(loan.valid?).to be_falsey
+  end
+
   context 'cloning records' do
     let(:cloned_attributes) {
       {


### PR DESCRIPTION
…date #3770

Before this it was possible to violate the spirit of the existing Loan validate: once a loan had been marked as a gift its model value could never be nil again (it was now either true or false), and so the existing validate was no longer checking anything.