### PR TITLE
Export user preferences on project export

### DIFF
--- a/app/views/tasks/projects/data/index.html.erb
+++ b/app/views/tasks/projects/data/index.html.erb
@@ -7,6 +7,9 @@
   <div class="panel content">
     <h3> Export SQL </h3>
     <p><em>Generate a downloadable copy of the database (PostgreSQL dump) with all data referenced in this project. Includes Community data like Sources, People, and Repositories.</em></p>
+
+    <p><em>All exported user passwords are set to</em> 'taxonworks'.</p>
+
     <p> Restorable with <b>psql -U :username -d :database -f dump.sql</b>. Requires database to be created without tables (<b>rails db:create</b>) </p>
 
     <div>

--- a/lib/export/project_data/sql.rb
+++ b/lib/export/project_data/sql.rb
@@ -149,7 +149,8 @@ module ::Export::ProjectData::Sql
         created_by_id: user.created_by_id || 'NULL',
         updated_by_id: user.updated_by_id || 'NULL',
         is_administrator: user.is_administrator || 'NULL',
-        hub_tab_order: "'{#{conn.escape_string(user.hub_tab_order.join(','))}}'"
+        hub_tab_order: "'{#{conn.escape_string(user.hub_tab_order.join(','))}}'",
+        preferences: %['"#{conn.escape_string(JSON.generate(user.preferences)).gsub('"', '\"')}"']
       }.merge!(
         if members.include?(user.id)
           {


### PR DESCRIPTION
I tested this locally with 1) default (reset) preferences, and 2)
```
{"layout"=>
  {"tasks::digitize::collectionObjects::hideBuffered"=>true,
   "tasks::digitize::collectionObjects::hideCatalogNumber"=>true,
   "tasks::digitize::LeftColumnOrder"=>["BiologicalAssociation", "TaxonDeterminationLayout", "TypeMaterial"],
   "tasks::extract::componentsOrder"=>["ByComponent", "MadeComponent", "ProtocolsComponent", "OriginComponent", "IdentifierComponent", "RepositoryComponent", "CustomAttributes"]},
 "disable_chime"=>false,
 "items_per_list_page"=>20,
 "taxon_name_autocomplete_redirects_to_valid"=>false,
 "default_hub_tab_order"=>["tasks", "data", "favorite"]}
```

Two caveats, please send back to me if there's any concern:
* I didn't try all of the preferences, maybe there are some that are more complicated?
* as far as I could tell the quoting gymnastics are necessary, but I didn't check/don't know if they do the right thing if there's already an escaped `"` in the preferences (since I'm expecting that never happens...)