### PR TITLE
Fix navbar links in Browse Asserted Distributions task

### DIFF
--- a/app/javascript/vue/tasks/otu/browse_asserted_distributions/components/navBar.vue
+++ b/app/javascript/vue/tasks/otu/browse_asserted_distributions/components/navBar.vue
@@ -18,10 +18,10 @@
             :key="item.id"
           >
             <a
-              :href="`/tasks/otus/browse_asserted_distributions/index?otu_id=${item.id}`"
+              :href="browseLink(item)"
             >
-              {{ item.object_label }}</a
-            >
+              {{ item.object_label }}
+            </a>
           </li>
         </ul>
       </template>
@@ -33,10 +33,10 @@
             :key="item.id"
           >
             <a
-              :href="`/tasks/otus/browse_asserted_distributions/index?otu_id=${item.id}`"
+              :href="browseLink(item)"
             >
-              {{ item.object_label }}</a
-            >
+              {{ item.object_label }}
+            </a>
           </li>
         </ul>
       </template>
@@ -48,10 +48,10 @@
             :key="item.id"
           >
             <a
-              :href="`/tasks/otus/browse_asserted_distributions/index?otu_id=${item.id}`"
+              :href="browseLink(item)"
             >
-              {{ item.object_label }}</a
-            >
+              {{ item.object_label }}
+            </a>
           </li>
         </ul>
       </template>
@@ -61,6 +61,7 @@
 
 <script>
 import { Otu } from '@/routes/endpoints'
+import { RouteNames } from '@/routes/routes'
 import RadialAnnotator from '@/components/radials/annotator/annotator'
 import RadialObject from '@/components/radials/navigation/radial'
 import OtuRadial from '@/components/radials/object/radial'
@@ -97,9 +98,15 @@ export default {
 
   methods: {
     loadNav(id) {
-      Otu.navigation(id).then((response) => {
+      Otu.navigation(id)
+      .then((response) => {
         this.navList = response.body
       })
+      .catch(() => {})
+    },
+
+    browseLink(item) {
+      return `${RouteNames.BrowseAssertedDistribution}?otu_id=${item.id}`
     }
   }
 }

--- a/app/views/otus/navigation.json.jbuilder
+++ b/app/views/otus/navigation.json.jbuilder
@@ -6,7 +6,7 @@ json.parent_otus do
   json.array! parent_otus(@otu) do |o|
     json.id o.id
     json.name o.name
-    json.object_tag otu_tag(o) 
+    json.object_label label_for_otu(o)
   end
 end
 
@@ -14,7 +14,7 @@ json.previous_otus do
   json.array! previous_otus(@otu) do |o|
     json.id o.id
     json.name o.name
-    json.object_tag otu_tag(o) 
+    json.object_label label_for_otu(o)
   end
 end
 
@@ -22,7 +22,7 @@ json.next_otus do
   json.array! next_otus(@otu) do |o|
     json.id o.id
     json.name o.name
-    json.object_tag otu_tag(o) 
+    json.object_label label_for_otu(o)
   end
 end
 


### PR DESCRIPTION
STR:
* Find an otu with siblings and/or a parent
* Load that otu in the 'Browse asserted distributions' task
See 'Parent', 'Previous', and/or 'Next' tags, but no links for those tags.