### PR TITLE
Order Gaz import project names by :name; fixes indeterminate spec

### DIFF
--- a/app/models/gazetteer.rb
+++ b/app/models/gazetteer.rb
@@ -444,7 +444,8 @@ class Gazetteer < ApplicationRecord
 
     progress_tracker.update!(
       num_records: file.num_records,
-      project_names: Project.where(id: projects).pluck(:name).join(', '),
+      project_names:
+        Project.where(id: projects).order(:name).pluck(:name).join(', '),
       started_at: DateTime.now
     )
 


### PR DESCRIPTION
Fixes rspec ./spec/jobs/import_gazetteers_job_spec.rb:160 which expects projects listed in alpha order - randomly failing here for example: https://github.com/SpeciesFileGroup/taxonworks/actions/runs/15165196962/job/42641046062?pr=4363