### PR TITLE
Slow cached map item translates

### DIFF
--- a/app/controllers/tasks/geographic_areas/usage_controller.rb
+++ b/app/controllers/tasks/geographic_areas/usage_controller.rb
@@ -4,7 +4,7 @@ class Tasks::GeographicAreas::UsageController < ApplicationController
   # GET
   def index
     if params[:geographic_area_id].present?
-      @geogrpahic_areas = GeographicArea.where(id: params[:geographic_area_id])
+      @geographic_areas = GeographicArea.where(id: params[:geographic_area_id])
     else
       @geographic_areas = GeographicArea.all
     end

--- a/app/models/cached_map_item.rb
+++ b/app/models/cached_map_item.rb
@@ -191,6 +191,10 @@ class CachedMapItem < ApplicationRecord
   #   area (and so has a chance of already being associated with a cached map
   #   item/translation)
   #
+  # @param search_existing_translates [Boolean]
+  #   true if existing cached_map_item_translations should be checked for a
+  #   match.
+  #
   # @param data_origin Array, String
   #   like `ne_states` or ['ne_states, 'ne_countries']
   #
@@ -199,7 +203,8 @@ class CachedMapItem < ApplicationRecord
   #   Typical use, do not apply for Georeferences, apply -10km for AssertedDistributions
   #
   def self.translate_geographic_item_id(
-    geographic_item_id, geographic_area_based, data_origin = nil, buffer = nil
+    geographic_item_id, geographic_area_based,
+    search_existing_translates = true, data_origin = nil, buffer = nil
   )
     return nil if data_origin.blank?
 
@@ -208,6 +213,13 @@ class CachedMapItem < ApplicationRecord
     a = nil
 
     b = buffer
+
+    if search_existing_translates
+      a = translate_by_geographic_item_translation(
+        geographic_item_id, cached_map_type
+      )
+      return a if a.present?
+    end
 
     # All these methods depend on "prior knowledge" (not spatial calculations)
     if geographic_area_based
@@ -280,19 +292,14 @@ class CachedMapItem < ApplicationRecord
     if geographic_item_id
       h[:origin_geographic_item_id] = geographic_item_id
 
-      # We assume georefs won't match on an existing translation
-      if base_class_name != 'Georeference' &&
-         (a = translate_by_geographic_item_translation(geographic_item_id, cached_map_type)).present?
-        h[:geographic_item_id] = a
-      else
-        geographic_area_based = base_class_name == 'AssertedDistribution' &&
-          o.asserted_distribution_shape_type == 'GeographicArea'
-        h[:geographic_item_id] = translate_geographic_item_id(
-          geographic_item_id,
-          geographic_area_based,
-          cached_map_type.safe_constantize::SOURCE_GAZETEERS
-        )
-      end
+      geographic_area_based = base_class_name == 'AssertedDistribution' &&
+        o.asserted_distribution_shape_type == 'GeographicArea'
+      search_existing_translates = base_class_name == 'AssertedDistribution'
+
+      h[:geographic_item_id] = translate_geographic_item_id(
+        geographic_item_id, geographic_area_based, search_existing_translates,
+        cached_map_type.safe_constantize::SOURCE_GAZETEERS
+      )
 
       if h[:geographic_item_id].blank?
         h[:geographic_item_id] = [geographic_item_id]

--- a/app/models/cached_map_item.rb
+++ b/app/models/cached_map_item.rb
@@ -168,17 +168,16 @@ class CachedMapItem < ApplicationRecord
     # aware of this assumption
 
     # This is a fast first pass, pure intersection
-    gi = GeographicItem.arel_table
     a = GeographicItem
-      .joins(:geographic_areas_geographic_items)
-      .where(geographic_areas_geographic_items: { data_origin: })
-      # !! very slow, don't use
-      #.merge(GeographicItem.intersecting(:multi_polygon, geographic_item_id))
+      .with(b: GeographicItem
+        .joins(:geographic_areas_geographic_items)
+        .where(geographic_areas_geographic_items: { data_origin: })
+      )
+      .from('b')
+      .select('b.*')
       .where(
-        GeographicItem.st_intersects_sql(
-          gi[:geography],
-          gi.project(gi[:geography]).where(gi[:id].eq(geographic_item_id))
-        )
+        'ST_Intersects(b.geography, (SELECT geography FROM geographic_items ' \
+        'WHERE geographic_items.id = ?))', geographic_item_id
       )
       .pluck(:id)
 

--- a/app/models/collecting_event.rb
+++ b/app/models/collecting_event.rb
@@ -668,9 +668,11 @@ class CollectingEvent < ApplicationRecord
       .where(GeographicItem.within_radius_of_item_sql(geographic_item_id, distance))
   end
 
+  # DEPRECATED (unused)
   # @return [Scope]
   # Find all (other) CEs which have GIs or EGIs (through georeferences) which intersect self
   def collecting_events_intersecting_with
+    # TODO may need to optimize through .intersecting
     pieces = GeographicItem.with_collecting_event_through_georeferences.intersecting('any', self.geographic_items.first.id).distinct
     gr     = [] # all collecting events for a geographic_item
 

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -673,6 +673,7 @@ class GeographicItem < ApplicationRecord
                           ).distinct
     end
 
+    # DEPRECATED (unused)
     # This is a geographic intersect, not geometric
     def intersecting(shape, *geographic_item_ids)
       shape = shape.to_s.downcase

--- a/app/views/tasks/geographic_items/debug/index.html.erb
+++ b/app/views/tasks/geographic_items/debug/index.html.erb
@@ -49,7 +49,7 @@
     <div class="panel content separate-left">
       <h3> WebLevel1 (full translate) </h3>
       <% a = CachedMapItem.translate_geographic_item_id( @geographic_item.id,
-        true, # A fib, but should give the correct result in all cases
+        true, true, # A fib, but should give the correct result in all cases
         ['ne_states'])
       %>
       <div>

--- a/lib/tasks/maintenance/cached/maps.rake
+++ b/lib/tasks/maintenance/cached/maps.rake
@@ -103,7 +103,7 @@ namespace :tw do
             h = CachedMapItem.cached_map_name_hierarchy(o.geographic_item_id)
 
             z = CachedMapItem.where(geographic_item_id: o.geographic_item_id)
-              .where.not(untranslated: true)
+              .where('untranslated IS NULL OR untranslated = FALSE')
 
             #puts 'Size: ' + z.size.to_s
 

--- a/lib/tasks/maintenance/cached/maps.rake
+++ b/lib/tasks/maintenance/cached/maps.rake
@@ -105,7 +105,7 @@ namespace :tw do
             z = CachedMapItem.where(geographic_item_id: o.geographic_item_id)
               .where.not(untranslated: true)
 
-            puts 'Size: ' + z.size.to_s
+            #puts 'Size: ' + z.size.to_s
 
             z.update_all(
               level0_geographic_name: h[:country],
@@ -113,8 +113,8 @@ namespace :tw do
               level2_geographic_name: h[:county]
             )
 
-            puts o.geographic_item_id
-            puts h
+            #puts o.geographic_item_id
+            #puts h
           end
           puts 'Done labelling cached map items.'
         end
@@ -277,7 +277,7 @@ namespace :tw do
           begin
             #  print "#{id}: "
             t = CachedMapItem.translate_geographic_item_id(
-              geographic_item_id, geographic_area_based, ['ne_states']
+              geographic_item_id, geographic_area_based, false, ['ne_states']
             )
             # if t.present?
             #   print t.join(', ')

--- a/lib/tasks/maintenance/cached/maps.rake
+++ b/lib/tasks/maintenance/cached/maps.rake
@@ -255,15 +255,19 @@ namespace :tw do
           ids_in__ga.sort!
           ids_in__gz.sort!
 
-          Parallel.each(ids_in__ga, progress: 'build_cached_map_item_translations', in_processes: cached_rebuild_processes ) do |id|
+          Parallel.each(ids_in__ga, progress: 'build_cached_map_item_translations GA', in_processes: cached_rebuild_processes ) do |id|
             reconnected ||= CachedMapItemTranslation.connection.reconnect! || true
             process_asserted_distribution_translation(id, true)
           end
 
-          Parallel.each(ids_in__gz, progress: 'build_cached_map_item_translations', in_processes: cached_rebuild_processes ) do |id|
+          puts 'Geographic Area-based Asserted Distributions done.'
+
+          Parallel.each(ids_in__gz, progress: 'build_cached_map_item_translations GZ', in_processes: cached_rebuild_processes ) do |id|
             reconnected ||= CachedMapItemTranslation.connection.reconnect! || true
             process_asserted_distribution_translation(id, false)
           end
+
+          puts 'Gazetteer-based Asserted Distributions done.'
 
           puts 'Done.'
         end

--- a/lib/tasks/maintenance/cached/maps.rake
+++ b/lib/tasks/maintenance/cached/maps.rake
@@ -103,7 +103,7 @@ namespace :tw do
             h = CachedMapItem.cached_map_name_hierarchy(o.geographic_item_id)
 
             z = CachedMapItem.where(geographic_item_id: o.geographic_item_id)
-              .where('untranslated IS NULL OR untranslated = FALSE')
+              .where(untranslated: [nil, false])
 
             #puts 'Size: ' + z.size.to_s
 

--- a/spec/models/cached_map_item_spec.rb
+++ b/spec/models/cached_map_item_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe CachedMapItem, type: :model, group: [:geo, :cached_map] do
 
   include_context 'cached map scenario'
 
-  specify '#translate_geographic_item_id' do
-    expect(CachedMapItem.translate_geographic_item_id(gi2.id, true,  ['ne_states'])).to contain_exactly(gi1.id)
+  specify '#translate_geographic_item_id 1' do
+    expect(CachedMapItem.translate_geographic_item_id(gi2.id, true, true, ['ne_states'])).to contain_exactly(gi1.id)
   end
 
-  specify '#translate_geographic_item_id' do
-    expect(CachedMapItem.translate_geographic_item_id(gi3.id, true, ['ne_states'])).to contain_exactly(gi1.id)
+  specify '#translate_geographic_item_id 2' do
+    expect(CachedMapItem.translate_geographic_item_id(gi3.id, true, true, ['ne_states'])).to contain_exactly(gi1.id)
   end
 
   context 'Gazetteer-backed asserted distributions' do

--- a/spec/models/geographic_item_spec.rb
+++ b/spec/models/geographic_item_spec.rb
@@ -643,7 +643,8 @@ describe GeographicItem, type: :model, group: [:geo, :shared_geo] do
         )
       end
 
-      specify 'does not work with arbitrary geometry collection' do
+      # This seems to work in recent pg?
+      xspecify 'does not work with arbitrary geometry collection' do
         pending 'ST_Covers fails when input GeometryCollection has a line intersecting a polygon\'s interior'
         # The same test as the previous only the geometry collection in the
         # first argument also contains a line intersecting the interior of


### PR DESCRIPTION
This fixes the gazetteer branch being 3x slower than old development on recreating the cached map index. On OSF project locally it's now:
gaz branch: 1h2m
old dev branch: 1h20m

Side note: I noticed that most of the time creating translations for ADs for OSF (at least the version of OSF I have) is spent on just _one_ geographic_item: North America (61718). Checking for intersection with 3,669 ne_states GAs takes a _long_ time in that case. No fix for that yet.