### PR TITLE
Quick form CollectingEvent slice fixups

### DIFF
--- a/app/javascript/vue/components/radials/object/components/collecting_event/label/QRCode.vue
+++ b/app/javascript/vue/components/radials/object/components/collecting_event/label/QRCode.vue
@@ -13,10 +13,11 @@
       </div>
       <div class="horizontal-right-content middle">
         <label
-          >Que to print
+          >Queue to print
           <input
             class="que-input"
             size="5"
+            min="1"
             v-model="label.total"
             type="number"
           />

--- a/app/javascript/vue/components/radials/object/components/collecting_event/label/QRCode.vue
+++ b/app/javascript/vue/components/radials/object/components/collecting_event/label/QRCode.vue
@@ -25,8 +25,10 @@
         <a
           v-if="label.id && label.total > 0"
           target="blank"
-          :href="`/tasks/labels/print_labels?label_id=${label.id}`"
-          >Preview
+          :href="`${RouteNames.PrintLabel}?label_id=${label.id}`"
+          class="preview"
+          >
+            Preview
         </a>
       </div>
     </div>
@@ -40,6 +42,8 @@
 </template>
 
 <script setup>
+import { RouteNames } from '@/routes/routes.js'
+
 const props = defineProps({
   identifier: {
     type: Object,
@@ -56,3 +60,10 @@ function setTextFromIdentifier() {
   label.value.text = props.identifier.cached
 }
 </script>
+
+<style lang="scss">
+.preview {
+  margin-left: 1em;
+  margin-right: 1em;
+}
+</style>

--- a/app/javascript/vue/components/radials/object/components/collecting_event/label/TextLabel.vue
+++ b/app/javascript/vue/components/radials/object/components/collecting_event/label/TextLabel.vue
@@ -25,8 +25,10 @@
         <a
           v-if="label.id && label.total > 0"
           target="blank"
-          :href="`/tasks/labels/print_labels?label_id=${label.id}`"
-          >Preview
+          :href="`${RouteNames.PrintLabel}?label_id=${label.id}`"
+          class="preview"
+        >
+          Preview
         </a>
       </div>
     </div>
@@ -41,6 +43,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { RouteNames } from '@/routes/routes.js'
 
 const props = defineProps({
   collectingEvent: {
@@ -60,3 +63,10 @@ function copyLabel() {
   label.value.text = props.collectingEvent.verbatim_label
 }
 </script>
+
+<style lang="scss">
+.preview {
+  margin-left: 1em;
+  margin-right: 1em;
+}
+</style>

--- a/app/javascript/vue/components/radials/object/components/collecting_event/label/TextLabel.vue
+++ b/app/javascript/vue/components/radials/object/components/collecting_event/label/TextLabel.vue
@@ -13,10 +13,11 @@
       </div>
       <div class="horizontal-right-content middle">
         <label
-          >Que to print
+          >Queue to print
           <input
             class="que-input"
             size="5"
+            min="1"
             v-model="label.total"
             type="number"
           />
@@ -53,7 +54,7 @@ const label = defineModel({
   required: true
 })
 
-const isEmpty = computed(() => props.collectingEvent?.verbatim_label)
+const isEmpty = computed(() => !props.collectingEvent?.verbatim_label)
 
 function copyLabel() {
   label.value.text = props.collectingEvent.verbatim_label

--- a/app/javascript/vue/components/radials/object/components/collecting_event/main.vue
+++ b/app/javascript/vue/components/radials/object/components/collecting_event/main.vue
@@ -181,8 +181,8 @@ function saveLabel() {
   })
 }
 
-function setLabel(label) {
-  label.value = label
+function setLabel(labelToSet) {
+  label.value = labelToSet
 }
 
 function removeLabel(label) {

--- a/app/javascript/vue/components/radials/object/components/collecting_event/main.vue
+++ b/app/javascript/vue/components/radials/object/components/collecting_event/main.vue
@@ -177,6 +177,7 @@ function saveLabel() {
 
   saveRequest.then(({ body }) => {
     addToList(body)
+    setLabel(body)
     TW.workbench.alert.create('Label was successfully saved.', 'notice')
   })
 }

--- a/app/views/labels/_attributes.json.jbuilder
+++ b/app/views/labels/_attributes.json.jbuilder
@@ -4,3 +4,5 @@ json.updated_by label.updater.name
 json.url label_url(label, format: :json)
 json.on object_tag(label.label_object)
 json.label taxonworks_label_tag(label)
+
+json.partial! '/shared/data/all/metadata', object: label

--- a/app/views/labels/index.json.jbuilder
+++ b/app/views/labels/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @labels, partial: '/labels/label', as: :label
+json.array! @labels, partial: 'attributes', as: :label

--- a/app/views/labels/show.json.jbuilder
+++ b/app/views/labels/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "labels/label", label: @label
+json.partial! 'attributes', label: @label


### PR DESCRIPTION
These are all from the CollectingEvent quick forms slice modal on a CollectionObject.

Side question: FieldOccurrence has a CE quick form, but does it make sense to print a label for an FO?

Commit 1 STR:
* note that the 'Copy verbatim label' button is disabled when the CE has a verbatim label, and enabled when it doesn't (opposite of expected).

Commit 2 STR:
* save a label
* click New to reset the form
* click the green edit button for that label, see nothing happens

Commit 3 STR:
* save a label
* note that the 'Preview' link does not appear (it only appears when you edit a label) - expected result: the preview link appears on save, not just edit

Commit 4 STR:
* click on the radial annotator for a saved label --> see an error in the console (missing label global_id)
I switched label views to use _attributes.json.jbuilder under the assumption that this was just old code, but if not using that was intentional just let me know and I'll revert.