### PR TITLE
Copy georef error attrs on Set Georeference filter CE operation

### DIFF
--- a/app/controllers/collecting_events_controller.rb
+++ b/app/controllers/collecting_events_controller.rb
@@ -295,7 +295,8 @@ class CollectingEventsController < ApplicationController
       :group, :member, :formation, :lithology, :max_ma, :min_ma,
       :end_date_year, :verbatim_habitat, :field_notes, :verbatim_datum,
       :verbatim_elevation, :meta_prioritize_geographic_area,
-      georeferences_attributes: [:type, :geographic_item_id], # batch add only use right now
+      georeferences_attributes: [:type, :geographic_item_id, :error_radius,
+        :error_depth, :error_geographic_item], # batch add only use right now
       roles_attributes: [:id, :_destroy, :type, :person_id, :position, :by,
                          person_attributes: [:last_name, :first_name, :suffix, :prefix, :by]],
     identifiers_attributes: [:id, :namespace_id, :identifier, :type, :_destroy],

--- a/app/javascript/vue/components/radials/ce/components/GeoreferenceSlice.vue
+++ b/app/javascript/vue/components/radials/ce/components/GeoreferenceSlice.vue
@@ -113,10 +113,14 @@ const isCountExceeded = computed(() => props.count > MAX_LIMIT)
 const payload = computed(() => ({
   collecting_event_query: props.parameters,
   collecting_event: {
-    georeferences_attributes: georeferences.value.map(
-      ({ geographic_item_id, type }) => ({
+    georeferences_attributes: selectedGeoreferences.value.map(
+      ({ geographic_item_id, type , error_radius, error_depth,
+         error_geographic_item_id }) => ({
         geographic_item_id,
-        type
+        type,
+        error_radius,
+        error_depth,
+        error_geographic_item_id
       })
     )
   }


### PR DESCRIPTION
Note also this fixes copying only the selected georefs from the UI:
![image](https://github.com/user-attachments/assets/aae5ecc7-9d98-4a3c-ac21-3fb30ef342fd)

There are other georef attributes that could be copied as well which I left off, e.g., `api_request`, `is_undefined_z`, `attribute_year_georefenced`, etc.

Also we still don't display error regions in the Set Georeferences map (I didn't look into that).