### PR TITLE
Edit taxon name fixups

### DIFF
--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/manageSynonym.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/manageSynonym.vue
@@ -136,6 +136,7 @@
 
 <script>
 import { GetterNames } from '../store/getters/getters'
+import { RouteNames } from '@/routes/routes'
 import { TaxonName } from '@/routes/endpoints'
 import RadialAnnotator from '@/components/radials/annotator/annotator'
 import BlockLayout from '@/components/layout/BlockLayout'
@@ -207,7 +208,7 @@ export default {
     loadTaxon(id) {
       if (window.confirm('Are you sure you want to load this taxon name?')) {
         window.open(
-          `/tasks/nomenclature/new_taxon_name?taxon_name_id=${id}`, `_self`
+          `${RouteNames.NewTaxonName}?taxon_name_id=${id}`, `_self`
         )
       }
     },

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/manageSynonym.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/manageSynonym.vue
@@ -206,7 +206,9 @@ export default {
 
     loadTaxon(id) {
       if (window.confirm('Are you sure you want to load this taxon name?')) {
-        window.open(`/tasks/nomenclature/new_taxon_name/${id}`, `_self`)
+        window.open(
+          `/tasks/nomenclature/new_taxon_name?taxon_name_id=${id}`, `_self`
+        )
       }
     },
 

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/relationshipPicker.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/relationshipPicker.vue
@@ -280,12 +280,11 @@ export default {
       this.objectLists.tree = copyList.tree || {}
       this.objectLists.commonList = copyList.common || {}
       this.objectLists.allList = copyList.all || {}
-      this.addType(this.objectLists.allList)
-      this.objectLists.allList = Object.keys(this.objectLists.allList).map(
-        (key) => this.objectLists.allList[key]
-      )
-      this.getTreeList(this.objectLists.tree, copyList.all)
       this.addType(this.objectLists.commonList)
+      this.addType(this.objectLists.allList)
+      this.objectLists.commonList = Object.values(this.objectLists.commonList)
+      this.objectLists.allList = Object.values(this.objectLists.allList)
+      this.getTreeList(this.objectLists.tree, copyList.all)
     },
 
     activeModal(value) {


### PR DESCRIPTION
STR commit 1: create a synonym where the old name has children, then go to manage synonymy in Edit Taxon Name and click green edit button --> bad link

STR commit 2: go to a taxon with a relationship, goto relationships section, click edit green --> in development mode in the console see [Vue warn]: Invalid prop: type check failed for prop "objectLists". Expected Array, got Object  
  at <CommonList key=1 object-lists= 