### PR TITLE
3867 adds sic handling to Protonym#original_combination_infraspecific_element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 - Add taxon name autocomplete to Type specimen facet
 - DwC Dashboard: Use the same DwC download of collection object filter task
 
+### Fixed
+- Handling of [sic] in Protonym#original_combination_infraspecific_element [#3867]
+
 ## [0.39.0] - 2024-03-01
 
 ### Added

--- a/app/models/protonym.rb
+++ b/app/models/protonym.rb
@@ -772,8 +772,10 @@ class Protonym < TaxonName
 
   # @return [[rank_name, name], nil]
   #   Used in ColDP export
-  def original_combination_infraspecific_element(elements = nil)
+  def original_combination_infraspecific_element(elements = nil, remove_sic = false)
     elements ||= original_combination_elements
+
+    elements = elements.each { |r, e| e.delete('[sic]') } if remove_sic
 
     # TODO: consider plants/other codes?
     [:form, :variety, :subspecies].each do |r|

--- a/lib/export/coldp/files/name.rb
+++ b/lib/export/coldp/files/name.rb
@@ -61,7 +61,7 @@ module Export::Coldp::Files::Name
   def self.add_original_combination(t, csv, origin_citation, name_remarks_vocab_id, project_members)
     e = t.original_combination_elements
 
-    infraspecific_element = t.original_combination_infraspecific_element(e)
+    infraspecific_element = t.original_combination_infraspecific_element(e, remove_sic: true)
 
     rank = nil
     if infraspecific_element


### PR DESCRIPTION
This fixes #3867, although I could also potentially keep the sic handling in the COLDP exporter instead of the model, depending on whether Protonym#original_combination_infraspecific_element and Protonym#original_combination_elements are supposed to include [sic] elements?