### PR TITLE
Implement create loan items for tagged objects for the 'all types' case

### DIFF
--- a/app/javascript/vue/tasks/loans/new/components/CreateTag.vue
+++ b/app/javascript/vue/tasks/loans/new/components/CreateTag.vue
@@ -38,8 +38,10 @@
 
           <button
             v-if="!isOneRow(item) && key === 'total'"
-            class="button normal-input button-submit">
-            Create for both
+            class="button normal-input button-submit"
+            @click="batchLoadForAll(item.object.id, item.totals)"
+          >
+            Create for all
           </button>
         </div>
       </template>

--- a/app/javascript/vue/tasks/loans/new/components/mixins/batch.js
+++ b/app/javascript/vue/tasks/loans/new/components/mixins/batch.js
@@ -44,6 +44,14 @@ export default {
       }
     },
 
+    batchLoadForAll(keywordId, totals) {
+      Object.entries(totals).forEach(([klass, total]) => {
+        if (klass != 'total' && total > 0) {
+          this.batchLoad(klass, keywordId, total)
+        }
+      })
+    },
+
     async getMeta() {
       const metadata = (await getTagMetadata()).body
       this.keywords = metadata[this.metadataList]


### PR DESCRIPTION
This implements the `Create for both` button for creating loan items from Tags, which as far as I can tell is not currently implemented:
![image](https://github.com/SpeciesFileGroup/taxonworks/assets/632915/56fa73a2-b873-404e-8442-20ac05f9edf1)

I changed `Create for both` to `Create for all` for the three cases: otus, collection objects, and containers.

I think there are some existing issues around reporting success (like what happens when one of many in a batch create is already on loan and the batch create fails partway through) that this pr doesn't address, and maybe makes a little worse since now a report of success could mean success on all, one, or two of the types attempting to be added, with silent failure on the others.