### PR TITLE
A couple commits around import attributes

### DIFF
--- a/app/javascript/vue/components/Filter/Facets/shared/FacetImportAttribute/AddInternalPredicate.vue
+++ b/app/javascript/vue/components/Filter/Facets/shared/FacetImportAttribute/AddInternalPredicate.vue
@@ -6,7 +6,6 @@
         url="/data_attributes/import_predicate_autocomplete"
         param="term"
         placeholder="Type a predicate..."
-        v-model="internalPredicate"
         @get-item="
           (item) => {
             internalPredicate = item

--- a/app/javascript/vue/tasks/sources/new_source/components/bibtex.vue
+++ b/app/javascript/vue/tasks/sources/new_source/components/bibtex.vue
@@ -89,6 +89,7 @@ function createSource() {
       setParam('/tasks/sources/new_source', 'source_id', response.body.id)
       TW.workbench.alert.create('New source from BibTeX created.', 'notice')
     })
+    .catch(() => {})
     .finally(() => {
       creating.value = false
     })

--- a/lib/queries/concerns/data_attributes.rb
+++ b/lib/queries/concerns/data_attributes.rb
@@ -293,7 +293,7 @@ module Queries::Concerns::DataAttributes
       w = w.or(c)
     end
 
-    referenced_klass.joins(:internal_attributes).where(w)
+    referenced_klass.joins(:import_attributes).where(w)
   end
 
   def data_attribute_exact_pair_facet


### PR DESCRIPTION
I'm not sure if the original AddInternalPredicate.vue behavior was intentional? If so I'll resubmit.

I can add some tests for the import attribute filtering, just let me know (https://github.com/SpeciesFileGroup/taxonworks/blob/development/spec/lib/queries/concerns/data_attributes_spec.rb).