### PR TITLE
Key hub updates and updates to updated_by/at handling for keys

### DIFF
--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -10,17 +10,11 @@ class LeadsController < ApplicationController
     respond_to do |format|
       format.html {
         one_week_ago = Time.now.utc.to_date - 7
-        recents = []
-        roots = Lead.roots_with_data(sessions_current_project_id)
-        roots.each do |k|
-          if k.key_updated_at > one_week_ago
-            recents.push k
-          end
-        end
-
-        recents.sort! { |a, b| b[:key_updated_at] <=> a[:key_updated_at] }
-
-        @recent_objects = recents.take(10)
+        @recent_objects = Lead
+          .roots_with_data(sessions_current_project_id)
+          .where('key_updated_at > ?', one_week_ago)
+          .reorder(key_updated_at: :desc)
+          .limit(10)
 
         render '/shared/data/all/index'
       }

--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -35,8 +35,7 @@ class LeadsController < ApplicationController
   end
 
   def list
-    @leads = Lead.with_project_id(sessions_current_project_id)
-      .where('parent_id is null').order(:id).page(params[:page])
+    @leads = loaded_roots.page(params[:page])
   end
 
   # GET /leads/1/all_texts.json

--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -25,11 +25,7 @@ class LeadsController < ApplicationController
         render '/shared/data/all/index'
       }
       format.json {
-        @leads = Lead.with_project_id(sessions_current_project_id)
-          .where('parent_id is null')
-          .order(:text)
-          .page(params[:page])
-          .per(params[:per])
+        @leads = loaded_roots
       }
     end
   end

--- a/app/controllers/leads_controller.rb
+++ b/app/controllers/leads_controller.rb
@@ -35,9 +35,8 @@ class LeadsController < ApplicationController
   end
 
   def list
-    @leads = Lead
-      .roots_with_data(sessions_current_project_id)
-      .page(params[:page])
+    @leads = Lead.
+      roots_with_data(sessions_current_project_id).page(params[:page])
   end
 
   # GET /leads/1/all_texts.json

--- a/app/helpers/leads_helper.rb
+++ b/app/helpers/leads_helper.rb
@@ -41,4 +41,10 @@ module LeadsHelper
   def leads_search_form
     render('/leads/quick_search_form')
   end
+
+  # @return [True]
+  #   indicates a custom partial should be used, see list_helper.rb
+  def leads_recent_objects_partial
+    true
+  end
 end

--- a/app/javascript/vue/tasks/leads/hub/components/KeyOtus.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyOtus.vue
@@ -1,5 +1,12 @@
 <template>
-  Root otu:
+  <span>
+    <template v-if="key.otus_count > 0">
+      Otus({{ key.otus_count }}), root:
+    </template>
+    <template v-else>
+      <i>No otus in this key</i>
+    </template>
+  </span>
   <a
     v-if="key.otu"
     :href="key.otu.object_url"
@@ -8,42 +15,44 @@
     target="_blank"
   />
   <span
-    v-else
+    v-else-if="childOtusExist"
     class="otu"
   >
-    <i>No root otu.</i>
+    <i>no root otu,</i>
   </span>
 
-  <span
-    v-if="!key.child_otus"
-    class="otus_button"
-  >
-    <LoadOtusButton
-      @click="() => emit('loadOtusForKey')"
-    />
-  </span>
-  <span
-    v-else
-    class="otu"
-  >
-    <template v-if="key.child_otus.length">
-      Other otus:
-      <a
-        v-for="otu in key.child_otus"
-        :key="otu.id"
-        :href="otu.object_url"
-        v-html="otu.object_tag"
-        class="otu"
-        target="_blank"
+  <template v-if="childOtusExist">
+    &nbsp;other:
+    <span
+      v-if="!key.child_otus"
+      class="otus_button"
+    >
+      <LoadOtusButton
+        @click="() => emit('loadOtusForKey')"
       />
-    </template>
-    <span v-else class="otu">
-      <i>No other otus.</i>
     </span>
-  </span>
+    <span
+      v-else
+    >
+      <template v-if="key.child_otus.length">
+        <a
+          v-for="otu in key.child_otus"
+          :key="otu.id"
+          :href="otu.object_url"
+          v-html="otu.object_tag"
+          class="otu"
+          target="_blank"
+        />
+      </template>
+      <span v-else class="otu">
+        <i>none</i>
+      </span>
+    </span>
+  </template>
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import LoadOtusButton from './LoadOtusButton.vue'
 
 const props = defineProps({
@@ -57,6 +66,10 @@ const props = defineProps({
 const emit = defineEmits(['loadOtusForKey'])
 
 const key = props.keyProp
+
+const childOtusExist = computed(() => {
+  return key.otu_id ? key.otus_count > 1 : key.otus_count > 0
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -104,7 +104,7 @@
       </table>
 
       <div v-else-if="!loading">
-        No key currently available. Use the
+        No keys currently available. Use the
         <a
           :href="RouteNames.NewLead"
           data-turbolinks="false"

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -25,10 +25,10 @@
             >
               # Couplets
             </th>
-            <th @click="() => sortTable('updated_at')">
+            <th @click="() => sortTable('key_updated_at')">
               Last Modified
             </th>
-            <th @click="() => sortTable('updated_by')">
+            <th @click="() => sortTable('key_updated_by')">
               Last Modified By
             </th>
             <th class="width_shrink"/> <!-- radials -->
@@ -62,9 +62,9 @@
 
               <td>{{ key.couplet_count }}</td>
 
-              <td>{{ key.updated_at_in_words }}</td>
+              <td>{{ key.key_updated_at_in_words }}</td>
 
-              <td>{{ key.updated_by }}</td>
+              <td>{{ key.key_updated_by }}</td>
 
               <td>
                 <div class="horizontal-right-content gap-small">
@@ -136,13 +136,10 @@ const ascending = ref(false)
 
 onBeforeMount(async () => {
   const loadKeys = Lead.where({
-    extend: ['couplet_count', 'updater', 'updated_at_in_words', 'otu']
-   })
+    extend: ['otu']
+  })
     .then(({ body }) => {
       keys.value = body
-    })
-    .finally(() => {
-      loading.value = false
     })
 
   const loadCitations = Citation.where({
@@ -155,6 +152,9 @@ onBeforeMount(async () => {
       addCitationsToKeysList(value.body)
     })
     .catch(() => {})
+    .finally(() => {
+      loading.value = false
+    })
 })
 
 function addCitationsToKeysList(citations) {
@@ -193,7 +193,11 @@ function changeIsPublicState(key) {
         otus_count: key.otus_count,
         couplet_count: key.couplet_count,
         citations: key.citations,
-        child_otus: key.child_otus
+        child_otus: key.child_otus,
+        key_updated_at: body.lead.updated_at,
+        key_updated_at_in_words: body.lead.updated_at_in_words,
+        key_updated_by: body.lead.updated_by,
+        key_updated_by_id: body.lead.updated_by_id
       }
 
       addToArray(keys.value, updatedKey)

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -21,15 +21,9 @@
             </th>
             <th
               @click="() => sortTable('couplet_count')"
-              class="narrow_col"
+              class="width_shrink"
             >
               # Couplets
-            </th>
-            <th
-              @click="() => sortTable('is_public')"
-              class="narrow_col"
-            >
-              Is Public
             </th>
             <th @click="() => sortTable('updated_at')">
               Last Modified
@@ -37,7 +31,13 @@
             <th @click="() => sortTable('updated_by')">
               Last Modified By
             </th>
-            <th /> <!-- radials -->
+            <th class="width_shrink"/> <!-- radials -->
+            <th
+              @click="() => sortTable('is_public')"
+              class="width_shrink"
+            >
+              Is Public
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -62,6 +62,17 @@
 
               <td>{{ key.couplet_count }}</td>
 
+              <td>{{ key.updated_at_in_words }}</td>
+
+              <td>{{ key.updated_by }}</td>
+
+              <td>
+                <div class="horizontal-right-content gap-small">
+                  <RadialAnnotator :global-id="key.global_id" />
+                  <RadialNavigator :global-id="key.global_id" />
+                </div>
+              </td>
+
               <td>
                 <input
                   type="checkbox"
@@ -69,22 +80,11 @@
                   @click="() => changeIsPublicState(key)"
                 />
               </td>
-
-              <td>{{ key.updated_at_in_words }}</td>
-
-              <td>{{ key.updated_by }}</td>
-
-              <td class="width-shrink">
-                <div class="horizontal-right-content gap-small">
-                  <RadialAnnotator :global-id="key.global_id" />
-                  <RadialNavigator :global-id="key.global_id" />
-                </div>
-              </td>
             </tr>
 
             <tr :class="{ even: (index % 2 == 0)}">
               <td
-                colspan="3"
+                colspan="2"
                 class="extension_data"
               >
                 <KeyOtus
@@ -93,7 +93,7 @@
                 />
               </td>
               <td
-                colspan="3"
+                colspan="4"
                 class="extension_data"
               >
                 <KeyCitations :citations="key.citations" />
@@ -236,7 +236,7 @@ function loadOtusForKey(key) {
   margin-right: 1em;
   margin-bottom: 2em;
 }
-.width-shrink {
+.width_shrink {
   width: 1%;
 }
 .meta_row:not(:first-child) {
@@ -248,9 +248,6 @@ function loadOtusForKey(key) {
   padding-bottom: .5em;
 }
 .table_name_col {
-  width: 40%;
-}
-.narrow_col {
-  width: 4em;
+  width: 45%;
 }
 </style>

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -190,6 +190,7 @@ function changeIsPublicState(key) {
       const updatedKey = {
         ...body.lead,
         otu: key.otu,
+        otus_count: key.otus_count,
         couplet_count: key.couplet_count,
         citations: key.citations,
         child_otus: key.child_otus
@@ -239,7 +240,7 @@ function loadOtusForKey(key) {
   width: 1%;
 }
 .meta_row:not(:first-child) {
-  border-top: 2px solid #5D9ECE;
+  border-top: 2px solid var(--color-primary);
 }
 .extension_data {
   border-top: 4px dotted #eee;

--- a/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeysList.vue
@@ -135,9 +135,7 @@ const loading = ref(true)
 const ascending = ref(false)
 
 onBeforeMount(async () => {
-  const loadKeys = Lead.where({
-    extend: ['otu']
-  })
+  const loadKeys = Lead.where({ load_root_otus: true })
     .then(({ body }) => {
       keys.value = body
     })

--- a/app/javascript/vue/tasks/leads/hub/components/LoadOtusButton.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/LoadOtusButton.vue
@@ -10,7 +10,7 @@
       }
     "
   >
-    Load other otus from the key
+    Load others
   </VBtn>
   <div
     v-else

--- a/app/javascript/vue/tasks/leads/show/components/KeyList.vue
+++ b/app/javascript/vue/tasks/leads/show/components/KeyList.vue
@@ -36,8 +36,8 @@
           </td>
           <td>{{ key.couplet_count }}</td>
           <td>{{ key.is_public? 'True' : 'False' }}</td>
-          <td>{{ key.updated_at }}</td>
-          <td>{{ key.updated_by }}</td>
+          <td>{{ key.key_updated_at_in_words }}</td>
+          <td>{{ key.key_updated_by }}</td>
           <td>
             <div class="horizontal-right-content gap-small">
               <RadialNavigator :global-id="key.global_id" />
@@ -74,7 +74,7 @@ const keys = ref([])
 const loading = ref(true)
 
 onBeforeMount(() => {
-  Lead.where({ extend: ['otu', 'couplet_count', 'updater'] })
+  Lead.where({ extend: ['otu'] })
     .then(({ body }) => {
       keys.value = body
     })

--- a/app/javascript/vue/tasks/leads/show/components/KeyList.vue
+++ b/app/javascript/vue/tasks/leads/show/components/KeyList.vue
@@ -74,7 +74,7 @@ const keys = ref([])
 const loading = ref(true)
 
 onBeforeMount(() => {
-  Lead.where({ extend: ['otu'] })
+  Lead.where()
     .then(({ body }) => {
       keys.value = body
     })

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -242,6 +242,7 @@ class Lead < ApplicationRecord
     # corresponding key_updated_at).
     # TODO: couplet_count will be wrong if any couplets don't have exactly two
     # children.
+    # Returns an array of roots ordered by text.
     updated_at = Lead
       .joins('JOIN lead_hierarchies AS lh
         ON leads.id = lh.ancestor_id')
@@ -260,7 +261,7 @@ class Lead < ApplicationRecord
       ')
 
     root_leads = Lead
-      .joins("JOIN (#{updated_at.to_sql}) as leads_updated_at
+      .joins("JOIN (#{updated_at.to_sql}) AS leads_updated_at
         ON leads_updated_at.key_updated_at = leads.updated_at")
       .joins('JOIN users
         ON users.id = leads.updated_by_id')
@@ -269,9 +270,9 @@ class Lead < ApplicationRecord
         leads.updated_by_id AS key_updated_by_id,
         users.name AS key_updated_by
       ')
-      .order(:text)
+      .order('leads_updated_at.text')
 
-    return load_root_otus ? root_leads.includes(:otu) : root_leads
+    return load_root_otus ? root_leads.includes(:otu).to_a : root_leads.to_a
   end
 
   protected

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -230,19 +230,23 @@ class Lead < ApplicationRecord
     result
   end
 
+  # @return [ActiveRecord::Relation] ordered by text.
   # Returns all root nodes, with new properties:
   #  * couplet_count (number of couplets in the key)
   #  * otus_count (total number of distinct otus on the key)
   #  * key_updated_at (last time the key was updated)
   #  * key_updated_by_id (id of last person to update the key)
   #  * key_updated_by (name of last person to update the key)
+  #
+  # !! Note, the relation is a join, check your results when changing order
+  # or plucking, most of want you want is on the table joined to, which is
+  # not the default table for ordering and plucking.
   def self.roots_with_data(project_id, load_root_otus = false)
     # The updated_at subquery computes key_updated_at (and others), the second
     # query uses that to compute key_updated_by (by finding which node has the
     # corresponding key_updated_at).
     # TODO: couplet_count will be wrong if any couplets don't have exactly two
     # children.
-    # Returns an array of roots ordered by text.
     updated_at = Lead
       .joins('JOIN lead_hierarchies AS lh
         ON leads.id = lh.ancestor_id')
@@ -272,7 +276,7 @@ class Lead < ApplicationRecord
       ')
       .order('leads_updated_at.text')
 
-    return load_root_otus ? root_leads.includes(:otu).to_a : root_leads.to_a
+    return load_root_otus ? root_leads.includes(:otu) : root_leads
   end
 
   protected

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -230,6 +230,50 @@ class Lead < ApplicationRecord
     result
   end
 
+  # Returns all root nodes, with new properties:
+  #  * couplet_count (number of couplets in the key)
+  #  * otus_count (total number of distinct otus on the key)
+  #  * key_updated_at (last time the key was updated)
+  #  * key_updated_by_id (id of last person to update the key)
+  #  * key_updated_by (name of last person to update the key)
+  def self.roots_with_data(project_id, load_root_otus = false)
+    # The updated_at subquery computes key_updated_at (and others), the second
+    # query uses that to compute key_updated_by (by finding which node has the
+    # corresponding key_updated_at).
+    # TODO: couplet_count will be wrong if any couplets don't have exactly two
+    # children.
+    updated_at = Lead
+      .joins('JOIN lead_hierarchies AS lh
+        ON leads.id = lh.ancestor_id')
+      .joins('JOIN leads AS otus_source
+        ON lh.descendant_id = otus_source.id')
+      .where("
+        leads.parent_id IS NULL
+        AND leads.project_id = #{project_id}
+      ")
+      .group(:id)
+      .select('
+        leads.*,
+        COUNT(DISTINCT otus_source.otu_id) AS otus_count,
+        MAX(otus_source.updated_at) as key_updated_at,
+        (COUNT(otus_source.id) - 1) / 2 AS couplet_count
+      ')
+
+    root_leads = Lead
+      .joins("JOIN (#{updated_at.to_sql}) as leads_updated_at
+        ON leads_updated_at.key_updated_at = leads.updated_at")
+      .joins('JOIN users
+        ON users.id = leads.updated_by_id')
+      .select('
+        leads_updated_at.*,
+        leads.updated_by_id AS key_updated_by_id,
+        users.name AS key_updated_by
+      ')
+      .order(:text)
+
+    return load_root_otus ? root_leads.includes(:otu) : root_leads
+  end
+
   protected
 
   def root_has_title

--- a/app/views/leads/_attributes.json.jbuilder
+++ b/app/views/leads/_attributes.json.jbuilder
@@ -1,7 +1,32 @@
 if lead.nil?
   json.nil
 else
-  json.extract! lead, :id, :parent_id, :otu_id, :text, :origin_label, :description, :redirect_id, :link_out, :link_out_text, :position, :is_public, :project_id, :created_by_id, :updated_by_id, :created_at, :updated_at
+  json.extract! lead, :id, :parent_id, :otu_id, :text, :origin_label,
+    :description, :redirect_id, :link_out, :link_out_text, :position,
+    :is_public, :project_id, :created_by_id, :updated_by_id, :created_at,
+    :updated_at
+
+  if lead[:otus_count]
+    json.otus_count lead[:otus_count]
+  end
+
+  if lead[:couplet_count]
+    json.couplet_count lead[:couplet_count]
+  end
+
+  if lead[:key_updated_at]
+    json.key_updated_at lead[:key_updated_at]
+    json.key_updated_at_in_words time_ago_in_words(lead[:key_updated_at])
+  end
+
+  if lead[:key_updated_by_id]
+    json.key_updated_by_id lead[:key_updated_by_id]
+  end
+
+  if lead[:key_updated_by]
+    json.key_updated_by lead[:key_updated_by]
+  end
+
   json.partial! '/shared/data/all/metadata', object: lead
 
   if extend_response_with('otu')

--- a/app/views/leads/_attributes.json.jbuilder
+++ b/app/views/leads/_attributes.json.jbuilder
@@ -32,7 +32,7 @@ else
   if extend_response_with('otu')
     json.otu do
       if lead.otu_id.nil?
-        json.nil
+        json.nil!
       else
         json.partial! '/otus/attributes', otu: lead.otu, extensions: false
       end

--- a/app/views/leads/_recent_objects_list.html.erb
+++ b/app/views/leads/_recent_objects_list.html.erb
@@ -1,0 +1,6 @@
+<ul>
+  <% recent_objects.each do |r| -%>
+    <li><div><%= object_link(r) -%></div> <div><%= edit_object_link(r) -%>  <%= time_ago_in_words(r.key_updated_at) -%> ago </div></li>
+  <% end %>
+</ul>
+<%= content_tag(:em, "No recently updated or created records.") if recent_objects.empty? -%>

--- a/app/views/leads/index.json.jbuilder
+++ b/app/views/leads/index.json.jbuilder
@@ -1,3 +1,12 @@
 json.array!(@leads) do |lead|
+  if params[:load_root_otus]
+    json.otu do
+      if lead.otu.nil?
+        json.nil!
+      else
+        json.partial! '/otus/attributes', otu: lead.otu, extensions: false
+      end
+    end
+  end
   json.partial! 'attributes', lead:
 end

--- a/app/views/leads/list.html.erb
+++ b/app/views/leads/list.html.erb
@@ -17,7 +17,9 @@
           <td><%= lead.text %></td>
           <td><%= lead.all_children.size / 2 %></td>
           <td><%= lead.is_public %></td>
-          <%= fancy_metadata_cells_tag(lead) -%>
+          <%= content_tag(:td, lead[:key_updated_by]) +
+              content_tag(:td, time_ago_in_words(lead[:key_updated_at])) +
+              fancy_options_cells_tag(lead) -%>
       <% end %>
   <% end %>
   </tbody>

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -155,9 +155,6 @@ RSpec.describe Lead, type: :model do
     expect{root.destroy!}.to raise_error ActiveRecord::RecordNotDestroyed
   end
 
-  # !! Note that roots_with_data selects data from the second table of a join,
-  # but pluck can only select columns from the first table of the join, so
-  # don't use pluck here or you'll get the wrong results.
   context 'Retrieving roots data using roots_with_data' do
     specify 'returns the right number of roots' do
       lead.insert_couplet
@@ -165,7 +162,7 @@ RSpec.describe Lead, type: :model do
       root2.insert_couplet
 
       q = Lead.roots_with_data(project_id)
-      expect(q.to_a.map { |r| r.parent_id }).to eq([nil, nil])
+      expect(q.map { |r| r.parent_id }).to eq([nil, nil])
     end
 
     specify 'returns roots from the right project' do
@@ -175,14 +172,16 @@ RSpec.describe Lead, type: :model do
       root2 = FactoryBot.create(:valid_lead, project_id: p2.id)
 
       q = Lead.roots_with_data(project_id)
-      expect(q.to_a.map { |r| r.project_id }).to eq([project_id])
+      expect(q.map { |r| r.project_id }).to eq([project_id])
     end
 
-    specify 'returns a node, the correct node' do
-      lead.insert_couplet
+    specify 'returns roots ordered by text' do
+      root1 = FactoryBot.create(:valid_lead, text: 'b')
+      root2 = FactoryBot.create(:valid_lead, text: 'c')
+      root3 = FactoryBot.create(:valid_lead, text: 'a')
 
       q = Lead.roots_with_data(project_id)
-      expect(q.first).to eq(lead)
+      expect(q.map { |r| r.text }). to eq(['a', 'b', 'c'])
     end
 
     specify 'returns couplet_count' do


### PR DESCRIPTION
There are two issues resolved here:
* 3884, show updated-by and -at for the whole key, not just the root node
* The last two TODOs from @mjy on the keys hub: move Is Public to the last column and display number of otus in the key. Given work done for the updated_ issues I was able to add the otus count on load instead of only after actually loading/displaying all of the otus (which is why the two issues are being submitted together).

It took me some time to figure out some technical issues concerning the new query for root leads - see the commit message on the next to last commit (feel free to skip if it's all old news).

In short, the issue is that the query is a `.joins`. A simplified example is `q = T.joins('JOIN U on T.id = U.id).select('U.*')`. This is a contrived example, but two of the issues with this query are that, even though you selected the `U` side:
* If you do `q.order(:text)` where both `T` and `U` have a text column, you get ordered by `T.text`, not `U.text`
* If you do `q.pluck(:text)` you get texts from the `T` side of the relation, not the `U` side.
There are ways to call both order and pluck to get what you want, but it requires knowledge of how the query was created and (in my case) the alias used for the second table `U`. if you return this query from a function, users will have no idea of the issue. That's the current state of these commits. I'm not sure if this is a common kind of issue, or if there's a standard way to fix it, or if it's just the way it is. Thanks for taking a look!