### PR TITLE
Key hub improvements

### DIFF
--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -2,7 +2,7 @@ class LeadsController < ApplicationController
   include DataControllerConfiguration::ProjectDataControllerConfiguration
   before_action :set_lead, only: %i[
     edit create_for_edit update destroy show show_all show_all_print all_texts
-    destroy_couplet insert_couplet delete_couplet duplicate update_meta ]
+    destroy_couplet insert_couplet delete_couplet duplicate update_meta otus]
 
   # GET /leads
   # GET /leads.json
@@ -221,6 +221,17 @@ class LeadsController < ApplicationController
       else
         format.json { render json: @lead.errors, status: :unprocessable_entity}
       end
+    end
+  end
+
+  # GET /leads/1/otus.json
+  def otus
+    leads_list = @lead.self_and_descendants.where.not(otu_id: nil).includes(:otu)
+
+    @otus = leads_list.to_a.map{|l| l.otu}.uniq(&:id)
+
+    respond_to do |format|
+      format.json {}
     end
   end
 

--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -217,7 +217,7 @@ class LeadsController < ApplicationController
   def update_meta
     respond_to do |format|
       if @lead.update(lead_params)
-        format.json { head :no_content }
+        format.json {}
       else
         format.json { render json: @lead.errors, status: :unprocessable_entity}
       end

--- a/app/javascript/vue/routes/endpoints/Lead.js
+++ b/app/javascript/vue/routes/endpoints/Lead.js
@@ -73,5 +73,9 @@ export const Lead = {
 
   delete_couplet: (id) => AjaxCall(
     'post', `/${controller}/${id}/delete_couplet.json`
+  ),
+
+  otus: (id) => AjaxCall(
+    'get', `/${controller}/${id}/otus.json`
   )
 }

--- a/app/javascript/vue/routes/routes.js
+++ b/app/javascript/vue/routes/routes.js
@@ -29,6 +29,7 @@ const RouteNames = {
   FreeFormTask: '/tasks/collection_objects/freeform_digitize',
   ImageMatrix: '/tasks/matrix_image/matrix_image/index',
   InteractiveKeys: '/tasks/observation_matrices/interactive_key',
+  LeadsHub: '/tasks/leads/hub',
   ManageBiocurationTask:
     '/tasks/controlled_vocabularies/biocuration/build_collection',
   ManageControlledVocabularyTask: '/tasks/controlled_vocabularies/manage',

--- a/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
@@ -8,14 +8,11 @@
       <a :href="citation.source.object_url" target="_blank">
         {{ citation.citation_source_body }}
       </a>
-      <RadialAnnotator :global-id="citation.global_id" />
     </div>
   </div>
 </template>
 
 <script setup>
-import RadialAnnotator from '@/components/radials/annotator/annotator.vue'
-
 const props = defineProps({
   citations: {
     type: Array,
@@ -27,8 +24,5 @@ const props = defineProps({
 <style lang="scss" scoped>
 .lead_citation {
   margin-bottom: 1em;
-  display: flex;
-  align-items: center;
-  column-gap: .5em;
 }
 </style>

--- a/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
@@ -1,6 +1,7 @@
 <template>
   Citations
   <div
+    v-if="citations.length"
     v-for="citation in citations"
     :key="citation.id"
   >
@@ -10,13 +11,16 @@
       </a>
     </div>
   </div>
+  <div v-else>
+    <i>No citations</i>
+  </div>
 </template>
 
 <script setup>
 const props = defineProps({
   citations: {
     type: Array,
-    required: true
+    default: []
   }
 })
 </script>

--- a/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
@@ -1,0 +1,34 @@
+<template>
+  <u>Citations</u>
+  <div
+    v-for="citation in citations"
+    :key="citation.id"
+  >
+    <div class="lead_citation">
+      <a :href="citation.source.object_url" target="_blank">
+        {{ citation.citation_source_body }}
+      </a>
+      <RadialAnnotator :global-id="citation.global_id" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import RadialAnnotator from '@/components/radials/annotator/annotator.vue'
+
+const props = defineProps({
+  citations: {
+    type: Array,
+    required: true
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.lead_citation {
+  margin-bottom: 1em;
+  display: flex;
+  align-items: center;
+  column-gap: .5em;
+}
+</style>

--- a/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
@@ -1,5 +1,5 @@
 <template>
-  <u>Citations</u>
+  Citations
   <div
     v-for="citation in citations"
     :key="citation.id"

--- a/app/javascript/vue/tasks/leads/hub/components/KeyOtus.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyOtus.vue
@@ -1,0 +1,69 @@
+<template>
+  <u>Root otu:</u>
+  <a
+    v-if="key.otu"
+    :href="key.otu.object_url"
+    v-html="key.otu.object_tag"
+    class="otu"
+    target="_blank"
+  />
+  <span
+    v-else
+    class="otu"
+  >
+    <i>No root otu.</i>
+  </span>
+
+  <span
+    v-if="!key.child_otus"
+    class="otus_button"
+  >
+    <LoadOtusButton
+      @click="() => emit('loadOtusForKey')"
+    />
+  </span>
+  <span
+    v-else
+    class="otu"
+  >
+    <template v-if="key.child_otus.length">
+      <u>Other otus:</u>
+      <a
+        v-for="otu in key.child_otus"
+        :key="otu.id"
+        :href="otu.object_url"
+        v-html="otu.object_tag"
+        class="otu"
+        target="_blank"
+      />
+    </template>
+    <span v-else class="otu">
+      <i>No other otus.</i>
+    </span>
+  </span>
+</template>
+
+<script setup>
+import LoadOtusButton from './LoadOtusButton.vue'
+
+const props = defineProps({
+  // 'key' isn't allowed as a prop.
+  keyProp: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits(['loadOtusForKey'])
+
+const key = props.keyProp
+</script>
+
+<style lang="scss" scoped>
+.otus_button {
+  margin-left: .5em;
+}
+.otu {
+  margin-left: .5em;
+}
+</style>

--- a/app/javascript/vue/tasks/leads/hub/components/KeyOtus.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyOtus.vue
@@ -1,5 +1,5 @@
 <template>
-  <u>Root otu:</u>
+  Root otu:
   <a
     v-if="key.otu"
     :href="key.otu.object_url"
@@ -27,7 +27,7 @@
     class="otu"
   >
     <template v-if="key.child_otus.length">
-      <u>Other otus:</u>
+      Other otus:
       <a
         v-for="otu in key.child_otus"
         :key="otu.id"

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -6,7 +6,7 @@
       :logo-size="{ width: '100px', height: '100px' }"
     />
     <h3 class="title-section">Keys</h3>
-    <div class="leads_list">
+    <div class="keys_list">
       <table
         v-if="keys.length"
         class="vue-table"
@@ -30,30 +30,54 @@
             </th>
             <th /> <!-- radials -->
           </tr>
-          <tr
+        </thead>
+        <tbody>
+          <template
             v-for="(key, index) in keys"
             :key="key.id"
-            :class="{ even: (index % 2 == 0)}"
           >
-            <td>{{ key.text }}</td>
-            <td>{{ key.couplet_count }}</td>
-            <td>
-              <input
-                type="checkbox"
-                :checked="key.is_public"
-                @click="() => changeIsPublicState(key)"
-              />
-            </td>
-            <td>{{ key.updated_at_in_words }}</td>
-            <td>{{ key.updated_by }}</td>
-            <td class="width-shrink">
-              <div class="horizontal-right-content gap-small">
-                <RadialAnnotator :global-id="key.global_id" />
-                <RadialNavigator :global-id="key.global_id" />
-              </div>
-            </td>
-          </tr>
-        </thead>
+            <tr
+              class="meta_row"
+              :class="{ even: (index % 2 == 0)}"
+            >
+              <td><b>{{ key.text }}</b></td>
+              <td>{{ key.couplet_count }}</td>
+              <td>
+                <input
+                  type="checkbox"
+                  :checked="key.is_public"
+                  @click="() => changeIsPublicState(key)"
+                />
+              </td>
+              <td>{{ key.updated_at_in_words }}</td>
+              <td>{{ key.updated_by }}</td>
+              <td class="width-shrink">
+                <div class="horizontal-right-content gap-small">
+                  <RadialAnnotator :global-id="key.global_id" />
+                  <RadialNavigator :global-id="key.global_id" />
+                </div>
+              </td>
+            </tr>
+
+            <tr :class="{ even: (index % 2 == 0)}">
+              <td colspan="6" class="extension_row">
+                <KeyOtus
+                  :key-prop="key"
+                  @load-otus-for-key="() => loadOtusForKey(key)"
+                />
+              </td>
+            </tr>
+
+            <tr
+              :class="{ even: (index % 2 == 0)}"
+              v-if="key.citations"
+            >
+              <td colspan="6">
+                <KeyCitations :citations="key.citations" />
+              </td>
+            </tr>
+          </template>
+        </tbody>
       </table>
 
       <div v-else-if="!loading">
@@ -72,10 +96,13 @@
 
 <script setup>
 import { addToArray } from '@/helpers/arrays'
-import { Lead } from '@/routes/endpoints'
+import { Citation, Lead } from '@/routes/endpoints'
+import { LEAD } from '@/constants/index.js'
 import { onBeforeMount, ref } from 'vue'
 import { RouteNames } from '@/routes/routes'
 import { sortArray } from '@/helpers'
+import KeyCitations from './KeyCitations.vue'
+import KeyOtus from './KeyOtus.vue'
 import RadialAnnotator from '@/components/radials/annotator/annotator.vue'
 import RadialNavigator from '@/components/radials/navigation/radial.vue'
 import VSpinner from '@/components/ui/VSpinner.vue'
@@ -84,15 +111,43 @@ const keys = ref([])
 const loading = ref(true)
 const ascending = ref(false)
 
-onBeforeMount(() => {
-  Lead.where({ extend: ['couplet_count', 'updater', 'updated_at_in_words'] })
+onBeforeMount(async () => {
+  const loadKeys = Lead.where({
+    extend: ['couplet_count', 'updater', 'updated_at_in_words', 'otu']
+   })
     .then(({ body }) => {
       keys.value = body
     })
     .finally(() => {
       loading.value = false
     })
+
+  const loadCitations = Citation.where({
+    citation_object_type: LEAD,
+    extend: ['source']
+  })
+
+  Promise.allSettled([loadKeys, loadCitations])
+    .then(([_, { value }]) => {
+      addCitationsToKeysList(value.body)
+    })
+    .catch(() => {})
 })
+
+function addCitationsToKeysList(citations) {
+  citations.forEach((citation) => {
+    const i = keys.value.findIndex(
+      (key) => (key.id == citation.citation_object_id)
+    )
+    if (i != -1) {
+      if (keys.value[i].citations) {
+        keys.value[i].citations.push(citation)
+      } else {
+        keys.value[i].citations = [ citation ]
+      }
+    }
+  })
+}
 
 function sortTable(sortProperty) {
   keys.value = sortArray(keys.value, sortProperty, ascending.value)
@@ -104,23 +159,68 @@ function changeIsPublicState(key) {
     lead: {
       is_public: !key.is_public
     },
-    extend: ['couplet_count', 'updater', 'updated_at_in_words']
+    extend: ['updater', 'updated_at_in_words']
   }
 
   Lead.update_meta(key.id, payload)
     .then(({ body }) => {
-      addToArray(keys.value, body.lead)
+      const updatedKey = {
+        ...body.lead,
+        otu: key.otu,
+        couplet_count: key.couplet_count,
+        citations: key.citations,
+        child_otus: key.child_otus
+      }
+
+      addToArray(keys.value, updatedKey)
     })
     .catch(() => {})
+}
+
+function loadOtusForKey(key) {
+  Lead.otus(key.id)
+    .then(({ body }) => {
+      let otus = body
+      if (key.otu) {
+        // Remove the root otu, which is already displayed.
+        const i = otus.find((otu) => (otu.id == key.otu_id))
+        if (i != -1) {
+          otus.splice(i, 1)
+        }
+      }
+
+      otus.sort((a, b) => {
+        if (a.object_label == b.object_label) {
+          return a.id < b.id ? -1 : 1
+        }
+        return a.object_label < b.object_label ? -1 : 1
+      })
+
+      key.child_otus = otus
+      addToArray(keys.value, key)
+    })
+    .catch(() => {
+      // Add child_otus or the loading spinner will never disappear.
+      key.child_otus = []
+      addToArray(keys.value, key)
+    })
 }
 </script>
 
 <style lang="scss" scoped>
-.leads_list {
+.keys_list {
   margin-right: 1em;
   margin-bottom: 2em;
 }
 .width-shrink {
   width: 1%;
+}
+.meta_row:not(:first-child) {
+  border-top: 2px solid #5D9ECE;
+}
+.extension_row {
+  border-top: 4px dotted #eee;
+  padding-top: .5em;
+  padding-bottom: .5em;
 }
 </style>

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -37,7 +37,13 @@
           >
             <td>{{ key.text }}</td>
             <td>{{ key.couplet_count }}</td>
-            <td>{{ key.is_public? 'True' : 'False' }}</td>
+            <td>
+              <input
+                type="checkbox"
+                :checked="key.is_public"
+                @click="() => changeIsPublicState(key)"
+              />
+            </td>
             <td>{{ key.updated_at_in_words }}</td>
             <td>{{ key.updated_by }}</td>
             <td class="width-shrink">
@@ -65,6 +71,7 @@
 </template>
 
 <script setup>
+import { addToArray } from '@/helpers/arrays'
 import { Lead } from '@/routes/endpoints'
 import { onBeforeMount, ref } from 'vue'
 import { RouteNames } from '@/routes/routes'
@@ -90,6 +97,21 @@ onBeforeMount(() => {
 function sortTable(sortProperty) {
   keys.value = sortArray(keys.value, sortProperty, ascending.value)
   ascending.value = !ascending.value
+}
+
+function changeIsPublicState(key) {
+  const payload = {
+    lead: {
+      is_public: !key.is_public
+    },
+    extend: ['couplet_count', 'updater', 'updated_at_in_words']
+  }
+
+  Lead.update_meta(key.id, payload)
+    .then(({ body }) => {
+      addToArray(keys.value, body.lead)
+    })
+    .catch(() => {})
 }
 </script>
 

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -38,7 +38,7 @@
             <td>{{ key.text }}</td>
             <td>{{ key.couplet_count }}</td>
             <td>{{ key.is_public? 'True' : 'False' }}</td>
-            <td>{{ key.updated_at }}</td>
+            <td>{{ key.updated_at_in_words }}</td>
             <td>{{ key.updated_by }}</td>
             <td class="width-shrink">
               <div class="horizontal-right-content gap-small">
@@ -78,7 +78,7 @@ const loading = ref(true)
 const ascending = ref(false)
 
 onBeforeMount(() => {
-  Lead.where({ extend: ['couplet_count', 'updater'] })
+  Lead.where({ extend: ['couplet_count', 'updater', 'updated_at_in_words'] })
     .then(({ body }) => {
       keys.value = body
     })

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -13,13 +13,22 @@
       >
         <thead>
           <tr>
-            <th @click="() => sortTable('text')">
+            <th
+              @click="() => sortTable('text')"
+              class="table_name_col"
+            >
               Name
             </th>
-            <th @click="() => sortTable('couplet_count')">
+            <th
+              @click="() => sortTable('couplet_count')"
+              class="narrow_col"
+            >
               # Couplets
             </th>
-            <th @click="() => sortTable('is_public')">
+            <th
+              @click="() => sortTable('is_public')"
+              class="narrow_col"
+            >
               Is Public
             </th>
             <th @click="() => sortTable('updated_at')">
@@ -60,19 +69,19 @@
             </tr>
 
             <tr :class="{ even: (index % 2 == 0)}">
-              <td colspan="6" class="extension_row">
+              <td
+                colspan="3"
+                class="extension_data"
+              >
                 <KeyOtus
                   :key-prop="key"
                   @load-otus-for-key="() => loadOtusForKey(key)"
                 />
               </td>
-            </tr>
-
-            <tr
-              :class="{ even: (index % 2 == 0)}"
-              v-if="key.citations"
-            >
-              <td colspan="6">
+              <td
+                colspan="3"
+                class="extension_data"
+              >
                 <KeyCitations :citations="key.citations" />
               </td>
             </tr>
@@ -218,9 +227,15 @@ function loadOtusForKey(key) {
 .meta_row:not(:first-child) {
   border-top: 2px solid #5D9ECE;
 }
-.extension_row {
+.extension_data {
   border-top: 4px dotted #eee;
   padding-top: .5em;
   padding-bottom: .5em;
+}
+.table_name_col {
+  width: 40%;
+}
+.narrow_col {
+  width: 4em;
 }
 </style>

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -49,8 +49,19 @@
               class="meta_row"
               :class="{ even: (index % 2 == 0)}"
             >
-              <td><b>{{ key.text }}</b></td>
+              <td>
+                <b>
+                  <a
+                    :href="RouteNames.ShowLead + '?lead_id=' + key.id"
+                    target="_blank"
+                  >
+                    {{ key.text }}
+                  </a>
+                </b>
+              </td>
+
               <td>{{ key.couplet_count }}</td>
+
               <td>
                 <input
                   type="checkbox"
@@ -58,8 +69,11 @@
                   @click="() => changeIsPublicState(key)"
                 />
               </td>
+
               <td>{{ key.updated_at_in_words }}</td>
+
               <td>{{ key.updated_by }}</td>
+
               <td class="width-shrink">
                 <div class="horizontal-right-content gap-small">
                   <RadialAnnotator :global-id="key.global_id" />

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -13,11 +13,21 @@
       >
         <thead>
           <tr>
-            <th>Name</th>
-            <th># Couplets</th>
-            <th>Is Public</th>
-            <th>Last Modified</th>
-            <th>Last Modified By</th>
+            <th @click="() => sortTable('text')">
+              Name
+            </th>
+            <th @click="() => sortTable('couplet_count')">
+              # Couplets
+            </th>
+            <th @click="() => sortTable('is_public')">
+              Is Public
+            </th>
+            <th @click="() => sortTable('updated_at')">
+              Last Modified
+            </th>
+            <th @click="() => sortTable('updated_by')">
+              Last Modified By
+            </th>
             <th /> <!-- radials -->
           </tr>
           <tr
@@ -58,12 +68,14 @@
 import { Lead } from '@/routes/endpoints'
 import { onBeforeMount, ref } from 'vue'
 import { RouteNames } from '@/routes/routes'
+import { sortArray } from '@/helpers'
 import RadialAnnotator from '@/components/radials/annotator/annotator.vue'
 import RadialNavigator from '@/components/radials/navigation/radial.vue'
 import VSpinner from '@/components/ui/VSpinner.vue'
 
 const keys = ref([])
 const loading = ref(true)
+const ascending = ref(false)
 
 onBeforeMount(() => {
   Lead.where({ extend: ['couplet_count', 'updater'] })
@@ -74,6 +86,11 @@ onBeforeMount(() => {
       loading.value = false
     })
 })
+
+function sortTable(sortProperty) {
+  keys.value = sortArray(keys.value, sortProperty, ascending.value)
+  ascending.value = !ascending.value
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/javascript/vue/tasks/leads/hub/components/LoadOtusButton.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/LoadOtusButton.vue
@@ -1,0 +1,43 @@
+<template>
+  <VBtn
+    v-if="!isLoading"
+    color="primary"
+    medium
+    @click="
+      () => {
+        isLoading = true
+        emit('click')
+      }
+    "
+  >
+    Load other otus from the key
+  </VBtn>
+  <div
+    v-else
+    class="otu_spinner"
+  >
+    <VSpinner
+      :show-legend="false"
+      :logo-size="{ width: '14px', height: '14px' }"
+      :legend-style="{ display: 'none' }"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import VBtn from '@/components/ui/VBtn/index.vue'
+import VSpinner from '@/components/ui/VSpinner.vue'
+
+const emit = defineEmits(['click'])
+
+const isLoading = ref(false)
+</script>
+
+<style lange="scss" scoped>
+.otu_spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+}
+</style>

--- a/app/javascript/vue/tasks/leads/new_lead/app.vue
+++ b/app/javascript/vue/tasks/leads/new_lead/app.vue
@@ -1,8 +1,14 @@
 <template>
   <CornerSpinner :loading="store.loading" />
   <h1>{{ store.root.id ? 'Editing' : 'Create a new key' }}</h1>
-  <!-- The back button on this link fails without data-turbolinks=false if the current url has an id param, but works fine if there's no id param. -->
-  <p><a href="/leads/list" data-turbolinks="false">List of Keys</a></p>
+  <p>
+    <a
+      :href="RouteNames.LeadsHub"
+      data-turbolinks="false"
+    >
+      Dichotomous Keys Hub
+    </a>
+  </p>
   <BlockLayout
     expand
     :set-expanded="!editingHasOccurred"

--- a/app/views/leads/_attributes.json.jbuilder
+++ b/app/views/leads/_attributes.json.jbuilder
@@ -21,4 +21,8 @@ else
   if extend_response_with('updater')
     json.updated_by lead.updater.name
   end
+
+  if extend_response_with('updated_at_in_words')
+    json.updated_at_in_words time_ago_in_words(lead.updated_at)
+  end
 end

--- a/app/views/leads/otus.json.jbuilder
+++ b/app/views/leads/otus.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @otus do |otu|
+  json.partial! '/otus/attributes', otu:, extensions: false
+end

--- a/app/views/leads/update_meta.json.jbuilder
+++ b/app/views/leads/update_meta.json.jbuilder
@@ -1,0 +1,3 @@
+json.lead do
+  json.partial! 'attributes', lead: @lead
+end

--- a/config/interface/object_radials.yml
+++ b/config/interface/object_radials.yml
@@ -111,6 +111,7 @@ GeographicItem:
 Lead:
   tasks:
     - show_lead_task
+    - leads_hub_task
   new: new_lead_task
   edit: new_lead_task
 Loan:

--- a/config/routes/data.rb
+++ b/config/routes/data.rb
@@ -427,6 +427,7 @@ resources :leads do
     post :delete_couplet
     post :duplicate
     get :all_texts
+    get :otus
   end
 end
 


### PR DESCRIPTION
Here's a screenshot of how it looks now:
![image](https://github.com/SpeciesFileGroup/taxonworks/assets/632915/7920c79d-9aae-4356-bcd2-38b70a8a83ba)

Otus and citations for a key are listed below that key's row in the keys table. The root otu and the root citations of each key are loaded right away; there's a button to load any other otus from a given key - in the screenshot that button has been clicked on the second and third keys already.

Like I said earlier, thoughts on both the ui and the ux welcome, and I don't have any expectations that this will make it into the current release but if you want to cherry-pick anything here feel free.