### PR TITLE
#3877 Update insert_couplet and destroy_couplet to deal with ordering…

### DIFF
--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -57,7 +57,7 @@ class Lead < ApplicationRecord
   has_many :redirecters, class_name: 'Lead', foreign_key: :redirect_id, inverse_of: :redirect, dependent: :restrict_with_error
 
   acts_as_list scope: [:parent_id, :project_id]
-  has_closure_tree order: 'position', dont_order_roots: true
+  has_closure_tree order: 'position'
 
   before_save :check_is_public
 


### PR DESCRIPTION
… issues

This seems to work, and I've added more tests, including testing positions after `insert_couplet` and `destroy_couplet`.

Once again, as was the case when `has_closure_tree` was setting positions, many attempts that seemed perfectly reasonable (to me) failed when reparenting children with `acts_as_list`, meaning one or more child-pairs involved wound up with what seemed to me like incorrect positions given the operations performed.

For `insert_couplet` the closest I was able to get using 'natural' expected-to-work calls was to have the reparented children with correct positions but the inserted nodes with the same position (or vice versa I think). I could use builtin calls like `lead.move_higher` to fix things up in that situation without explicitly setting position values, but it would have still seemed strange since you wouldn't expect that call to be needed in the first place. So instead I went with explictly setting positions of both the inserted nodes and their new children. It's more calls than necessary (given the way things currently work), but it seems to work and I don't think it's too many extra database calls for a function that won't see much use (but would welcome other thoughts on that). It may also be more future proof, maybe.

That said, at some point I'd like to dig into why the expected calls are not working the way I'd expect and then maybe revisit this solution. If you'd rather figure things out that way now instead of using the direct position-setting calls, that's fine with me, just let me know.

New-rails-person lessons learned for me so far:
* there are more database `position`-setting calls going on than what appears in my `docker compose up` output; presumably this is `acts_as_list` making direct sql calls in addition to using builtin rails methods: that those direct sql calls don't show up in the output (I'd welcome corrections here). Lesson being you can't always just watch that output to figure out what's going on.
* you may need to reload your ActiveRecord objects after behind-the-scenes updates; otherwise things like updating position may fail if the actual position is different than what your outdated object thinks it is.
* (Don't expect the docs to always be accurate (I already knew that :).)

@mjy, since there are more tests now and it's been a number of years, I went ahead and disregarded your warning from mx this time:
https://github.com/mx3/mx/blob/e63b72db1e3cfd3f448430fc2bc07214288ab925/app/models/clave.rb#L110
I added grandkids to one of the destroy_couplet tests to try to test that warning a little more deeply and things are looking good, but if you remember any explicit things worth adding for that scenario, or you think it's wiser to do that destroy the mx way, please let me know!