### PR TITLE
Comprehensive digitization can sometimes fail to save identifiers

### DIFF
--- a/app/javascript/vue/tasks/digitize/components/catalogueNumber/catalogNumber.vue
+++ b/app/javascript/vue/tasks/digitize/components/catalogueNumber/catalogNumber.vue
@@ -64,8 +64,7 @@
             }"
             type="text"
             v-model="store.identifier.identifier"
-            @input="checkIdentifier"
-            @change="() => (store.identifier.isUnsaved = true)"
+            @input="identifierChanged"
           />
           <label>
             <input
@@ -182,6 +181,11 @@ function handleTabChange(tab) {
   if (tab === 'new') {
     widgetNamespaceRef.value.open()
   }
+}
+
+function identifierChanged() {
+  store.identifier.isUnsaved = true
+  checkIdentifier()
 }
 
 function checkIdentifier() {

--- a/app/javascript/vue/tasks/digitize/components/recordNumber/recordNumber.vue
+++ b/app/javascript/vue/tasks/digitize/components/recordNumber/recordNumber.vue
@@ -65,8 +65,7 @@
               'validate-identifier': store.existingIdentifiers.length
             }"
             v-model="store.identifier.identifier"
-            @input="checkIdentifier"
-            @change="() => (store.identifier.isUnsaved = true)"
+            @input="identifierChanged"
           />
           <label>
             <input
@@ -167,6 +166,11 @@ watch(
   },
   { immediate: true }
 )
+
+function identifierChanged() {
+  store.identifier.isUnsaved = true
+  checkIdentifier()
+}
 
 function checkIdentifier() {
   clearTimeout(saveRequest)

--- a/app/javascript/vue/tasks/field_occurrences/new/components/FieldOccurenceForm/Identifier/IdentifierForm.vue
+++ b/app/javascript/vue/tasks/field_occurrences/new/components/FieldOccurenceForm/Identifier/IdentifierForm.vue
@@ -30,8 +30,7 @@
                   existingIdentifier && !isCreatedIdentifierCurrent
               }"
               type="text"
-              @input="findExistingIdentifier"
-              @change="() => (store.identifier.isUnsaved = true)"
+              @input="identifierChanged"
               v-model="store.identifier.identifier"
             />
             <label>
@@ -100,6 +99,11 @@ const isCreatedIdentifierCurrent = computed(
 watch(existingIdentifier, (newVal) => {
   settings.saveIdentifier = !newVal
 })
+
+function identifierChanged() {
+  store.identifier.isUnsaved = true
+  findExistingIdentifier()
+}
 
 function findExistingIdentifier() {
   if (timeOut) {


### PR DESCRIPTION
STR:
* In digitize, save CO identifier+namespace (either Catalog Number pane or Record Number pane) or load one that has it already
* change the identifier without leaving that input
* use alt+s to save the form, see "Saved successfully"

Reload the page and see the identifier was not updated, because identifier.isUnsaved is linked to the identifier input @change which is only triggered when you leave the input.