### PR TITLE
#3815 Don't assign to the citation ref when a new citation is added i…

### DIFF
--- a/app/javascript/vue/components/radials/annotator/components/citations/citation_annotator.vue
+++ b/app/javascript/vue/components/radials/annotator/components/citations/citation_annotator.vue
@@ -185,7 +185,6 @@ function saveCitation(item) {
   request
     .then(({ body }) => {
       addToArray(list.value, body)
-      citation.value = body
       emit('update-count', list.value.length)
       TW.workbench.alert.create('Citation was successfully saved.', 'notice')
     })


### PR DESCRIPTION
…n the citation annotator

The citation ref is for something else I think (related to resolving citations marked as original? Maybe a different name would help there?).