### PR TITLE
Filter Contents fixes

### DIFF
--- a/app/javascript/vue/routes/routes.js
+++ b/app/javascript/vue/routes/routes.js
@@ -90,6 +90,7 @@ const FILTER_ROUTES = {
   [BIOLOGICAL_ASSOCIATION]: RouteNames.FilterBiologicalAssociations,
   [COLLECTING_EVENT]: RouteNames.FilterCollectingEvents,
   [COLLECTION_OBJECT]: RouteNames.FilterCollectionObjects,
+  [CONTENT]: RouteNames.FilterContents,
   [DWC_OCCURRENCE]: RouteNames.FilterDwcOccurrences,
   [EXTRACT]: RouteNames.FilterExtracts,
   [FIELD_OCCURRENCE]: RouteNames.FilterFieldOccurrence,

--- a/app/javascript/vue/tasks/contents/filter/App.vue
+++ b/app/javascript/vue/tasks/contents/filter/App.vue
@@ -8,6 +8,7 @@
       :object-type="CONTENT"
       :selected-ids="selectedIds"
       :list="list"
+      :radial-navigator="false"
       v-model="parameters"
       v-model:append="append"
       @filter="makeFilterRequest({ ...parameters, extend, page: 1 })"

--- a/app/javascript/vue/tasks/data_attributes/field_synchronize/constants/queryParameters.js
+++ b/app/javascript/vue/tasks/data_attributes/field_synchronize/constants/queryParameters.js
@@ -3,6 +3,7 @@ import {
   BiologicalAssociation,
   CollectionObject,
   CollectingEvent,
+  Content,
   Descriptor,
   Extract,
   Image,
@@ -19,6 +20,7 @@ import {
   BIOLOGICAL_ASSOCIATION,
   COLLECTING_EVENT,
   COLLECTION_OBJECT,
+  CONTENT,
   DESCRIPTOR,
   EXTRACT,
   IMAGE,
@@ -50,6 +52,12 @@ export const QUERY_PARAMETER = {
     model: COLLECTING_EVENT,
     service: CollectingEvent,
     filterUrl: FILTER_ROUTES[COLLECTING_EVENT]
+  },
+
+  [QUERY_PARAM[CONTENT]]: {
+    model: CONTENT,
+    service: Content,
+    filterUrl: FILTER_ROUTES[CONTENT]
   },
 
   [QUERY_PARAM[COLLECTION_OBJECT]]: {


### PR DESCRIPTION
STR commit 1
1. Go to Filter Contents, filter something, try to use the mass navigator radial
Get a 500 because Contents doesn't have any non-default navigator links (in `object_radials.yml`).

STR commit 2
1. as above
2. Use Field Synchronize from the mass linker radial
Get a message `Query parameter is not supported`
3. Use Multi-Update Data Attributes from the mass linker radial
Get an empty screen and a console error `_field_synchronize_constants__WEBPACK_IMPORTED_MODULE_0__.QUERY_PARAMETER[queryParam] is undefined`