### PR TITLE
Handle popState for the Browse CO task #3768

### DIFF
--- a/app/javascript/vue/tasks/collection_objects/browse/App.vue
+++ b/app/javascript/vue/tasks/collection_objects/browse/App.vue
@@ -60,14 +60,26 @@ const collectingEvent = computed(
 const { collection_object_id: coId } = URLParamsToJSON(location.href)
 
 if (coId) {
+  // Call this for history.replaceState - otherwise turbolinks saves state
+  // that causes a reload every time we revisit this initial CO.
+  setParam(RouteNames.BrowseCollectionObject, 'collection_object_id', coId)
   store.dispatch(ActionNames.LoadCollectionObject, coId)
 }
 
-function loadCO(coId) {
+function loadCO(coId, doSetParam = true) {
   store.dispatch(ActionNames.ResetStore)
   store.dispatch(ActionNames.LoadCollectionObject, coId)
-  setParam(RouteNames.BrowseCollectionObject, 'collection_object_id', coId)
+  if (doSetParam) {
+    setParam(RouteNames.BrowseCollectionObject, 'collection_object_id', coId)
+  }
 }
+
+window.addEventListener('popstate', () => {
+  const { collection_object_id: coId } = URLParamsToJSON(location.href)
+  if (coId) {
+    loadCO(coId, false)
+  }
+})
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
The trick here is that when you first load the Browse CO task, turbolinks adds a history state object (seen here from a popstate event object):
![turbolinks](https://github.com/SpeciesFileGroup/taxonworks/assets/632915/20777887-3cdb-419b-befa-4951f04fba18)
Apparently that state has the effect of causing a reload everytime browser history returns to the inital browse CO - so if you just loadCO on each popstate without taking care of that then everything works fine except that when history returns to that initial CO you get a loadCO that gets overrun by an App load (which loads fine in the end but causes jank and extra useless fetching). Fortunately timing is such that we're able to remove/replace that turbolinks state in the App code.

Tested on firefox and chrome.