### PR TITLE
3833 improves COLDP sic handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 
 [#3794]: https://github.com/SpeciesFileGroup/taxonworks/issues/3794
 [#3824]: https://github.com/SpeciesFileGroup/taxonworks/issues/3824
+[#3833]: https://github.com/SpeciesFileGroup/taxonworks/issues/3833
 
 ## [0.38.2] - 2024-02-09
 

--- a/lib/export/coldp/files/name.rb
+++ b/lib/export/coldp/files/name.rb
@@ -116,26 +116,26 @@ module Export::Coldp::Files::Name
     end
 
     csv << [
-      id,                                                                 # ID
-      basionym_id,                                                        # basionymID
-      clean_sic(t.cached_original_combination),                           # scientificName
-      authorship_field(t, true),                                          # authorship
-      rank,                                                               # rank
-      uninomial,                                                          # uninomial
-      genus,                                                              # genus
-      subgenus,                                                           # subgenus (no parens)
-      species,                                                            # species
-      infraspecific_element ? infraspecific_element.last : nil,           # infraspecificEpithet
-      origin_citation&.source_id,                                         # referenceID    |
-      origin_citation&.pages,                                             # publishedInPage  | !! All origin citations get added to reference_csv via the main loop, not here
-      t.year_of_publication,                                              # publishedInYear  |
-      true,                                                               # original
-      code_field(t),                                                      # code
-      nil,                                                                # status https://api.checklistbank.org/vocab/nomStatus
-      nil,                                                                # link (probably TW public or API)
-      Export::Coldp.sanitize_remarks(remarks(t, name_remarks_vocab_id)),  # remarks
-      Export::Coldp.modified(t[:updated_at]),                             # modified
-      Export::Coldp.modified_by(t[:updated_by_id], project_members)       # modifiedBy
+      id,                                                                  # ID
+      basionym_id,                                                         # basionymID
+      clean_sic(t.cached_original_combination),                            # scientificName
+      authorship_field(t, true),                                           # authorship
+      rank,                                                                # rank
+      clean_sic(uninomial),                                                # uninomial
+      clean_sic(genus),                                                    # genus
+      clean_sic(subgenus),                                                 # subgenus (no parens)
+      clean_sic(species),                                                  # species
+      infraspecific_element ? clean_sic(infraspecific_element.last) : nil, # infraspecificEpithet
+      origin_citation&.source_id,                                          # referenceID    |
+      origin_citation&.pages,                                              # publishedInPage  | !! All origin citations get added to reference_csv via the main loop, not here
+      t.year_of_publication,                                               # publishedInYear  |
+      true,                                                                # original
+      code_field(t),                                                       # code
+      nil,                                                                 # status https://api.checklistbank.org/vocab/nomStatus
+      nil,                                                                 # link (probably TW public or API)
+      Export::Coldp.sanitize_remarks(remarks(t, name_remarks_vocab_id)),   # remarks
+      Export::Coldp.modified(t[:updated_at]),                              # modified
+      Export::Coldp.modified_by(t[:updated_by_id], project_members)        # modifiedBy
     ]
   end
 

--- a/lib/export/coldp/files/name.rb
+++ b/lib/export/coldp/files/name.rb
@@ -140,7 +140,7 @@ module Export::Coldp::Files::Name
   end
 
   def self.clean_sic(name)
-    name&.gsub(/\s+\[sic\]/, '') # TODO: remove `&` once cached_original_combination is re-indexed
+    name&.gsub(/\[sic\]/, '') # TODO: remove `&` once cached_original_combination is re-indexed
   end
 
   # @params otu [Otu]


### PR DESCRIPTION
Added clean_sic() processing on original combinations and modified the regex to eliminate the space because it was missing name components that included only `[sic]` with no space. Fixes #3833 