### PR TITLE
Make sure all container labels are strings, not numbers

### DIFF
--- a/app/helpers/collection_objects_helper.rb
+++ b/app/helpers/collection_objects_helper.rb
@@ -44,7 +44,7 @@ module CollectionObjectsHelper
     return nil if collection_object.nil?
     collection_object.dwc_catalog_number ||
       collection_object.dwc_scientific_name ||
-      collection_object.id
+      collection_object.id.to_s
   end
 
   def collection_object_autocomplete_tag(collection_object)
@@ -132,7 +132,7 @@ module CollectionObjectsHelper
     j = collection_object.container&.identifiers&.order(:position)&.first
     return [:container, identifier_tag(j)] if j
 
-    # Use a non local/non container if provided 
+    # Use a non local/non container if provided
     return [:collection_object, identifier_tag(i)] if i
     return [:container, identifier_tag(j)] if j
 

--- a/app/helpers/containers_helper.rb
+++ b/app/helpers/containers_helper.rb
@@ -39,7 +39,7 @@ module ContainersHelper
   # TODO: Clean, refactor
   def label_for_container_container(container)
     return nil if container.nil?
-    container.name || container.print_label || label_for_identifier(container.identifiers.first) || container.id
+    container.name || container.print_label || label_for_identifier(container.identifiers.first) || container.id.to_s
   end
 
   def container_autocomplete_tag(container)
@@ -75,8 +75,8 @@ module ContainersHelper
     return nil if !object.containable?
     parts = []
     object.enclosing_containers.each do |c|
-      s = c.name.blank? ? c.class.class_name : c.name
-      s += " [#{c.disposition}]" if !c.disposition.blank?
+      s = (c.name.presence || c.class.class_name)
+      s += " [#{c.disposition}]" if c.disposition.present?
       parts.push s
     end
     parts.join('; ')


### PR DESCRIPTION
Downstream code assumes they're strings.

STR:
1) Create a CO without a dwc_catalog_number or dwc_scientific_name (in my case toy test data).
2) Add a container item to that CO so that both are now in a container.
3) Load 'New container' for either of those COs
Get a javascript exception on String#shorten trying to shorten the label for either CO, which is an id number, not a string.