### PR TITLE
Permit not-array TD filter parameters

### DIFF
--- a/lib/queries/taxon_determination/filter.rb
+++ b/lib/queries/taxon_determination/filter.rb
@@ -4,17 +4,20 @@ module Queries
 
       PARAMS = [
         :collection_object_id,
+        :determiner_id,
         :field_occurrence_id,
         :otu_id,
         :taxon_determination_id,
+        :taxon_determination_object_id,
+        :taxon_determination_object_type,
 
-        taxon_determination_object_type: [],
-        taxon_determination_object_id: [],
         collection_object_id: [],
-        field_occurrence_id: [],
         determiner_id: [],
+        field_occurrence_id: [],
         otu_id: [],
         taxon_determination_id: [],
+        taxon_determination_object_id: [],
+        taxon_determination_object_type: []
       ].freeze
 
       # all Arrays


### PR DESCRIPTION
So queries like taxon_determinations.json?taxon_determination_object_id[]=9&taxon_determination_object_type=FieldOccurrence
from https://github.com/SpeciesFileGroup/taxonworks/blob/96dc3273d67e7d022245a09faf80185e00c981ac/app/javascript/vue/tasks/otu/browse/components/FieldOccurrence/FieldOccurrenceRow.vue#L117-L119

 work as expected instead of silently ignoring the not-array param.

The symptom was that I was seeing two TDs for an FO in Browse OTU when I knew there was only actually one.