### PR TITLE
Filter mass annotator fixes

### DIFF
--- a/app/javascript/vue/components/radials/mass/components/Annotator/Confidence/ConfidenceMain.vue
+++ b/app/javascript/vue/components/radials/mass/components/Annotator/Confidence/ConfidenceMain.vue
@@ -79,6 +79,11 @@ const props = defineProps({
   parameters: {
     type: Object,
     default: undefined
+  },
+
+  nestedQuery: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -141,9 +146,7 @@ function makePayload(confidence) {
   return {
     mode: selectedMode.value.mode,
     confidence_level_id: confidence.id,
-    filter_query: {
-      [QUERY_PARAM[props.objectType]]: props.parameters
-    }
+    filter_query: filterQuery()
   }
 }
 
@@ -152,9 +155,13 @@ function makeReplacePayload([replace, to]) {
     mode: selectedMode.value.mode,
     confidence_level_id: to.id,
     replace_confidence_level_id: replace.id,
-    filter_query: {
-      [QUERY_PARAM[props.objectType]]: props.parameters
-    }
+    filter_query: filterQuery()
   }
+}
+
+function filterQuery() {
+  return props.nestedQuery
+    ? props.parameters
+    : {[QUERY_PARAM[props.objectType]]: props.parameters}
 }
 </script>

--- a/app/javascript/vue/components/radials/mass/components/Annotator/Protocol/ProtocolMain.vue
+++ b/app/javascript/vue/components/radials/mass/components/Annotator/Protocol/ProtocolMain.vue
@@ -73,6 +73,11 @@ const props = defineProps({
   parameters: {
     type: Object,
     default: undefined
+  },
+
+  nestedQuery: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -132,9 +137,7 @@ function makePayload(protocol) {
   return {
     mode: selectedMode.value.mode,
     protocol_id: protocol.id,
-    filter_query: {
-      [QUERY_PARAM[props.objectType]]: props.parameters
-    }
+    filter_query: filterQuery()
   }
 }
 
@@ -143,9 +146,13 @@ function makeReplacePayload([replace, to]) {
     mode: selectedMode.value.mode,
     protocol_id: to.id,
     replace_protocol_id: replace.id,
-    filter_query: {
-      [QUERY_PARAM[props.objectType]]: props.parameters
-    }
+    filter_query: filterQuery()
   }
+}
+
+function filterQuery() {
+  return props.nestedQuery
+    ? props.parameters
+    : {[QUERY_PARAM[props.objectType]]: props.parameters}
 }
 </script>

--- a/app/models/confidence.rb
+++ b/app/models/confidence.rb
@@ -99,7 +99,7 @@ class Confidence < ApplicationRecord
             confidence_level_id: replace_confidence_level_id
           ).find_each do |o|
             o.update(confidence_level_id:)
-            if o.valid? 
+            if o.valid?
               r.updated.push o.id
             else
               r.not_updated.push o.id
@@ -111,7 +111,8 @@ class Confidence < ApplicationRecord
       Confidence
         .where(
           confidence_object_id: q.pluck(:id),
-          confidence_object_type: b.referenced_klass.name
+          confidence_object_type: b.referenced_klass.name,
+          confidence_level_id:
         ).delete_all
     when :add
       if async
@@ -126,8 +127,8 @@ class Confidence < ApplicationRecord
       else
         q.find_each do |o|
           o = Confidence.create(confidence_object: o, confidence_level_id:)
-          
-          if o.valid? 
+
+          if o.valid?
             r.updated.push o.id
           else
             r.not_updated.push o.id


### PR DESCRIPTION
Commit 1 STR:
1. Use any filter with at least one parameter that returns results (preferably not too many)
2. Use the left-side mass batch annotator to update Protocol or Confidence.
See a popup error in the Response modal:
`can not update records without at least one filter parameter` even though you have at
least one filter parameter.

Commit 2 STR:
1. as above
2. Use either mass annotator menu to remove a confidence --> see *all* confidences
   were removed.