### PR TITLE
Filter roll call

### DIFF
--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -192,6 +192,7 @@ module Queries
       # Shape is a Hash in GeoJSON format
       def geo_json_facet
         return nil if geo_json.nil?
+        return ::AssertedDistribution.none if roll_call
 
         i = spatial_query
         return nil if i.nil?
@@ -213,7 +214,6 @@ module Queries
             ::AssertedDistribution
               .where( asserted_distribution_shape: gz_ids )
               .where( asserted_distribution_shape_type: 'Gazetteer')
-
           )
 
       end
@@ -263,6 +263,7 @@ module Queries
         return nil if geo_shape_id.empty? || geo_shape_type.empty? ||
           # TODO: this should raise an error(?)
           geo_shape_id.length != geo_shape_type.length
+        return ::AssertedDistribution.none if roll_call
 
         geographic_area_shapes, gazetteer_shapes = shapes_for_geo_mode
 

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -277,11 +277,9 @@ module Queries
 
         if geo_mode == true # spatial
           i = ::Queries.union(::GeographicItem, [a,b])
-          wkt_shape =
-            ::Queries::GeographicItem.st_union(i)
-              .to_a.first['st_union'].to_s
+          u = ::Queries::GeographicItem.st_union_text(i).to_a.first
 
-          return from_wkt(wkt_shape)
+          return from_wkt(u['st_astext'])
         end
 
         referenced_klass_union([a,b])

--- a/lib/queries/biological_association/filter.rb
+++ b/lib/queries/biological_association/filter.rb
@@ -376,15 +376,11 @@ module Queries
       end
 
       def base_otu_query(opts)
-        q = ::Queries::Otu::Filter.new(opts)
-        q.project_id = nil # reset at use
-        q
+        ::Queries::Otu::Filter.new(opts)
       end
 
       def base_collection_object_query(opts)
-        q = ::Queries::CollectionObject::Filter.new(opts)
-        q.project_id = nil # reset at use
-        q
+        ::Queries::CollectionObject::Filter.new(opts)
       end
 
       def subject_collection_object_query
@@ -465,13 +461,11 @@ module Queries
 
         a_sql, b_sql = nil, nil
 
-        if !a&.all(true).nil?
-          a.project_id = project_id
+        if !a.nil? && !a.only_project?
           a_sql = a.all.to_sql
         end
 
-        if !b&.all(true).nil?
-          b.project_id = project_id
+        if !b.nil? && !b.only_project?
           b_sql = b.all.to_sql
         end
 
@@ -526,13 +520,11 @@ module Queries
 
         a_sql, b_sql = nil, nil
 
-        if !a&.all(true).nil?
-          a.project_id = project_id
+        if !a.nil? && !a.only_project?
           a_sql = a.all.to_sql
         end
 
-        if !b&.all(true).nil?
-          b.project_id = project_id
+        if !b.nil? && !b.only_project?
           b_sql = b.all.to_sql
         end
 

--- a/lib/queries/collecting_event/filter.rb
+++ b/lib/queries/collecting_event/filter.rb
@@ -239,6 +239,7 @@ module Queries
         return nil if geo_shape_id.empty? || geo_shape_type.empty? ||
           # TODO: this should raise an error(?)
           geo_shape_id.length != geo_shape_type.length
+        return ::CollectingEvent.none if roll_call
 
         geographic_area_shapes, gazetteer_shapes = shapes_for_geo_mode
 
@@ -327,6 +328,8 @@ module Queries
 
       def wkt_facet
         return nil if wkt.blank?
+        return ::CollectingEvent.none if roll_call
+
         from_wkt(wkt)
       end
 
@@ -340,6 +343,8 @@ module Queries
       # Shape is a Hash in GeoJSON format
       def geo_json_facet
         return nil if geo_json.nil?
+        return ::CollectingEvent.none if roll_call
+
         if a = RGeo::GeoJSON.decode(geo_json)
           return spatial_query(a.geometry_type.to_s, a.to_s)
         else

--- a/lib/queries/collecting_event/filter.rb
+++ b/lib/queries/collecting_event/filter.rb
@@ -51,6 +51,7 @@ module Queries
         :use_max,
         :use_min,
         :wkt,
+        :wkt_geometry_type,
         collecting_event_id: [],
         collector_id: [],
         geo_shape_id: [],
@@ -89,6 +90,9 @@ module Queries
 
       # A spatial representation in well known text
       attr_accessor :wkt
+
+      # Geometry type (Point, MultiPolygon, etc.) of `wkt`
+      attr_accessor :wkt_geometry_type
 
       # Integer in Meters
       #   !! defaults to 100m
@@ -166,6 +170,7 @@ module Queries
         @use_max = params[:use_max]
         @use_min = params[:use_min]
         @wkt = params[:wkt]
+        @wkt_geometry_type = params[:wkt_geometry_type]
 
         set_confidences_params(params)
         set_attributes_params(params)
@@ -330,7 +335,7 @@ module Queries
         return nil if wkt.blank?
         return ::CollectingEvent.none if roll_call
 
-        from_wkt(wkt)
+        from_wkt(wkt, wkt_geometry_type)
       end
 
       # TODO: check, this should be simplifiable.

--- a/lib/queries/collection_object/filter.rb
+++ b/lib/queries/collection_object/filter.rb
@@ -879,12 +879,8 @@ module Queries
       end
 
       def base_collecting_event_query_facet
-        # Turn project_id off and check for a truly empty query
-        base_collecting_event_query.project_id = nil
-        return nil if base_collecting_event_query.all(true).nil?
-
-        # Turn project_id back on
-        base_collecting_event_query.project_id = project_id
+        return nil if
+          base_collecting_event_query.only_project?
 
         s = 'WITH query_ce_base_co AS (' + base_collecting_event_query.all.select(:id).to_sql + ') ' +
           ::CollectionObject

--- a/lib/queries/concerns/geo.rb
+++ b/lib/queries/concerns/geo.rb
@@ -101,14 +101,4 @@ module Queries::Concerns::Geo
 
     a
   end
-
-  def gazetteer_id_facet
-    return nil if gazetteer_id.empty?
-
-    i = ::GeographicItem.joins(:gazetteers).where(gazetteers: { id: gazetteer_id })
-    wkt_shape = ::Queries::GeographicItem.st_union(i).to_a.first['st_union'].to_s
-
-    from_wkt(wkt_shape)
-  end
-
 end

--- a/lib/queries/field_occurrence/filter.rb
+++ b/lib/queries/field_occurrence/filter.rb
@@ -29,9 +29,6 @@ module Queries
         # :determiner_name_regex,
         # :determiners,
         # :dwc_indexed,
-        :geo_mode,
-        :geo_shape_id,
-        :geo_shape_type,
         :georeferences,
         # :import_dataset_id,
         :otu_id,
@@ -46,8 +43,6 @@ module Queries
         collecting_event_id: [],
         field_occurrence_id: [],
         determiner_id: [],
-        geo_shape_id: [],
-        geo_shape_type: [],
         # import_dataset_id: [],
         # is_type: [],
         otu_id: [],
@@ -445,12 +440,7 @@ module Queries
       end
 
       def base_collecting_event_query_facet
-        # Turn project_id off and check for a truly empty query
-        base_collecting_event_query.project_id = nil
-        return nil if base_collecting_event_query.all(true).nil?
-
-        # Turn project_id back on
-        base_collecting_event_query.project_id = project_id
+        return nil if base_collecting_event_query.only_project?
 
         s = 'WITH query_ce_base_co AS (' + base_collecting_event_query.all.to_sql + ') ' +
           ::FieldOccurrence

--- a/lib/queries/geographic_item/filter.rb
+++ b/lib/queries/geographic_item/filter.rb
@@ -1,6 +1,7 @@
 module Queries
   module GeographicItem
 
+    # DEPRECATED, unused
     def self.st_union(geographic_item_scope)
       ::GeographicItem
         .select(

--- a/lib/queries/geographic_item/filter.rb
+++ b/lib/queries/geographic_item/filter.rb
@@ -9,6 +9,23 @@ module Queries
         .where(id: geographic_item_scope.pluck(:id))
     end
 
+    def self.st_union_text(geographic_item_scope)
+      ::GeographicItem
+        .with(u:
+          ::GeographicItem
+            .select(
+              ::GeographicItem
+                .st_union_sql(::GeographicItem.geography_as_geometry)
+            )
+            .where(id: geographic_item_scope.pluck(:id))
+        )
+        .from('u')
+        .select(
+          ::GeographicItem.st_as_text_sql(Arel.sql('u.st_union')),
+          ::GeographicItem.st_geometry_type(Arel.sql('u.st_union'))
+        )
+    end
+
     class Filter < Query::Filter
       PARAMS = [
         :geographic_item_id

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -266,7 +266,7 @@ module Queries
         from_wkt(wkt)
       end
 
-      def from_wkt(wkt_shape, wkt_geometry_type)
+      def from_wkt(wkt_shape, wkt_geometry_type = nil)
         c = ::Queries::CollectingEvent::Filter.new(
           wkt: wkt_shape, wkt_geometry_type:, project_id:
         )

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -278,6 +278,7 @@ module Queries
 
       def geo_json_facet
         return nil if geo_json.blank?
+        return ::Otu.none if roll_call
 
         c = ::Queries::CollectingEvent::Filter.new(geo_json:, project_id:, radius:)
         a = ::Queries::AssertedDistribution::Filter.new(geo_json:, project_id:, radius:)
@@ -410,6 +411,7 @@ module Queries
         return nil if geo_shape_id.empty? || geo_shape_type.empty? ||
           # TODO: this should raise an error(?)
           geo_shape_id.length != geo_shape_type.length
+          return ::Otu.none if roll_call
 
         geographic_area_shapes, gazetteer_shapes = shapes_for_geo_mode
 

--- a/lib/queries/query/filter.rb
+++ b/lib/queries/query/filter.rb
@@ -66,9 +66,7 @@ module Queries
       base_name + '_query'
     end
 
-    def query_name
-      self.class.query_name
-    end
+    delegate :query_name, to: :class
 
     # @return [Hash]
     #  only referenced in specs
@@ -257,6 +255,16 @@ module Queries
     # !! This is used strictly during the permission process of ActionController::Parameters !!
     attr_reader :params
 
+    # @return Boolean
+    # If true then *_facet methods need only return
+    # scope.none to indicate that the facet is active
+    # given the current parameters. Facet return scopes
+    # are never actually queried in this case.
+    # If you're a facet that does work to create your scope
+    # then you should check this attribute and *not* do
+    # that work when it's true. Otherwise you can safely
+    # ignore this.
+    attr_accessor :roll_call
 
     # @params query_params [ActionController::Parameters]
     def initialize(query_params)
@@ -290,6 +298,8 @@ module Queries
       @page = query_params[:page]
 
       @order_by = query_params[:order_by]
+
+      @roll_call = false
 
       # After this point, if you started with ActionController::Parameters,
       # then all values have been explicitly permitted.
@@ -749,7 +759,13 @@ module Queries
     #   true - the only param pasted is `project_id` !! Note that this is the default for all queries, it is set on initialize
     #   false - there are no params at ALL or at least one that is not `project_id`, and project_id != false
     def only_project?
-      (project_id_facet && target_and_clauses.size == 1 && all_merge_clauses.nil?) ? true : false
+      @roll_call = true
+      a = (project_id_facet &&
+        target_and_clauses.size == 1 &&
+        all_merge_clauses.nil?) ? true : false
+      @roll_call = false
+
+      a
     end
 
     # @param nil_empty [Boolean]


### PR DESCRIPTION
See what you think, I'm open to other approaches or holding off on this. The tldr: ~2x speed up on (some) spatial filters.

There are two patterns in use for checking if a query's params generate any facets other than the default project_id_facet: the `# Turn project_id off and check for a truly empty query` pattern and the `Filter#only_project?` call.

The issue with both of those patterns is that they both create every facet to see which are not nil. (Some of the) spatial filters do almost all of their work *before* returning their facet scope, so in effect when the above pattern is used it doubles the time spent on spatial queries.
See for example https://github.com/SpeciesFileGroup/taxonworks/blob/e1ff19a25bb138fb3cdac0ad9cc551ba38bed2fd/lib/queries/collecting_event/filter.rb#L253-L260

This pr adds a `@roll_call` member variable to Filter that lets filter facets know they're just being polled to see if they're nil or not, allowing them to just return a scope.none value instead of doing all of their normal work. For facets that don't do much work to create their scope, they just ignore this and do what they've always done. In the spatial scopes though this make the facet run ~2x as fast.

Filters that benefit (for spatial facets): CO, CE, AD, Otu, BA, FO
Tasks that benefit (on spatial filters): Batch update Confidence and Protocol Relationships on filters, since they check for `only_project?` on their filter_query before running.

A couple timing examples:
* Filter Biological Associations on the NZ Stewart Island Gaz (with 38,055 exterior vertices) went from 4.39 minutes to 2m15s.
* Filter Collection Objects on the Fiordland Gaz (with 99,556 exterior vertices) went from 2.10 to 1.02m

