### PR TITLE
Fix exception on mouseover of AD region in show AD

### DIFF
--- a/app/assets/javascripts/views/tasks/gis/otu_distribution_data/show.js.es6
+++ b/app/assets/javascripts/views/tasks/gis/otu_distribution_data/show.js.es6
@@ -11,7 +11,7 @@ Object.assign(TW.views.tasks.gis.otu_distribution, {
     init_otu_distribution_data();
 
     function init_otu_distribution_data() {
-      
+
         if (document.getElementById('_displayed_distribution_form') != null) {
           var newfcdata = $("#_displayed_distribution_form");
           var fcdata = newfcdata.data('feature-collection');
@@ -25,7 +25,7 @@ Object.assign(TW.views.tasks.gis.otu_distribution, {
             add_otu_distribution_data_listeners(otu_map);
           });
         }
-      
+
     };
 
     function add_otu_distribution_data_listeners(map) {
@@ -75,9 +75,11 @@ Object.assign(TW.views.tasks.gis.otu_distribution, {
         map.data.overrideStyle(event.feature, {fillOpacity: 1.0});  // bolder
         map.data.overrideStyle(event.feature, {icon: TW.vendor.lib.google.maps.mapIcons['white']});       // highlight markers
         //if (event.feature.getProperty('label') != undefined) {
-        document.getElementById("displayed_distribution_style").textContent = event.feature.getProperty('label');
-        //$("#displayed_distribution_style").html(event.feature.getProperty('label'));
+        if (document.getElementById('displayed_distribution_style') != null) {
+          document.getElementById("displayed_distribution_style").textContent = event.feature.getProperty('label');
+          //$("#displayed_distribution_style").html(event.feature.getProperty('label'));
         //}
+        }
       });
 
       map.data.addListener('mouseout', function (event) {


### PR DESCRIPTION
STR:
* Visit asserted_distributions/1
* mouse over the shaded AD region in the map
* see an error in the console: `Uncaught TypeError: document.getElementById(...) is null`

The id element in question seems to be used to display the name of the AD region being moused over in other cases (like the Otu Distribution task), but no such display is used in asserted_distributions/1