### PR TITLE
Catching some more errors

### DIFF
--- a/app/javascript/vue/components/radials/annotator/components/tag_annotator.vue
+++ b/app/javascript/vue/components/radials/annotator/components/tag_annotator.vue
@@ -72,10 +72,12 @@ function createWithId({ id }) {
     tag_object_type: props.objectType
   }
 
-  Tag.create({ tag }).then(({ body }) => {
-    addToList(body)
-    TW.workbench.alert.create('Tag was successfully created.', 'notice')
-  })
+  Tag.create({ tag })
+    .then(({ body }) => {
+      addToList(body)
+      TW.workbench.alert.create('Tag was successfully created.', 'notice')
+    })
+    .catch(() => {})
 }
 
 function removeItem(item) {

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/relationshipPicker.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/relationshipPicker.vue
@@ -328,10 +328,13 @@ export default {
             object_taxon_name_id: this.taxonRelation.id,
             subject_taxon_name_id: this.taxon.id
           })
-          .then(() => {
-            this.taxonRelation = undefined
-            this.$store.commit(MutationNames.UpdateLastChange)
-          })
+          .then(
+            () => {
+              this.taxonRelation = undefined
+              this.$store.commit(MutationNames.UpdateLastChange)
+            },
+            (errors) => {}
+          )
       }
       this.isInsertaeSedis = false
     },

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/saveTaxonName.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/saveTaxonName.vue
@@ -56,11 +56,11 @@ export default {
     },
 
     createTaxonName() {
-      this.$store.dispatch(ActionNames.CreateTaxonName, this.taxon)
+      this.$store.dispatch(ActionNames.CreateTaxonName, this.taxon).catch(() => {})
     },
 
     updateTaxonName() {
-      this.$store.dispatch(ActionNames.UpdateTaxonName, this.taxon)
+      this.$store.dispatch(ActionNames.UpdateTaxonName, this.taxon).catch(() => {})
     }
   }
 }

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/taxonNameBox.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/taxonNameBox.vue
@@ -169,9 +169,11 @@ export default {
 
   methods: {
     deleteTaxon() {
-      TaxonName.destroy(this.taxon.id).then(() => {
-        this.reloadPage()
-      })
+      TaxonName.destroy(this.taxon.id)
+        .then(() => {
+          this.reloadPage()
+        })
+        .catch(() => {})
     },
 
     reloadPage() {

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/store/actions/createTaxonName.js
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/store/actions/createTaxonName.js
@@ -34,7 +34,7 @@ export default ({ commit, dispatch }, taxon) => {
         commit(MutationNames.UpdateLastSave)
         resolve(response.body)
       },
-      (response) => {
+      ({ response }) => {
         commit(MutationNames.SetHardValidation, response.body)
         reject(response.body)
       }

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/store/actions/updateTaxonName.js
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/store/actions/updateTaxonName.js
@@ -45,7 +45,7 @@ export default ({ commit, state, dispatch }, taxon) => {
         commit(MutationNames.SetSaving, false)
         return resolve(response.body)
       },
-      (response) => {
+      ({ response }) => {
         commit(MutationNames.SetHardValidation, response.body)
         commit(MutationNames.SetSaving, false)
         return reject(response.body)


### PR DESCRIPTION
Commit 2 is the only one with real substance here (at least I hope) - without it the hard validation doesn't get set when creating or updating a taxon name.

p.s. I don't mind submitting these error-catching fixes, but feel free to weigh in on whether they're worth it. Personally I almost only work in docker development, so I have to deal with the red overlays, but actual users never see them, so the error-catching changes have no effect on them.