### PR TITLE
Fix to put cursor in input on DestroyConfirmation modal

### DIFF
--- a/app/javascript/vue/components/radials/navigation/components/DestroyConfirmation.vue
+++ b/app/javascript/vue/components/radials/navigation/components/DestroyConfirmation.vue
@@ -64,7 +64,9 @@ export default {
   },
 
   mounted() {
-    this.$refs.inputtext.focus()
+    this.$nextTick(() => {
+      this.$refs.inputtext.focus()
+    })
   },
 
   methods: {


### PR DESCRIPTION
Was throwing a this.$refs.inputtext nil error before.