### PR TITLE
Process destroys in before_destroy for DarwinCoreOccurrences

### DIFF
--- a/app/models/concerns/shared/dwc_occurrence_hooks.rb
+++ b/app/models/concerns/shared/dwc_occurrence_hooks.rb
@@ -16,10 +16,8 @@ module Shared::DwcOccurrenceHooks
     #   See also Shared::IsDwcOccurrence
     attr_accessor :no_dwc_occurrence
 
-    after_commit :update_dwc_occurrence, unless: :no_dwc_occurrence
-
-#   after_save_commit :update_dwc_occurrence, unless: :no_dwc_occurrence
-#   around_destroy :process_destroy
+    after_save_commit :update_dwc_occurrence, unless: :no_dwc_occurrence
+    before_destroy :update_dwc_occurrence
 
     def update_dwc_occurrence
       t = dwc_occurrences.count
@@ -45,7 +43,7 @@ module Shared::DwcOccurrenceHooks
                    end
 
         ::DwcOccurrenceRefreshJob.set(priority:).perform_later(
-          rebuild_set:, 
+          rebuild_set:,
           user_id: Current.user_id,
         )
 

--- a/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
+++ b/spec/models/concerns/shared/dwc_occurrence_hooks_spec.rb
@@ -114,6 +114,9 @@ describe 'Shared::DwcOccurrenceHooks', type: :model, group: :dwc_occurrence do
     specify 'destroy 1' do
       fo.collecting_event.georeferences <<
         FactoryBot.create(:valid_georeference)
+
+      perform_enqueued_jobs
+
       fo.collecting_event.georeferences.first.destroy!
 
       perform_enqueued_jobs
@@ -132,10 +135,12 @@ describe 'Shared::DwcOccurrenceHooks', type: :model, group: :dwc_occurrence do
         role_object: ce
       )
 
+      perform_enqueued_jobs
+
       c2.destroy!
 
       perform_enqueued_jobs
-      
+
       expect(co.reload.dwc_occurrence.recordedBy).to eq('Butter River')
       expect(fo.reload.dwc_occurrence.recordedBy).to eq('Butter River')
     end


### PR DESCRIPTION
Suspicion is that in after_commit the dwc_occurrences query that tries to link some is_dwco object with a hooked object fails because the hooked object has already been removed from the db.