### PR TITLE
Some AlternateValueAnnotator component updates

### DIFF
--- a/app/javascript/vue/components/radials/annotator/components/alternate_value_annotator.vue
+++ b/app/javascript/vue/components/radials/annotator/components/alternate_value_annotator.vue
@@ -210,9 +210,11 @@ function loadAlternateValue({
     language_id
   }
 
-  Language.find(language_id).then(({ body }) => {
-    language.value = body
-  })
+  if (language_id) {
+    Language.find(language_id).then(({ body }) => {
+      language.value = body
+    })
+  }
 }
 
 function removeItem(item) {

--- a/app/javascript/vue/components/radials/annotator/components/alternate_value_annotator.vue
+++ b/app/javascript/vue/components/radials/annotator/components/alternate_value_annotator.vue
@@ -1,76 +1,78 @@
 <template>
-  <div class="alternate_values_annotator">
-    <VSwitch
-      :options="Object.values(TYPE_LIST)"
-      use-index
-      v-model="alternateType"
-    />
-    <ul class="no_bullets content">
-      <li
-        v-for="(item, key) in values"
-        :key="item"
+  <div>
+    <div class="alternate_values_annotator">
+      <VSwitch
+        :options="Object.values(TYPE_LIST)"
+        use-index
+        v-model="alternateType"
+      />
+      <ul class="no_bullets content">
+        <li
+          v-for="(item, key) in values"
+          :key="item"
+        >
+          <label>
+            <input
+              type="radio"
+              v-model="alternateValue.alternate_value_object_attribute"
+              :value="key"
+            />
+            "{{ key }}" -> {{ item }}
+          </label>
+        </li>
+      </ul>
+
+      <fieldset v-if="alternateValue.type === ALTERNATE_VALUE_TRANSLATION">
+        <legend>Language</legend>
+        <SmartSelector
+          v-model="language"
+          model="languages"
+          klass="AlternateValue"
+          label="english_name"
+          @selected="setLanguage"
+        />
+        <SmartSelectorItem
+          :item="language"
+          label="english_name"
+          @unset="setLanguage"
+        />
+      </fieldset>
+
+      <div class="field margin-medium-top">
+        <input
+          class="normal-input full_width"
+          type="text"
+          v-model="alternateValue.value"
+          placeholder="Value"
+        />
+      </div>
+
+      <VBtn
+        class="margin-small-right"
+        color="create"
+        medium
+        :disabled="!validateFields"
+        @click="saveAlternateValue"
       >
-        <label>
-          <input
-            type="radio"
-            v-model="alternateValue.alternate_value_object_attribute"
-            :value="key"
-          />
-          "{{ key }}" -> {{ item }}
-        </label>
-      </li>
-    </ul>
-
-    <fieldset v-if="alternateValue.type === ALTERNATE_VALUE_TRANSLATION">
-      <legend>Language</legend>
-      <SmartSelector
-        v-model="language"
-        model="languages"
-        klass="AlternateValue"
-        label="english_name"
-        @selected="setLanguage"
-      />
-      <SmartSelectorItem
-        :item="language"
-        label="english_name"
-        @unset="setLanguage"
-      />
-    </fieldset>
-
-    <div class="field margin-medium-top">
-      <input
-        class="normal-input full_width"
-        type="text"
-        v-model="alternateValue.value"
-        placeholder="Value"
-      />
+        Save
+      </VBtn>
+      <VBtn
+        color="primary"
+        medium
+        @click="reset"
+      >
+        New
+      </VBtn>
     </div>
 
-    <VBtn
-      class="margin-small-right"
-      color="create"
-      medium
-      :disabled="!validateFields"
-      @click="saveAlternateValue"
-    >
-      Save
-    </VBtn>
-    <VBtn
-      color="primary"
-      medium
-      @click="reset"
-    >
-      New
-    </VBtn>
+    <DisplayList
+      label="object_tag"
+      :list="list"
+      edit
+      @edit="loadAlternateValue"
+      @delete="removeItem"
+    />
   </div>
-
-  <DisplayList
-    label="object_tag"
-    :list="list"
-    edit
-    @edit="loadAlternateValue"
-    @delete="removeItem"
-  />
 </template>
 
 <script setup>

--- a/app/javascript/vue/components/radials/annotator/components/alternate_value_annotator.vue
+++ b/app/javascript/vue/components/radials/annotator/components/alternate_value_annotator.vue
@@ -190,9 +190,9 @@ function reset() {
   language.value = undefined
 }
 
-function setLanguage(language) {
-  alternateValue.value.language_id = language?.id
-  language.value = language
+function setLanguage(new_language) {
+  alternateValue.value.language_id = new_language?.id
+  language.value = new_language
 }
 
 function loadAlternateValue({


### PR DESCRIPTION
STR: Find a radial annotator for something that has alternate values, like GAs, open the Alternate Values panel from the radial.
* Exceptions when you try to edit an Abbreviation, Misspelling, or Alternate Spelling (due to an exception on `Language.find(null)`) - those are the alternate value options that don't set a language
* Exception/unable to delete the existing language when editing a Translation (due to a `language` parameter shadowing a `language` ref I think)
* Vue warnings in the console in development about AlternateValueAnnotator not having a root node - I added a root div which silences the warnings and looks right, I think that's the right fix here? (Sorry the diff on that is so mangled here)