### PR TITLE
Support (multiply encoded) brackets in venn query strings

### DIFF
--- a/lib/queries/query/filter.rb
+++ b/lib/queries/query/filter.rb
@@ -316,7 +316,6 @@ module Queries
 
     def venn_mode
       v = @venn_mode.to_s.downcase.to_sym
-      v  = :ab if v.blank?
       if [:a, :ab, :b].include?(v)
         v
       else
@@ -765,7 +764,7 @@ module Queries
         q = referenced_klass.all
       end
 
-      if venn && !api
+      if venn_mode && venn && !api
         q = apply_venn(q)
       end
 

--- a/lib/queries/query/filter.rb
+++ b/lib/queries/query/filter.rb
@@ -707,8 +707,18 @@ module Queries
     end
 
     def venn_query
-      u = ::Addressable::URI.parse(venn)
-      p = ::Rack::Utils.parse_query(u.query)
+      u = ::Addressable::URI.parse(venn).query
+      # Brackets may be multi-encoded
+      t = nil
+      i = 0
+      max = 10
+      while t != u && i < max
+        t = u
+        u = Addressable::URI.unencode(t)
+        i += 1
+      end
+
+      p = ::Rack::Utils.parse_nested_query(u) # nested supports brackets
 
       a = ActionController::Parameters.new(p)
 

--- a/spec/lib/queries/query/filter_spec.rb
+++ b/spec/lib/queries/query/filter_spec.rb
@@ -28,7 +28,7 @@ describe Queries::Query::Filter, type: [:model] do
 
     specify '#apply_venn ab' do
       v = "http://127.0.0.1:3000/otus/filter.json?name=#{o2.name}"
-      a = ::Queries::Otu::Filter.new(otu_id: [o1.id, o2.id, o3.id], venn: v)
+      a = ::Queries::Otu::Filter.new(otu_id: [o1.id, o2.id, o3.id], venn: v, venn_mode: :ab)
       expect(a.all).to contain_exactly(o2)
     end
 
@@ -69,6 +69,7 @@ describe Queries::Query::Filter, type: [:model] do
   end
 
   specify '#venn_mode 0' do
+    query.venn_mode = 'ab'
     expect(query.venn_mode).to eq(:ab)
   end
 

--- a/spec/lib/queries/query/filter_spec.rb
+++ b/spec/lib/queries/query/filter_spec.rb
@@ -44,9 +44,9 @@ describe Queries::Query::Filter, type: [:model] do
       expect(a.all).to contain_exactly(o3)
     end
 
-    specify '#apply_venn #venn_mode b' do
-      v = "http://127.0.0.1:3000/otus/filter.json?otu_id[]=#{o2.id}&otu_id[]=#{o3.id}"
-      a = ::Queries::Otu::Filter.new(otu_id: [o1.id, o2.id], venn: v, venn_mode: :b)
+    specify '#apply_venn #venn_mode b multiply encoded' do
+      v = "http://127.0.0.1:3000/otus/filter.json?otu_id%25255B%25255D=#{o2.id}&otu_id%25255B%25255D=#{o3.id}"
+      a = ::Queries::Otu::Filter.new(otu_id: [o2.id], venn: v, venn_mode: :b)
       expect(a.all).to contain_exactly(o3)
     end
   end
@@ -103,13 +103,13 @@ describe Queries::Query::Filter, type: [:model] do
   end
 
   specify '.base_filter 1' do
-     p = ActionController::Parameters.new(collection_object_query: {}, foo: :bar)
-     expect(Queries::Query::Filter.base_filter(p)).to eq(::Queries::CollectionObject::Filter)
+    p = ActionController::Parameters.new(collection_object_query: {}, foo: :bar)
+    expect(Queries::Query::Filter.base_filter(p)).to eq(::Queries::CollectionObject::Filter)
   end
 
   specify '.base_filter 1' do
-     p = ActionController::Parameters.new(collection_object_query: { otu_query: {}}, foo: :bar)
-     expect(Queries::Query::Filter.base_filter(p)).to eq(::Queries::CollectionObject::Filter)
+    p = ActionController::Parameters.new(collection_object_query: { otu_query: {}}, foo: :bar)
+    expect(Queries::Query::Filter.base_filter(p)).to eq(::Queries::CollectionObject::Filter)
   end
 
   context 'PARAMS defined' do


### PR DESCRIPTION
For example, pasting something like this as the 'b' query string (which I copied from 'JSON response'):
```
http://localhost:3000/collection_objects/filter.json?per=50&collecting_event_id%5B%5D=87629&extend%5B%5D=dwc_occurrence&extend%5B%5D=repository&extend%5B%5D=current_repository&extend%5B%5D=collecting_event&extend%5B%5D=taxon_determinations&extend%5B%5D=identifiers&exclude%5B%5D=object_labels&page=1
```

I think there are two issues:
* venn doesn't support inputting query strings that already include encoded brackets (because they get encoded again on their way to the server(?) and ::Rack::Utils.parse... functions only unencode once)
* venn doesn't support any kind of brackets in its 'b' query, encoded or not --> use ::Rack::Utils.parse_nested_query instead of ::Rack::Utils.parse_query (more details in the commit message)
