### PR TITLE
Move type_materials relation to CO from biological_extensions

### DIFF
--- a/app/models/collection_object.rb
+++ b/app/models/collection_object.rb
@@ -143,6 +143,8 @@ class CollectionObject < ApplicationRecord
 
   has_many :collectors, through: :collecting_event
 
+  has_many :type_materials, inverse_of: :collection_object, dependent: :restrict_with_error
+
   accepts_nested_attributes_for :collecting_event, allow_destroy: true, reject_if: :reject_collecting_event
 
   before_validation :assign_type_if_total_or_ranged_lot_category_id_provided

--- a/app/models/concerns/shared/biological_extensions.rb
+++ b/app/models/concerns/shared/biological_extensions.rb
@@ -22,8 +22,6 @@ module Shared::BiologicalExtensions
 
     has_many :taxon_names, through: :otus
 
-    has_many :type_materials, inverse_of: :collection_object, dependent: :restrict_with_error
-
     has_many :biocuration_classifications, as: :biocuration_classification_object, dependent: :destroy, inverse_of: :biocuration_classification_object
 
     has_many :biocuration_classes, through: :biocuration_classifications #, inverse_of: :biological_collection_objects

--- a/app/models/concerns/shared/taxonomy.rb
+++ b/app/models/concerns/shared/taxonomy.rb
@@ -61,7 +61,9 @@ module Shared::Taxonomy
 
             # If we have no name, see if there is a Type reference and use it as proxy
             # !! Careful/TODO this is an arbitrary choice, technically can be only one primary, but not restricted in DB yet
-            a ||= type_materials.primary.first&.protonym
+            if self.class.base_class.name == 'CollectionObject'
+              a ||= type_materials.primary.first&.protonym
+            end
           when 'Otu'
             taxon_name&.valid_taxon_name
 

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -25,7 +25,7 @@ module Shared::Unify
     :dwc_occurrence,       # Will be destroyed on related objects destruction
     :pinboard_items,       # Technically not needed here
     :cached_map_register,  # Destroyed on merge of things like Georeferences and AssertedDistributions
-    :cached_map_items,    
+    :cached_map_items,
     :cached_maps,          # Destroy alternate
   ]
 


### PR DESCRIPTION
It doesn't apply to FOs when in biological_extensions, and that was breaking Unify FOs.