### PR TITLE
Only show Predicate CVTs in Filter CEs batch update for Data Attributes

### DIFF
--- a/app/controllers/data_attributes_controller.rb
+++ b/app/controllers/data_attributes_controller.rb
@@ -111,7 +111,7 @@ class DataAttributesController < ApplicationController
     if @data_attributes.present?
       render '/data_attributes/index'
     else
-      render json: { failed: true, status: :unprocessable_entity}
+      render json: { errors: ['Batch create failed - make sure your controlled vocabulary term is a predicate.'] }, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/vue/components/radials/mass/components/Annotator/AnnotatorDataAttribute.vue
+++ b/app/javascript/vue/components/radials/mass/components/Annotator/AnnotatorDataAttribute.vue
@@ -93,14 +93,16 @@ function createDataAttributes() {
     type: 'InternalAttribute',
     controlled_vocabulary_term_id: predicate.value.id,
     value: inputValue.value
-  }).then((response) => {
-    TW.workbench.alert.create(
-      'Data attribute(s) were successfully created',
-      'notice'
-    )
-    resetForm()
-    emit('create', response.body)
   })
+    .then((response) => {
+      TW.workbench.alert.create(
+        'Data attribute(s) were successfully created',
+        'notice'
+      )
+      resetForm()
+      emit('create', response.body)
+    })
+    .catch(() => {})
 }
 
 const all = ref([])

--- a/app/javascript/vue/components/radials/mass/components/Annotator/AnnotatorDataAttribute.vue
+++ b/app/javascript/vue/components/radials/mass/components/Annotator/AnnotatorDataAttribute.vue
@@ -107,7 +107,7 @@ function createDataAttributes() {
 
 const all = ref([])
 
-ControlledVocabularyTerm.where({ type: 'Predicate' }).then(({ body }) => {
+ControlledVocabularyTerm.where({ type: ['Predicate'] }).then(({ body }) => {
   all.value = body
 })
 </script>


### PR DESCRIPTION
The second commit changes the `type` value to be an array since the CVT controller only permits arrays for `type`: https://github.com/SpeciesFileGroup/taxonworks/blob/cc1c44b782c3fcbd3347ec9bcf747228d6486272/app/controllers/controlled_vocabulary_terms_controller.rb#L158-L162