### PR TITLE
Bring back Browse Otu otu navigation links

### DIFF
--- a/app/views/otus/navigation.json.jbuilder
+++ b/app/views/otus/navigation.json.jbuilder
@@ -6,6 +6,7 @@ json.parent_otus do
   json.array! parent_otus(@otu) do |o|
     json.id o.id
     json.name o.name
+    json.object_tag otu_tag(o)
     json.object_label label_for_otu(o)
   end
 end
@@ -14,6 +15,7 @@ json.previous_otus do
   json.array! previous_otus(@otu) do |o|
     json.id o.id
     json.name o.name
+    json.object_tag otu_tag(o)
     json.object_label label_for_otu(o)
   end
 end
@@ -22,6 +24,7 @@ json.next_otus do
   json.array! next_otus(@otu) do |o|
     json.id o.id
     json.name o.name
+    json.object_tag otu_tag(o)
     json.object_label label_for_otu(o)
   end
 end


### PR DESCRIPTION
The Browse Otu task uses tags, not labels.

Broken by f085dc142b7dc4c1282fbc5dd98d7edde03c1276, sorry about that