### PR TITLE
Add volumes/ and /.ruby-lsp to .gitignore and remove some duplicate e…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ config/initializers/vendor/better_errors.rb
 /tmp
 /coverage
 /.ruby-gemset
+/.ruby-lsp
+/volumes
 
 /.bundle
 /bundle_bin
@@ -50,19 +52,13 @@ config/initializers/vendor/better_errors.rb
 /spec/test_files/
 
 REVISION
-yarn-debug.log*
-.yarn-integrity
 npm-debug.log
+/node_modules
+
+/public/packs
+/public/packs-test
 
 yarn.lock
-/public/packs
-/public/packs-test
-/node_modules
-/yarn-error.log
-
-/public/packs
-/public/packs-test
-/node_modules
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity


### PR DESCRIPTION
…ntries

volumes/ is used by Docker so shouldn't be tracked; I'm not seeing any files in it even after `docker-compose up`, which I guess is why it hasn't been an issue in the past, but it still shows up in `git ls-files --others --directory --exclude-standard` which I'd like to use to chown directories created as root by `bin/rails generate ...` inside the docker image.

/.ruby-lsp is used by the ruby-lsp vscode plugin.