### PR TITLE
Matrix/row fixups

### DIFF
--- a/app/controllers/observation_matrices_controller.rb
+++ b/app/controllers/observation_matrices_controller.rb
@@ -40,6 +40,7 @@ class ObservationMatricesController < ApplicationController
 
   # GET /observation_matrices/1/edit
   def edit
+    redirect_to new_matrix_task_path observation_matrix_id: @observation_matrix.id
   end
 
   # POST /observation_matrices

--- a/app/controllers/observation_matrix_row_items_controller.rb
+++ b/app/controllers/observation_matrix_row_items_controller.rb
@@ -75,11 +75,12 @@ class ObservationMatrixRowItemsController < ApplicationController
   # POST /observation_matrix_row_items/batch_create?batch_type=tags&observation_matrix_id=123&keyword_id=456&klass=Otu
   # POST /observation_matrix_row_items/batch_create?batch_type=pinboard&observation_matrix_id=123&klass=Otu
   def batch_create
-    if @loan_items = ObservationMatrixRowItem.batch_create(batch_params)
+    begin
+      ObservationMatrixRowItem.batch_create(batch_params)
       render :index
-    else
-      render json: {success: false}
-    end 
+    rescue TaxonWorks::Error => e
+      render json: { errors: e.to_s }, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/javascript/vue/tasks/observation_matrices/new/components/rows/batchView.vue
+++ b/app/javascript/vue/tasks/observation_matrices/new/components/rows/batchView.vue
@@ -3,14 +3,16 @@
     <div
       class="tag_list"
       v-for="(object, key) in list.totals"
-      v-if="object">
-      <div class="capitalize tag_label">{{ key }}</div>
-      <div class="tag_total">{{ object }}</div>
-      <button
-        class="button normal-input button-submit"
-        type="button"
-        @click="batchLoad(key, matrixId)">Create
-      </button>
+    >
+      <template v-if="object">
+        <div class="capitalize tag_label">{{ key }}</div>
+        <div class="tag_total">{{ object }}</div>
+        <button
+          class="button normal-input button-submit"
+          type="button"
+          @click="batchLoad(key, matrixId)">Create
+        </button>
+      </template>
     </div>
   </div>
 </template>
@@ -39,14 +41,19 @@
     },
     methods: {
       batchLoad(classType, matrixId) {
-        let object = {
+        const object = {
           observation_matrix_id: matrixId,
           batch_type: this.batchType,
           klass: classType
         }
-        CreateRowBatchLoad(object).then((response) => {
-          this.$store.dispatch(ActionNames.GetMatrixObservationRows, { per: 500 })
-        })
+        CreateRowBatchLoad(object)
+          .then((response) => {
+              this.$store.dispatch(
+                ActionNames.GetMatrixObservationRows, { per: 500 }
+              )
+            }
+          )
+          .catch(() => {})
       }
     }
   }

--- a/app/javascript/vue/tasks/observation_matrices/new/components/rows/keywordView.vue
+++ b/app/javascript/vue/tasks/observation_matrices/new/components/rows/keywordView.vue
@@ -18,7 +18,7 @@
             v-if="key != 'total'"
             class="separate-left button normal-input button-delete"
             type="button"
-            @click="removeKeyword(matrixId, key)">Remove
+            @click="removeKeyword(object.object.id, key)">Remove
           </button>
         </template>
       </div>

--- a/app/javascript/vue/tasks/observation_matrices/new/components/rows/keywordView.vue
+++ b/app/javascript/vue/tasks/observation_matrices/new/components/rows/keywordView.vue
@@ -49,20 +49,28 @@
     },
     methods: {
       batchLoad(classType, matrixId, type, keywordId) {
-        let object = {
+        const object = {
           observation_matrix_id: matrixId,
           keyword_id: keywordId,
           batch_type: 'tags',
           klass: (type == 'total' ? undefined : type)
         }
-        CreateRowBatchLoad(object).then((response) => {
-          this.$store.dispatch(ActionNames.GetMatrixObservationRows, { per: 500 })
-        })
+        CreateRowBatchLoad(object)
+          .then((response) => {
+            this.$store.dispatch(
+              ActionNames.GetMatrixObservationRows, { per: 500 }
+            )
+          })
+          .catch(() => {})
       },
       removeKeyword(id, type) {
-        BatchRemoveKeyword(id, type).then(response => {
-          this.$store.dispatch(ActionNames.GetMatrixObservationRows, { per: 500 })
-        })
+        BatchRemoveKeyword(id, type)
+          .then(response => {
+            this.$store.dispatch(
+              ActionNames.GetMatrixObservationRows, { per: 500 }
+            )
+          })
+          .catch(() => {})
       }
     }
   }

--- a/app/javascript/vue/tasks/observation_matrices/new/store/actions/createRowItem.js
+++ b/app/javascript/vue/tasks/observation_matrices/new/store/actions/createRowItem.js
@@ -3,15 +3,17 @@ import ActionNames from '../actions/actionNames'
 
 export default ({ state, dispatch }, data) =>
   new Promise((resolve, reject) => {
-    ObservationMatrixRowItem.create({ observation_matrix_row_item: data }).then(
-      (response) => {
-        dispatch(ActionNames.GetMatrixObservationRows, { per: 500 })
-        dispatch(ActionNames.GetMatrixObservationRowsDynamic, state.matrix.id)
-        TW.workbench.alert.create(
-          'Row item was successfully created.',
-          'notice'
-        )
-        return resolve(response)
-      }
-    )
+    ObservationMatrixRowItem.create({ observation_matrix_row_item: data })
+      .then(
+        (response) => {
+          dispatch(ActionNames.GetMatrixObservationRows, { per: 500 })
+          dispatch(ActionNames.GetMatrixObservationRowsDynamic, state.matrix.id)
+          TW.workbench.alert.create(
+            'Row item was successfully created.',
+            'notice'
+          )
+          return resolve(response)
+        }
+      )
+      .catch(() => {})
   })


### PR DESCRIPTION
These might be a couple of 7 year old bugs - I did try to use the pinboard to add a matrix row item recently though...

These are associated with the `Rows` panel of the New/Edit Observation Matrix task:

![image](https://github.com/user-attachments/assets/9a2ef9b7-13f7-4824-ae6c-0be7f6bd2166)

STR commit 1: Add a CO and/or otu to the pinboard, click the Pinboard tab: nothing is displayed.
STR commit 2: try to add a row that already exists from the Keywords, Pinboard, or Search tab, get a red screen of death or a 500 (the 'From Another Matrix' tab doesn't allow you to add an existing row)
STR commit 3: Add tags to otus and/or COs, click on the Keywords tab, click the Remove button for either otus or COs: nothing happens (but it could remove the wrong tag if there's a tag with the same id as the current matrix id). Expected result: that tag is removed from ALL otus or COs, whichever was selected (would a warning/explanation be expected here?)