### PR TITLE
A couple New FO CE panel fixups

### DIFF
--- a/app/javascript/vue/components/Form/FormCollectingEvent/components/parsed/Group.vue
+++ b/app/javascript/vue/components/Form/FormCollectingEvent/components/parsed/Group.vue
@@ -8,7 +8,10 @@
         label="name"
         nested="records"
         :send-label="collectingEvent.group"
-        @getItem="collectingEvent.group = $event.name"
+        @getItem="(e) => {
+            collectingEvent.group = e.name
+            collectingEvent.isUnsaved = true
+          }"
         :headers="EXTERNAL_HEADERS"
         :add-params="{
           limit: 30,
@@ -26,7 +29,10 @@
         label="name"
         nested="records"
         :send-label="collectingEvent.formation"
-        @getItem="collectingEvent.formation = $event.name"
+        @getItem="(e) => {
+            collectingEvent.formation = e.name
+            collectingEvent.isUnsaved = true
+          }"
         :headers="EXTERNAL_HEADERS"
         :add-params="{
           limit: 30,
@@ -41,6 +47,7 @@
       <input
         type="text"
         v-model="collectingEvent.member"
+        @change="() => { collectingEvent.isUnsaved = true }"
       />
     </div>
     <div class="field label-above">
@@ -48,14 +55,16 @@
       <input
         type="text"
         v-model="collectingEvent.lithology"
+        @change="() => { collectingEvent.isUnsaved = true }"
       />
     </div>
     <div class="horizontal-left-content ma-fields">
       <div class="separate-right label-above">
-        <label>Minumum MA</label>
+        <label>Minimum MA</label>
         <input
           type="text"
           v-model="collectingEvent.min_ma"
+          @change="() => { collectingEvent.isUnsaved = true }"
         />
       </div>
       <div class="separate-left label-above">
@@ -63,6 +72,7 @@
         <input
           type="text"
           v-model="collectingEvent.max_ma"
+          @change="() => { collectingEvent.isUnsaved = true }"
         />
       </div>
     </div>

--- a/app/javascript/vue/components/Form/FormCollectingEvent/store/identifier.js
+++ b/app/javascript/vue/components/Form/FormCollectingEvent/store/identifier.js
@@ -58,7 +58,7 @@ export default defineStore('tripCode', {
 
     async load({ objectId, objectType }) {
       try {
-        const { body } = Identifier.where({
+        const { body } = await Identifier.where({
           identifier_object_id: objectId,
           identifier_object_type: objectType,
           type: IDENTIFIER_LOCAL_FIELD_NUMBER


### PR DESCRIPTION
Issues:
* in the New FO task saved identifiers aren't loaded in the UI on page reload
* data added to the 'Group' section of the CE input are never saved

Another issue I ran into that I left since I'm not sure what you want the UX to be:
* in New FO's CE, add a new georef, scroll down to its (unsaved) record in the georef panel, click on 'click to edit' in the error radius column, enter a number --> error