### PR TITLE
Display citations as html in Keys Hub

### DIFF
--- a/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
+++ b/app/javascript/vue/tasks/leads/hub/components/KeyCitations.vue
@@ -6,9 +6,11 @@
     :key="citation.id"
   >
     <div class="lead_citation">
-      <a :href="citation.source.object_url" target="_blank">
-        {{ citation.citation_source_body }}
-      </a>
+      <a
+        :href="citation.source.object_url"
+        target="_blank"
+        v-html="citation.citation_source_body"
+      />
     </div>
   </div>
   <div v-else>


### PR DESCRIPTION
The only html part of citation_source_body is topics (and citation_source_body is, in my opinion, the best option available in citations _attributes).

We could add citation_source_body_label to Citation _attributes if we don't like html topics here.

![image](https://github.com/user-attachments/assets/f0157fa7-6f04-4eab-b85f-bfc726ee4714)
