### PR TITLE
Fix 500 in check for reverse of a valid origin relationship pairing

### DIFF
--- a/app/models/origin_relationship.rb
+++ b/app/models/origin_relationship.rb
@@ -75,9 +75,20 @@ class OriginRelationship < ApplicationRecord
     errors.add(:new_object, "#{new_object.class.name} is not a legal part of an origin relationship") if !(new_object.class < Shared::OriginRelationship)
   end
 
+  def new_object_can_be_derived_from(klass)
+    new_object.respond_to?(:valid_old_object_classes) &&
+      new_object.valid_old_object_classes.include?(klass)
+  end
+
+  def old_object_can_be_origin_of(klass)
+    old_object.respond_to?(:valid_new_object_classes) &&
+      old_object.valid_new_object_classes.include?(klass)
+  end
+
   def pairing_is_allowed
-    errors.add(:old_object, "#{old_object_type} is not a valid origin relationship old object of a #{old_object.class.name}") if !new_object.valid_old_object_classes.include?(old_object.class.name)
-    errors.add(:new_object, "#{new_object_type} is not a valid origin relationship new object of a #{new_object.class.name}") if !old_object.valid_new_object_classes.include?(new_object.class.name)
+    errors.add(:old_object, "#{old_object_type} is not a valid origin relationship old object of a #{new_object.class.name}") unless new_object_can_be_derived_from(old_object.class.name)
+
+    errors.add(:new_object, "#{new_object_type} is not a valid origin relationship new object of a #{old_object.class.name}") unless old_object_can_be_origin_of(new_object.class.name)
   end
 
   def not_a_clone


### PR DESCRIPTION
This 500 only occurs if you try to do something that (probably) doesn't make sense.

For example, CO is a valid origin of AD. The UI allows you to reverse that pairing and attempt to save an AD as the origin of a CO: without this fix that save raises *since AD is the origin of **NO** origin relationships* and therefore never has its `valid_new_object_classes` method defined.