### PR TITLE
Add gap detection for Qualitative OM stuff and compute Symbols list for nexus export

### DIFF
--- a/app/helpers/observation_matrices_helper.rb
+++ b/app/helpers/observation_matrices_helper.rb
@@ -147,4 +147,24 @@ module ObservationMatricesHelper
     rows.join("\n")
   end
 
+  # @return [String]
+  #   the list of symbols actually used as character state labels, like
+  #   0 1 2 3 4 5 6 7 8 9 A
+  def nexus_symbol_list(descriptors)
+    max = 1
+    descriptors.each do |d|
+      case d.type
+      when 'Descriptor::Qualitative'
+        # Assumes non-gap character state labels are sequential starting at 0.
+        size = d.has_gap_state? ?
+          d.character_states.size - 1 : d.character_states.size
+        max = size if size > max
+      when 'Descriptor::PresenceAbsence'
+        max = 2 if max < 2
+      end
+    end
+
+    (0..max - 1).to_a
+      .map{|i| i > 9 ? LABEL_REPLACEMENT[i.to_s] : i.to_s}.compact.join(' ')
+  end
 end

--- a/app/models/character_state.rb
+++ b/app/models/character_state.rb
@@ -39,6 +39,10 @@ class CharacterState < ApplicationRecord
 
   validate :descriptor_kind
 
+  def is_gap?
+    label == '-' && name.downcase == 'gap'
+  end
+
   # @return [String] name of the character_state in a particular language
   # @parm :target
   #   one of :key, :description, nil

--- a/app/models/descriptor/qualitative.rb
+++ b/app/models/descriptor/qualitative.rb
@@ -1,11 +1,19 @@
 # A descriptor that has qualitative states. For example a phylogenetic character. Also used for descriptive matrices.
 # Note that presence/absence descriptors have their own subclass and should be represented there to maximize utility.
 #
-class Descriptor::Qualitative < Descriptor 
+class Descriptor::Qualitative < Descriptor
 
   has_many :character_states, foreign_key: :descriptor_id, inverse_of: :descriptor, dependent: :destroy
 
   accepts_nested_attributes_for :character_states, allow_destroy: true, reject_if: :reject_character_states
+
+  def has_gap_state?
+    character_states.each do |c|
+      return true if c.is_gap?
+    end
+
+    false
+  end
 
   protected
 

--- a/app/views/observation_matrices/export/nexus/_nexus.html.erb
+++ b/app/views/observation_matrices/export/nexus/_nexus.html.erb
@@ -23,7 +23,7 @@ Format
 <%= as_file ? '  ' : nb -%>datatype = STANDARD
 <%= as_file ? '  ' : nb -%>gap = -
 <%= as_file ? '  ' : nb -%>missing = ?
-<%= as_file ? '  ' : nb -%>symbols = "0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N P Q R S U V W X Y Z !";
+<%= as_file ? '  ' : nb -%>symbols = "<%= nexus_symbol_list(descriptors) -%>";
 Charstatelabels
 <% descriptors.each_with_index do |d, i| -%>
   <%= as_file ? '  ' : nb -%><%= "#{i+1} #{descriptor_matrix_label(d).html_safe} /".html_safe %> <%= d.character_states.order(:position).filter_map{|cs| "'#{cs.name}'".html_safe if !cs.is_gap?}.join(' ').html_safe if d.qualitative? -%>,

--- a/app/views/observation_matrices/export/nexus/_nexus.html.erb
+++ b/app/views/observation_matrices/export/nexus/_nexus.html.erb
@@ -26,7 +26,7 @@ Format
 <%= as_file ? '  ' : nb -%>symbols = "0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N P Q R S U V W X Y Z !";
 Charstatelabels
 <% descriptors.each_with_index do |d, i| -%>
-  <%= as_file ? '  ' : nb -%><%= "#{i+1} #{descriptor_matrix_label(d).html_safe} /".html_safe %> <%= d.character_states.order(:position).filter_map{|cs| "'#{cs.name}'".html_safe if cs.name.downcase != 'gap'}.join(' ').html_safe if d.qualitative? -%>,
+  <%= as_file ? '  ' : nb -%><%= "#{i+1} #{descriptor_matrix_label(d).html_safe} /".html_safe %> <%= d.character_states.order(:position).filter_map{|cs| "'#{cs.name}'".html_safe if !cs.is_gap?}.join(' ').html_safe if d.qualitative? -%>,
 <% end %>
 ;
 Matrix


### PR DESCRIPTION
Should a gap state be 'required' to have label '-'?