### PR TITLE
A couple hub adjustments

### DIFF
--- a/app/assets/stylesheets/helpers/hub/tasks.scss
+++ b/app/assets/stylesheets/helpers/hub/tasks.scss
@@ -76,6 +76,9 @@
       opacity: 0.2;
       overflow: hidden;
     }
+    a {
+      flex-grow: 1;
+    }
   }
 
   .task_card:hover {
@@ -104,7 +107,6 @@
 
   .task-information {
     margin-left: 30px;
-    width: 100%;
   }
 
   .fav-link {

--- a/lib/hub/data.rb
+++ b/lib/hub/data.rb
@@ -120,7 +120,7 @@ module Hub::Data
   # @param [String] section
   # @return [Array]
   def self.visual_items_for(section)
-    INDEX[section].select{|a| !a.hide}
+    INDEX[section].select{|a| !a.hide}.sort_by(&:name)
   end
 
   # @param [String] prefix


### PR DESCRIPTION
Regarding the issue I mention in the first commit with the `task-information` divs rendering outside the bounds of the task card, here's what it looked like before the commit (with the task-information divs highlighted in blue):
![pre](https://github.com/SpeciesFileGroup/taxonworks/assets/632915/eae4183e-5598-470b-8f93-9a38de490b29)
and with the commit:
![post](https://github.com/SpeciesFileGroup/taxonworks/assets/632915/7fd1271a-ab56-42aa-abe1-b0f52fed7a9c)
