### PR TITLE
#3774 Don't require the taxonworks_extension_methods param when downl…

### DIFF
--- a/app/controllers/tasks/dwc/dashboard_controller.rb
+++ b/app/controllers/tasks/dwc/dashboard_controller.rb
@@ -70,6 +70,7 @@ class Tasks::Dwc::DashboardController < ApplicationController
   end
 
   def taxonworks_extension_params
+    return [] if !params.include?(:taxonworks_extension_methods)
     params.permit(taxonworks_extension_methods: []).dig(:taxonworks_extension_methods).map(&:to_sym)
   end
 


### PR DESCRIPTION
…oading dwc

Just to check that I'm understanding what happened:
You can now download DWC data with internal data included if you do so from the Filter COs task:
![image](https://github.com/SpeciesFileGroup/taxonworks/assets/632915/aea8af8d-a3d6-491e-b562-bff1de3965ff)
So a `taxonworks_extension_params` method was added to pull out which internal values you want to include in your download. But if you instead do the download directly from the DWC dashboard task - which doesn't allow for selecting to include those internal values - that extensions parameter isn't present in the download request.