### PR TITLE
Modernize docker compose usage & language

### DIFF
--- a/.github/docker-tests/compose.yml
+++ b/.github/docker-tests/compose.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   taxonworks:
     build: ./docker-image-taxonworks

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,6 @@
 #
-# docker-compose targets development only
+# docker compose targets development only
 #
-version: '2'
 services:
   app:
     build:
@@ -30,6 +29,7 @@ services:
       - '0.0.0.0:15432:5432'
     volumes:
       - pg12:/var/lib/postgresql/data
+      - ./unzip:/mnt/unzip
   webpack:
     build:
       context: .

--- a/exe/docker_compose_start.sh
+++ b/exe/docker_compose_start.sh
@@ -13,7 +13,7 @@ function wait_for_db() {
   done
 }
 # Could do sanity check of environment here
-# * Raise a warning of the database.yml file looks like it is setup for docker-compose
+# * Raise a warning if the database.yml file looks like it is setup for docker compose
 
 wait_for_db "postgres10_legacy"
 wait_for_db "db"


### PR DESCRIPTION
I think the old versions of `docker-compose` have percolated out of dev environments by now, since v2 was released in 2020. See https://docs.docker.com/compose/releases/migrate

* `docker-compose` –> `docker compose`
* `docker-compose.yml` –> `compose.yml`
* Remove deprecated "version" tag from `compose.yml` (it is causing warnings in the dev env)