### PR TITLE
Refactor DWCO hooks callbacks for create/delete handling

### DIFF
--- a/app/models/depiction.rb
+++ b/app/models/depiction.rb
@@ -73,11 +73,6 @@ class Depiction < ApplicationRecord
   # TODO: almost certainly deprecate
   after_update :destroy_image_stub_collection_object, if: Proc.new {|d| d.depiction_object_type_previously_was == 'CollectionObject' && d.depiction_object_type == 'CollectionObject' }
 
-  # !? This is purposefully redundant with Shared::DwcOccurrencHooks without
-  # constraints because that version doesn't catch `saved_changes?` in specs.
-  # Maybe because specs pass objects. Maybe because other hooks?
-  after_save_commit :update_dwc_occurrence, unless: :no_dwc_occurrence
-
   def normalize_image
     if o = Image.where(project_id: Current.project_id, image_file_fingerprint: image.image_file_fingerprint).first
       self.image = o

--- a/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
+++ b/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
@@ -17,6 +17,66 @@ describe 'Shared::DwcOccurrenceHooks', type: :model, group: :dwc_occurrence do
 
     end
   end
+
+  context 'CUD' do
+    let(:fo) { FactoryBot.create(:valid_field_occurrence) }
+
+    before(:each) {
+      Georeference::Leaflet.create!(collecting_event: fo.collecting_event,
+        geographic_item_attributes: {
+          shape: {
+            type: 'Feature', properties: {},
+            geometry: {type: 'Point', coordinates: [20, 30]}
+          }
+        }
+      )
+    }
+
+    specify 'hook gets called on a hooked model that uses has_nested_attributes' do
+      # Using the hook `after_save :process_dwc_occurrences, if:
+      # :saved_changes?` fails in this case because(?) the nested create causes
+      # a nested save on create, which causes saved_changes? to be empty in
+      # after_save_commit.
+      expect(fo.reload.dwc_occurrence.footprintWKT).to match('20 30')
+    end
+
+    # TODO FO's CE gets created/updated through georefs/collectors etc.
+
+    # TODO many (all?) annotator classes like Protocol, Notes, Citations need to
+    # be hooked in some way.
+    xspecify 'hook gets called on annotator classes' do
+      fo.protocols <<
+        FactoryBot.create(:valid_protocol, is_machine_output: true)
+
+      expect(fo.reload.dwc_occurrence.basisOfRecord).to match('MachineObservation')
+    end
+
+    specify "hook gets called on a hooked model that doesn't use has_nested_attributes" do
+      # Using FactoryBot doesn't trigger after_save on Determiner.
+      #determiner = FactoryBot.create(:valid_determiner,
+      #  role_object_type: 'TaxonDetermination',
+      #  role_object_id: fo.taxon_determinations.first.id
+      #)
+      p = FactoryBot.create(:valid_person, last_name: 'Donut, 13/10')
+      Determiner.create!(
+        role_object_type: 'TaxonDetermination',
+        role_object_id: fo.taxon_determinations.first.id,
+        person_id: p.id
+      )
+
+      # TODO: use TestDwcHookable so non-has_nested_attributes-ness can be
+      # controlled.
+      expect(fo.reload.dwc_occurrence.identifiedBy).to match('Donut')
+    end
+
+    specify 'update' do
+      fo.collecting_event.georeferences.first.update!(
+        error_radius: 345
+      )
+      expect(fo.reload.dwc_occurrence.coordinateUncertaintyInMeters)
+        .to match('345')
+    end
+  end
 end
 
 class TestDwcHookable < ApplicationRecord

--- a/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
+++ b/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
@@ -18,69 +18,127 @@ describe 'Shared::DwcOccurrenceHooks', type: :model, group: :dwc_occurrence do
     end
   end
 
-  context 'CUD' do
-    let(:fo) { FactoryBot.create(:valid_field_occurrence) }
-
-    before(:each) {
-      Georeference::Leaflet.create!(collecting_event: fo.collecting_event,
-        geographic_item_attributes: {
-          shape: {
-            type: 'Feature', properties: {},
-            geometry: {type: 'Point', coordinates: [20, 30]}
+  context 'running hooks on create, update, delete' do
+    context 'with nested attributes' do
+      let(:fo) { FactoryBot.create(:valid_field_occurrence) }
+      before(:each) {
+        Georeference::Leaflet.create!(collecting_event: fo.collecting_event,
+          geographic_item_attributes: {
+            shape: {
+              type: 'Feature', properties: {},
+              geometry: {type: 'Point', coordinates: [20, 30]}
+            }
           }
-        }
-      )
-    }
+        )
+      }
 
-    specify 'hook gets called on a hooked model that uses has_nested_attributes' do
-      # Using the hook `after_save :process_dwc_occurrences, if:
-      # :saved_changes?` fails in this case because(?) the nested create causes
-      # a nested save on create, which causes saved_changes? to be empty in
-      # after_save_commit.
-      expect(fo.reload.dwc_occurrence.footprintWKT).to match('20 30')
+      specify "hook gets called on a hooked model that doesn't use has_nested_attributes" do
+        p = FactoryBot.create(:valid_person, last_name: 'Donut, 13/10')
+        Determiner.create!(
+          role_object_type: 'TaxonDetermination',
+          role_object_id: fo.taxon_determinations.first.id,
+          person_id: p.id
+        )
+
+        # TODO: use TestDwcHookable so non-has_nested_attributes-ness can be
+        # controlled.
+        expect(fo.reload.dwc_occurrence.identifiedBy).to match('Donut')
+      end
+
+      specify 'hook gets called on a hooked model that uses has_nested_attributes' do
+        # Using the hook `after_save :process_dwc_occurrences, if:
+        # :saved_changes?` fails in this case because(?) the nested create causes
+        # a nested save on create, which causes saved_changes? to be empty in
+        # after_save_commit.
+        expect(fo.reload.dwc_occurrence.footprintWKT).to match('20 30')
+      end
+
+      specify 'update' do
+        fo.collecting_event.georeferences.first.update!(
+          error_radius: 345
+        )
+        expect(fo.reload.dwc_occurrence.coordinateUncertaintyInMeters)
+          .to match('345')
+      end
+
+      specify 'destroy' do
+        fo.collecting_event.georeferences.first.destroy!
+        expect(fo.reload.dwc_occurrence.footprintWKT).to be_nil
+      end
     end
 
-    # TODO FO's CE gets created/updated through georefs/collectors etc.
+    context 'with multi-creates and updates' do
+      let!(:ce) { FactoryBot.create(:valid_collecting_event) }
+      let!(:co) {
+        FactoryBot.create(:valid_collection_object,
+          collecting_event: ce, no_dwc_occurrence: false
+        )
+      }
+      let(:fo) {
+        FactoryBot.create(:valid_field_occurrence, collecting_event: ce)
+      }
 
-    # TODO many (all?) annotator classes like Protocol, Notes, Citations need to
-    # be hooked in some way.
-    xspecify 'hook gets called on annotator classes' do
-      fo.protocols <<
-        FactoryBot.create(:valid_protocol, is_machine_output: true)
+      specify 'updating isDwCO object along with nested hooked objects' do
+        person = FactoryBot.create(:valid_person, first_name: 'Beevis')
 
-      expect(fo.reload.dwc_occurrence.basisOfRecord).to match('MachineObservation')
+        co.update!(
+          total: 3,
+          collecting_event_attributes: {
+            verbatim_label: 'far far away',
+            roles_attributes: [
+              { person_id: person.id, type: 'Collector' }
+            ]
+          }
+        )
+
+        co = CollectionObject.first # co is now a Lot
+        # Data from the CO update:
+        expect(co.dwc_occurrence.individualCount).to eq(3)
+        # Data from the CO's nested CE update:
+        expect(co.dwc_occurrence.verbatimLabel).to eq('far far away')
+        # Data from the CE's nested role create:
+        expect(co.dwc_occurrence.recordedBy).to match('Beevis')
+      end
+
+      specify 'Updating hooked object linked to multiple DwCOs' do
+        fo
+        locality = '11nty hundred and 11'
+        ce.update!(verbatim_locality: locality)
+        expect(co.reload.dwc_occurrence.verbatimLocality).to eq(locality)
+        expect(fo.reload.dwc_occurrence.verbatimLocality).to eq(locality)
+      end
+
+      specify 'Delete hooked object linked to multiple DwCOs' do
+        fo
+        _c1 = Collector.create!(
+          person: Person.create!(first_name: 'Butter', last_name: 'River'),
+          role_object: ce
+        )
+        c2 = Collector.create!(
+          person: Person.create!(first_name: 'Wax', last_name: 'Smith'),
+          role_object: ce
+        )
+
+        expect(co.reload.dwc_occurrence.recordedBy)
+          .to match(/Butter.*Wax|Wax.*Butter/)
+        expect(fo.reload.dwc_occurrence.recordedBy)
+          .to match(/Butter.*Wax|Wax.*Butter/)
+
+        c2.destroy!
+
+        expect(co.reload.dwc_occurrence.recordedBy).to eq('Butter River')
+        expect(fo.reload.dwc_occurrence.recordedBy).to eq('Butter River')
+      end
     end
+  end
 
-    specify "hook gets called on a hooked model that doesn't use has_nested_attributes" do
-      # Using FactoryBot doesn't trigger after_save on Determiner.
-      #determiner = FactoryBot.create(:valid_determiner,
-      #  role_object_type: 'TaxonDetermination',
-      #  role_object_id: fo.taxon_determinations.first.id
-      #)
-      p = FactoryBot.create(:valid_person, last_name: 'Donut, 13/10')
-      Determiner.create!(
-        role_object_type: 'TaxonDetermination',
-        role_object_id: fo.taxon_determinations.first.id,
-        person_id: p.id
-      )
+  # TODO many (all?) annotator classes like Protocol, Notes, Citations need to
+  # be hooked in some way.
+  xspecify 'hook gets called on annotator classes' do
+    fo.protocols <<
+      FactoryBot.create(:valid_protocol, is_machine_output: true)
 
-      # TODO: use TestDwcHookable so non-has_nested_attributes-ness can be
-      # controlled.
-      expect(fo.reload.dwc_occurrence.identifiedBy).to match('Donut')
-    end
-
-    specify 'update' do
-      fo.collecting_event.georeferences.first.update!(
-        error_radius: 345
-      )
-      expect(fo.reload.dwc_occurrence.coordinateUncertaintyInMeters)
-        .to match('345')
-    end
-
-    specify 'delete' do
-      fo.collecting_event.georeferences.first.destroy!
-      expect(fo.reload.dwc_occurrence.footprintWKT).to be_nil
-    end
+    expect(fo.reload.dwc_occurrence.basisOfRecord).to match('MachineObservation')
   end
 end
 

--- a/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
+++ b/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
@@ -76,6 +76,11 @@ describe 'Shared::DwcOccurrenceHooks', type: :model, group: :dwc_occurrence do
       expect(fo.reload.dwc_occurrence.coordinateUncertaintyInMeters)
         .to match('345')
     end
+
+    specify 'delete' do
+      fo.collecting_event.georeferences.first.destroy!
+      expect(fo.reload.dwc_occurrence.footprintWKT).to be_nil
+    end
   end
 end
 

--- a/spec/models/concerns/shared/is_dwc_occurrence_spec.rb
+++ b/spec/models/concerns/shared/is_dwc_occurrence_spec.rb
@@ -70,11 +70,11 @@ describe 'IsDwcOccurrence', type: :model, group: :darwin_core do
       expect(class_with_dwc_occurrence.dwc_occurrence_persisted?).to be_falsey
     end
 
-    specify 'a map between TW and DWC attributes is defined in DWC_OCCURRENCE_METADATA' do
+    specify 'a map between TW and DWC attributes is defined in DWC_OCCURRENCE_MAP' do
       expect(TestIsDwcOccurrence::DWC_OCCURRENCE_MAP).to be_truthy
     end
 
-    context 'DWC_OCCURRENCE_METADATA map is used to' do
+    context 'DWC_OCCURRENCE_MAP is used to' do
       before {class_with_dwc_occurrence.save!}
       specify 'generate #dwc_occurrence_attributes' do
         expect(class_with_dwc_occurrence.dwc_occurrence_attributes).to include(island: 'Gold', disposition: 'Old Men')


### PR DESCRIPTION
@mjy see what you think here please when you get a chance - maybe you'll see some better alternatives. I'll want to add some specs in any case before merging.

There were two issues:
* `after_save_commit` wasn't getting called on Georef creates, apparently because georef create nested geo_items, and in that case there's a nested save during create which causes saved_changes to be {} in after_save_commit (more details at #4240)
  * Downside to this fix: we now update dwcos (potentially expensive) even if there were no saved_changes

* the hook wasn't working on deletes: in after_destroy the record is already gone, so dwc_occurrences doesn't find what you want it to. (And if the record was still in the db, so dwc_occurrences finds what you want it to, then you update dwcos as though your record that's about to disappear still exists!).
  * Downside to this fix: if the destroy was done in a transaction that fails then we've marked some dwcos for update that shouldn't have been so marked. (Seems fine to me.)

Then there was another issue: apparently joins in a scope break update_all, so the previous version was updating _every_ DwcOccurrence. This version seems safe.