### PR TITLE
Remove acts as list from Lead

### DIFF
--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -122,13 +122,18 @@ class Lead < ApplicationRecord
       c = Lead.create!(text: left_text, parent: self)
       d = Lead.create!(text: right_text, parent: self)
 
-      o.each do |i|
-        if p == :left || p == :root
-          i.update!(parent: c)
-        else
-          i.update!(parent: d)
-        end
+      new_parent = (p == :left || p == :root) ? c : d
+      last_sibling = nil
 
+      # !! The more obvious version using add_child is actually more error
+      # prone than using add_sibling.
+      o.each_with_index do |c, i|
+        if i == 0
+          new_parent.add_child c
+        else
+          last_sibling.append_sibling c
+        end
+        last_sibling = c
       end
     else
       c = Lead.create!(text: t1, parent: self)

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -50,11 +50,6 @@ class Lead < ApplicationRecord
 
   has_closure_tree order: 'position', numeric_order: true, dont_order_roots: true , dependent: nil
 
-  # New records added at bottom (default)
-  # !! Note there is some oddness with update(parent: obj) vs. update(parent_id: object.id),
-  # if your function is not working as expected try the opposite.
-  acts_as_list scope: [:parent_id, :project_id]
-
   belongs_to :parent, class_name: 'Lead'
 
   belongs_to :otu, inverse_of: :leads
@@ -110,7 +105,7 @@ class Lead < ApplicationRecord
   end
 
   def insert_couplet
-    a,b,c,d = nil, nil, nil, nil
+    c,d = nil, nil
 
     p = node_position
 
@@ -166,20 +161,16 @@ class Lead < ApplicationRecord
 
         i = has_kids.children
 
+        # !! Use append_sibling, which is numeric_order-aware, to reparent
+        # the children of has_kids to self.
+        last_sibling = children[-1]
         i.each do |z|
-          # reload is required for pass, it seems we need to know the sibiling state
-          z.reload.update!(parent_id: has_kids.parent_id)
+          last_sibling.append_sibling z
+          last_sibling = z
         end
 
-        # `position` looks OK here
         has_kids.destroy!
-        # `position` looks OK here
         no_kids.destroy!
-        # !! `position` NOT OK here
-
-        # Give up as to why destroy fails to re-index. Force re-index of `position`
-        children.reload.reverse.map(&:save)  # reload is required
-
       else # Neither side has children
         Lead.transaction do
           a.destroy!

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -160,8 +160,9 @@ class Lead < ApplicationRecord
 
         i = has_kids.children
 
-        # !! Use append_sibling, which is numeric_order-aware, to reparent
-        # the children of has_kids to self.
+        # Reparent the children of has_kids to self.
+        # !! The obvious solution using add_child is actually more error-prone
+        # than using add_sibling.
         last_sibling = children[-1]
         i.each do |z|
           last_sibling.append_sibling z

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -112,8 +112,7 @@ class Lead < ApplicationRecord
     t1 = 'Inserted node'
     t2 = 'Child nodes are attached to this node'
 
-    # !! This reload is key to have specs pass
-    if children.reload.any?
+    if children.any?
       o = children.to_a
 
       left_text = (p == :left || p == :root) ? t2 : t1

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Lead, type: :model do
 
   specify '#insert_couplet between leads inserts with positions' do
     FactoryBot.create(:valid_lead, parent: lead, text: 'bottom')
-    lead.insert_couplet
+    lead.reload.insert_couplet
     a = lead.children.reload.order(:position)
 
     expect(a.first.children.size).to eq(1)
@@ -44,7 +44,7 @@ RSpec.describe Lead, type: :model do
     FactoryBot.create(:valid_lead, parent: lead, text: 'bottom left')
     FactoryBot.create(:valid_lead, parent: lead, text: 'bottom right')
 
-    lead.insert_couplet
+    lead.reload.insert_couplet
 
     a = lead.reload.children.order(:position)
     expect(a.first.children.size).to eq(2)
@@ -54,7 +54,7 @@ RSpec.describe Lead, type: :model do
     FactoryBot.create(:valid_lead, parent: lead, text: 'bottom left')
     FactoryBot.create(:valid_lead, parent: lead, text: 'bottom right')
 
-    lead.insert_couplet
+    lead.reload.insert_couplet
 
     a = lead.reload.children.order(:position)
     expect(a.first.children.pluck(:position)).to eq([0,1])

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -20,10 +20,9 @@ RSpec.describe Lead, type: :model do
   end
 
   specify '#insert_couplet children are ordered' do
-    lead.insert_couplet
-    a = lead.children.order(:position)
-    expect(a.first.position).to eq(0)
-    expect(a.last.position).to eq(1)
+    ids = lead.insert_couplet
+    expect(Lead.find(ids[0]).position).to eq(0)
+    expect(Lead.find(ids[1]).position).to eq(1)
   end
 
   specify '#insert_couplet inserts between leads' do
@@ -51,13 +50,12 @@ RSpec.describe Lead, type: :model do
   end
 
   specify '#insert_couplet between leads with siblings maintains position' do
-    FactoryBot.create(:valid_lead, parent: lead, text: 'bottom left')
-    FactoryBot.create(:valid_lead, parent: lead, text: 'bottom right')
+    bl = FactoryBot.create(:valid_lead, parent: lead, text: 'bottom left')
+    br = FactoryBot.create(:valid_lead, parent: lead, text: 'bottom right')
 
     lead.reload.insert_couplet
 
-    a = lead.reload.children.order(:position)
-    expect(a.first.children.pluck(:position)).to eq([0,1])
+    expect(bl.reload.position).to be < br.reload.position
   end
 
   specify '#node_position of root' do

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Lead, type: :model do
     lead.insert_couplet
 
     a = lead.reload.children.order(:position)
-    expect(a.first.children.order(:position).pluck(:position)).to eq([0,1])
+    expect(a.first.children.pluck(:position)).to eq([0,1])
   end
 
   specify '#node_position of root' do
@@ -122,6 +122,21 @@ RSpec.describe Lead, type: :model do
     root = FactoryBot.create(:valid_lead)
     child = root.children.create! text: 'c'
     expect {child.update! redirect_id: root.id}.to raise_error ActiveRecord::RecordInvalid
+  end
+
+  # TODO: should this be a request test instead, so that we're testing
+  # whatever current leads_controller#update behavior is?
+  specify "'ui update' doesn't change order of chidren" do
+    # Simulate a ui 'Update' saving all three nodes of a couplet.
+    lead = FactoryBot.create(:valid_lead)
+    l = FactoryBot.create(:valid_lead, parent: lead, text: 'bottom left')
+    r = FactoryBot.create(:valid_lead, parent: lead, text: 'bottom right')
+
+    lead.update! text: lead.text
+    l.update! text: 'new text'
+    r.update! text: r.text
+
+    expect(l.reload.position).to be < r.reload.position
   end
 
   xspecify "keys with external referrers can't be destroyed" do

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -361,6 +361,16 @@ RSpec.describe Lead, type: :model do
       expect(Lead.find_by(text: 'rll').position).to be < Lead.find_by(text: 'rlr').position
     end
 
+    specify "destroy_couplet doesn't change order of 3 reparented nodes (left)" do
+      lrm = FactoryBot.create(:valid_lead, text: 'middle child of lr')
+      lrl.append_sibling(lrm)
+
+      l.reload.destroy_couplet
+
+      expect(Lead.find_by(text: 'lrl').position).to be < Lead.find_by(text: 'middle child of lr').position
+      expect(Lead.find_by(text: 'middle child of lr').position).to be < Lead.find_by(text: 'lrr').position
+    end
+
     specify '#all_children' do
       lrll = lrl.children.create! text: 'lrll'
       lrlr = lrl.children.create! text: 'lrlr'


### PR DESCRIPTION
It turned out that `append_sibling` was what worked again here for reparenting (I'm personally starting to believe there's a bug in some of the other reparenting techniques regarding ordering).