### PR TITLE
Update text in Loans dashboard for Created in... section

### DIFF
--- a/app/views/tasks/loans/dashboard/index.html.erb
+++ b/app/views/tasks/loans/dashboard/index.html.erb
@@ -32,7 +32,7 @@
   </div>
 
   <div class="panel content separate-top">
-    <h2> Created at in the past </h2>
+    <h2> Created in the past </h2>
     <table>
       <tr><td>24 hours</td><td><%= tag.strong @loans.where('loans.created_at > ?', 24.hours.ago).count %></td></tr>
       <tr><td>Week</td><td><%= tag.strong @loans.where('loans.created_at > ?', 1.week.ago).count %></td></tr>


### PR DESCRIPTION
Fixing a typo:
![image](https://github.com/SpeciesFileGroup/taxonworks/assets/632915/3b22356e-6914-41a9-b600-a604ec73ecaa)

(Feel free to let me know if you'd like an associated issue for these small ones, or if I should just bundle them with some other issue, or something else.)