### PR TITLE
SimpleMappr fixups

### DIFF
--- a/app/helpers/vendor/simple_mappr_helper.rb
+++ b/app/helpers/vendor/simple_mappr_helper.rb
@@ -5,14 +5,14 @@ module Vendor::SimpleMapprHelper
     # TODO: Add support for FieldOccurrence, or by Otu Filter
 
     if params[:collection_object_query]
-      a = ::Queries::DwcOccurrence::Filter.new(collection_object_query: params[:collection_object_query]).all.select(:id, :scientificName, :decimalLatitude, :decimalLongitude)
+      a = ::Queries::DwcOccurrence::Filter.new(collection_object_query: params[:collection_object_query]).all.select(:id, :scientificName, :occurrenceID, :decimalLatitude, :decimalLongitude)
 
       return nil if a.size > 10_000
 
       d = {}
 
       a.find_each do |i|
-        k = i.scientificName
+        k = i.scientificName || "[Occurrence id: #{i.occurrenceID}]"
         d[k] ||= []
         d[k].push [i.decimalLatitude, i.decimalLongitude].compact.join(',').presence
       end

--- a/app/helpers/vendor/simple_mappr_helper.rb
+++ b/app/helpers/vendor/simple_mappr_helper.rb
@@ -19,6 +19,14 @@ module Vendor::SimpleMapprHelper
         end
       end
 
+      return CSV::Table.new([CSV::Row.new([], [])]) if d.empty?
+
+      if d.count == 1
+        # SimpleMappr (currently) requires at least 2 columns - otherwise it
+        # parses an input file incorrectly - so add an empty second column.
+        d['sm_empty_column'] = []
+      end
+
       h = d.keys.dup
       z =  CSV::Row.new(h,h,true)
 

--- a/app/helpers/vendor/simple_mappr_helper.rb
+++ b/app/helpers/vendor/simple_mappr_helper.rb
@@ -13,8 +13,10 @@ module Vendor::SimpleMapprHelper
 
       a.find_each do |i|
         k = i.scientificName || "[Occurrence id: #{i.occurrenceID}]"
-        d[k] ||= []
-        d[k].push [i.decimalLatitude, i.decimalLongitude].compact.join(',').presence
+        if i.decimalLatitude && i.decimalLongitude
+          d[k] ||= []
+          d[k].push [i.decimalLatitude, i.decimalLongitude].join(',')
+        end
       end
 
       h = d.keys.dup

--- a/app/helpers/vendor/simple_mappr_helper.rb
+++ b/app/helpers/vendor/simple_mappr_helper.rb
@@ -21,8 +21,12 @@ module Vendor::SimpleMapprHelper
       z =  CSV::Row.new(h,h,true)
 
       x = d.values
+      max_points_count = x.max {|a, b| a.length <=> b.length}.length
       y = x.shift
 
+      # The array zip here is based (in part) on the length of y, so make sure y
+      # is as long as the longest d.values array.
+      y.fill(nil, y.length...max_points_count)
       t = y.zip(*x)
 
       tbl = CSV::Table.new([z], headers: true ) # , col_sep: "\t", encoding: Encoding::UTF_8)

--- a/app/views/tasks/gis/simplemappr/index.html.erb
+++ b/app/views/tasks/gis/simplemappr/index.html.erb
@@ -1,13 +1,19 @@
 <h1> Simplemappr table </h1>
-<p> Only selected Collection Objects with geographic data are included here. </p>
+<p> Only Collection Objects with geographic data are displayed here. </p>
 <em> Paste the copied table into a text file, name it your_data.txt. The file should load at simplemappr. </em>
 <br/>
 <br/>
 
 <% d = simple_mappr_data(params) %>
 
-<% if d&.headers.length > 13 %>
-  <%= tag.div("Only the first 13 of the #{d.headers.length} columns will be loaded by SimpleMappr.", class: [:feedback, 'feedback-warning'])  %>
+<% if d&.headers&.length.present? %>
+  <% if d.headers.length == 0 %>
+    <%= tag.div("None of the provided Collection Objects reference geographic data.", class: [:feedback, 'feedback-warning'])  %>
+  <% elsif d.headers.length == 2 && d.headers.second == 'sm_empty_column' %>
+    <%= tag.div("SimpleMappr can't read a single column of data, so a required 'sm_empty_column' was added as well - it has no effect on the created map.", class: [:feedback, 'feedback-warning'])  %>
+  <% elsif d.headers.length > 13 %>
+    <%= tag.div("Only the first 13 of the #{d.headers.length} columns will be loaded by SimpleMappr.", class: [:feedback, 'feedback-warning'])  %>
+  <% end %>
 <% end %>
 
 <% if d.nil? %>

--- a/app/views/tasks/gis/simplemappr/index.html.erb
+++ b/app/views/tasks/gis/simplemappr/index.html.erb
@@ -1,10 +1,14 @@
 <h1> Simplemappr table </h1>
-<p> Only Collection Objects with geographic data are included here. </p>
+<p> Only selected Collection Objects with geographic data are included here. </p>
 <em> Paste the copied table into a text file, name it your_data.txt. The file should load at simplemappr. </em>
 <br/>
 <br/>
 
 <% d = simple_mappr_data(params) %>
+
+<% if d&.headers.length > 13 %>
+  <%= tag.div("Only the first 13 of the #{d.headers.length} columns will be loaded by SimpleMappr.", class: [:feedback, 'feedback-warning'])  %>
+<% end %>
 
 <% if d.nil? %>
   <%= tag.div('No data, or > 10k rows returned.', class: [:feedback, 'feedback-warning'])  %>

--- a/app/views/tasks/gis/simplemappr/index.html.erb
+++ b/app/views/tasks/gis/simplemappr/index.html.erb
@@ -1,4 +1,5 @@
 <h1> Simplemappr table </h1>
+<p> Only Collection Objects with geographic data are included here. </p>
 <em> Paste the copied table into a text file, name it your_data.txt. The file should load at simplemappr. </em>
 <br/>
 <br/>
@@ -10,6 +11,6 @@
 <% else %>
   <%= copy_table_to_clipboard('div#simplemappr') %>
   <div id="simplemappr">
-    <%= table_from_csv( d ) %> 
+    <%= table_from_csv( d ) %>
   </div>
 <% end %>


### PR DESCRIPTION
The main fix here is to the zip call: with existing code the number of points associated with the first CO in the COs list becomes the max number of points displayed for any CO in the list.

The other commits handle some edge cases associated with SimpleMappr behavior:
* make sure every CO has a header name, otherwise SimpleMappr (rightfully) gets confused
* if there's only one CO - so only one column of data sent to SimpleMappr - then SimpleMappr parses wrong and errors out
* SimpleMappr won't process more than 13 columns in a file (extra columns are silently dropped). (It may process more if you add extra columns by hand.)
* Columns (COs) with no geographic data don't appear in any way in the output of SimpleMappr, so I've dropped them in the TW UI output as well to give more room for 13 populated COS (I'm not sure if this is a "good" thing or not).