### PR TITLE
Add common names as an option to OTU autocomplete

### DIFF
--- a/app/controllers/otus_controller.rb
+++ b/app/controllers/otus_controller.rb
@@ -313,7 +313,7 @@ class OtusController < ApplicationController
       having_taxon_name_only: params[:having_taxon_name_only]
     ).api_autocomplete_extended
 
-    render '/otus/api/v1/autocomplete'
+    render '/otus/api/v1/autocomplete', locals: { include_common_names: params[:include_common_names] }
   end
 
   # GET /api/v1/otus/:id/inventory/images

--- a/app/helpers/otus_helper.rb
+++ b/app/helpers/otus_helper.rb
@@ -1,8 +1,8 @@
 module OtusHelper
 
-  def otu_tag(otu)
+  def otu_tag(otu, include_common_names = false)
     return nil if otu.nil?
-    a = otu_tag_elements(otu)
+    a = otu_tag_elements(otu, include_common_names)
     a.push taxon_name_type_short_tag(otu.taxon_name)
     content_tag(:span, a.compact.join(' ').html_safe, class: :otu_tag)
   end
@@ -14,21 +14,26 @@ module OtusHelper
     ].compact.join(': ')
   end
 
-  def otu_tag_elements(otu)
+  def otu_tag_elements(otu, include_common_names = false)
     return nil if otu.nil?
     [
       ( otu.name ? content_tag(:span, otu.name, class: :otu_tag_otu_name, title: otu.id) : nil ),
-      ( otu.taxon_name ? content_tag(:span, full_taxon_name_tag(otu.taxon_name).html_safe, class: :otu_tag_taxon_name, title: otu.taxon_name.id) : nil)
+      ( otu.taxon_name ? content_tag(:span, full_taxon_name_tag(otu.taxon_name).html_safe, class: :otu_tag_taxon_name, title: otu.taxon_name.id) : nil),
+      ( include_common_names && otu.common_names.present? ? content_tag(:span, "(" + otu.common_names.map(&:name).join(', ') + ")", class: :otu_tag_common_name) : nil ),
     ].compact
   end
 
   # Used exclusively in /api/v1/otus/autocomplete
-  def otu_extended_autocomplete_tag(target)
+  def otu_extended_autocomplete_tag(target, include_common_names = false)
     if target.kind_of?(Otu)
-      otu_tag(target)
+      otu_tag(target, include_common_names)
     else # TaxonName
       a = [ tag.span( full_taxon_name_tag(target).html_safe, class: :otu_tag_taxon_name, title: target.id) ]
       a.push taxon_name_type_short_tag(target)
+      if include_common_names
+        common_names = target.common_names.map(&:name).join(', ')
+        a.push tag.span("(" + common_names + ")", class: :otu_tag_common_name) if common_names.present?
+      end
       tag.span( a.compact.join(' ').html_safe, class: :otu_tag )
     end
   end

--- a/app/views/otus/api/v1/autocomplete.json.jbuilder
+++ b/app/views/otus/api/v1/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @otu_metadata do |r|
   json.id r[:otu].id
   json.label otu_autocomplete_selected_tag(r[:otu]) # !! Note this is not used in TaxonPages
-  json.label_html otu_extended_autocomplete_tag( r[:label_target])
+  json.label_html otu_extended_autocomplete_tag(r[:label_target], local_assigns[:include_common_names] == 'true')
   json.gid r[:otu].to_global_id.to_s
   json.otu_valid_id r[:otu_valid_id]
 end

--- a/lib/queries/otu/autocomplete.rb
+++ b/lib/queries/otu/autocomplete.rb
@@ -21,6 +21,12 @@ module Queries
       #   nil - ignored
       attr_accessor :with_taxon_name
 
+      # @return Boolean, nil
+      #  true - include common names in response
+      # false - do not include common names in response
+      # nil - ignored
+      attr_accessor :include_common_names
+
       # @return [Boolean]
       #   &exact=<"true"|"false">
       #   if 'true' then only #name = query_string results are returned (no fuzzy matching)
@@ -53,10 +59,11 @@ module Queries
         # common_name_name_similarity: {priority: 200},
       }.freeze
 
-      def initialize(string, project_id: nil, having_taxon_name_only: false, with_taxon_name: nil, exact: 'false')
+      def initialize(string, project_id: nil, having_taxon_name_only: false, with_taxon_name: nil, include_common_names: false, exact: 'false')
         super(string, project_id:)
         @having_taxon_name_only = boolean_param({having_taxon_name_only:}, :having_taxon_name_only)
         @with_taxon_name = boolean_param({with_taxon_name:}, :with_taxon_name)
+        @include_common_names = boolean_param({ include_common_names:}, :with_common_names)
 
         # TODO: move to mode
         @exact = boolean_param({exact:}, :exact)


### PR DESCRIPTION
Add an optional parameter `include_common_name` to the OTU autocomplete endpoint `/api/v1/otus/autocomplete`.

How it looks in TaxonPages:

<img width="421" alt="image" src="https://github.com/user-attachments/assets/fa122f0d-d957-4d53-81a5-5a2ee2eab8a6" />