### PR TITLE
Remove duplicates in Filter CE 'with collectors' result

### DIFF
--- a/lib/queries/collecting_event/filter.rb
+++ b/lib/queries/collecting_event/filter.rb
@@ -366,7 +366,7 @@ module Queries
       def collectors_facet
         return nil if collectors.nil?
         if collectors
-          ::CollectingEvent.joins(:collectors)
+          ::CollectingEvent.joins(:collectors).distinct
         else
           ::CollectingEvent.where.missing(:collectors)
         end


### PR DESCRIPTION
STR:
1. Add more than one collector to a collecting event.
2. Go to Filter CEs and filter on the 'Collectors: with' facet.

See duplicate rows in the result set.