### PR TITLE
Fix "Otu in key" case of api call for otu key inventory

### DIFF
--- a/app/helpers/otus_helper.rb
+++ b/app/helpers/otus_helper.rb
@@ -353,7 +353,7 @@ module OtusHelper
     assign_pagination(a) if pagination_headers
 
     b = Image.with(dwc_scope: a)
-      .joins("JOIN depictions d on d.image_id = images.id" )
+      .joins('JOIN depictions d on d.image_id = images.id' )
       .joins("JOIN dwc_scope on d.depiction_object_id = dwc_scope.dwc_occurrence_object_id AND d.depiction_object_type = 'CollectionObject' AND dwc_scope.dwc_occurrence_object_type = 'CollectionObject'")
       .select('images.*, dwc_scope.id dwc_id')
       .distinct
@@ -370,11 +370,13 @@ module OtusHelper
     return {
       observation_matrices: {
         scoped: otu.in_scope_observation_matrices.where(is_public:).select(:id, :name).inject({}){|hsh, m| hsh[m.id] = m.name; hsh;} || {} ,
+
         in: otu.observation_matrices.where(is_public:).select(:id, :name).inject({}){|hsh, m| hsh[m.id] = m.name; hsh;} || {},
       },
       leads: {
         scoped: otu.leads.where(parent_id: nil, is_public:).select(:id, :text).inject({}){|hsh, m| hsh[m.id] = m.text; hsh;} || {},
-        in:  otu.leads.where.not(parent_id: nil).where(is_public: true).select(:id, :text).inject({}){|hsh, m| hsh[m.id] = m.text; hsh;} || {},
+
+        in: Lead.root_leads_for_leaf_otus(otu).select(:id, :text).inject({}){|hsh, m| hsh[m.id] = m.text; hsh;} || {},
       }
     }
   end

--- a/app/helpers/otus_helper.rb
+++ b/app/helpers/otus_helper.rb
@@ -366,17 +366,17 @@ module OtusHelper
     r
   end
 
-  def otu_key_inventory(otu, is_public: true)
+  def otu_key_inventory(otu)
     return {
       observation_matrices: {
-        scoped: otu.in_scope_observation_matrices.where(is_public:).select(:id, :name).inject({}){|hsh, m| hsh[m.id] = m.name; hsh;} || {} ,
+        scoped: otu.in_scope_observation_matrices.where(is_public: true).select(:id, :name).inject({}){|hsh, m| hsh[m.id] = m.name; hsh;} || {} ,
 
-        in: otu.observation_matrices.where(is_public:).select(:id, :name).inject({}){|hsh, m| hsh[m.id] = m.name; hsh;} || {},
+        in: otu.observation_matrices.where(is_public: true).select(:id, :name).inject({}){|hsh, m| hsh[m.id] = m.name; hsh;} || {},
       },
       leads: {
-        scoped: otu.leads.where(parent_id: nil, is_public:).select(:id, :text).inject({}){|hsh, m| hsh[m.id] = m.text; hsh;} || {},
+        scoped: otu.leads.where(parent_id: nil, is_public: true).select(:id, :text).inject({}){|hsh, m| hsh[m.id] = m.text; hsh;} || {},
 
-        in: Lead.root_leads_for_leaf_otus(otu).select(:id, :text).inject({}){|hsh, m| hsh[m.id] = m.text; hsh;} || {},
+        in: Lead.public_root_leads_for_leaf_otus(otu).select(:id, :text).inject({}){|hsh, m| hsh[m.id] = m.text; hsh;} || {},
       }
     }
   end

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -74,7 +74,7 @@ class Lead < ApplicationRecord
   validate :node_parent_doesnt_have_redirect
   validate :root_has_no_redirect
   validate :redirect_isnt_ancestor_or_self
-  validates_uniqueness_of :text, scope: [:otu_id, :parent_id], unless: -> { otu_id.nil? }
+  validates :text, uniqueness: { scope: [:otu_id, :parent_id], unless: -> { otu_id.nil? } }
 
   def future
     redirect_id.blank? ? all_children : redirect.all_children
@@ -341,7 +341,7 @@ class Lead < ApplicationRecord
     end
   end
 
-  def self.root_leads_for_leaf_otus(otu)
+  def self.public_root_leads_for_leaf_otus(otu)
     # Leaf leads that have otu as their Otu.
     leaf_otu_leads = Lead
       .with(l_h: LeadHierarchy.where('ancestor_id != descendant_id'))
@@ -354,9 +354,9 @@ class Lead < ApplicationRecord
     # descendant.
     Lead
       .with(l_o_l: leaf_otu_leads)
-      .where(parent_id: nil)
       .joins('JOIN lead_hierarchies l_h2 ON l_h2.ancestor_id = leads.id')
       .where('l_h2.descendant_id IN (SELECT id FROM l_o_l)')
+      .where(parent_id: nil)
       .where(is_public: true)
   end
 

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -341,14 +341,17 @@ class Lead < ApplicationRecord
     end
   end
 
+  # @return Public root leads that have a leaf descendant with `otu` as its Otu,
+  # i.e. keys that have otu on a leaf node.
+  # !! Note it doesn't count if a key only has otu on an internal node;
+  # currently that's only allowed in TW, not in TP.
   def self.public_root_leads_for_leaf_otus(otu)
     # Leaf leads that have otu as their Otu.
     leaf_otu_leads = Lead
       .with(l_h: LeadHierarchy.where('ancestor_id != descendant_id'))
-      .with(otu_lead_ids: otu.leads)
+      .merge(otu.leads)
       .joins('LEFT OUTER JOIN l_h ON leads.id = l_h.ancestor_id')
       .where(l_h: {ancestor_id: nil})
-      .where('id IN (SELECT id FROM otu_lead_ids)')
 
     # Root leads that are public and have one of leaf_otu_leads as their
     # descendant.


### PR DESCRIPTION
Keys only set `is_public` on their root lead: https://github.com/SpeciesFileGroup/taxonworks/blob/199c7193b416006e3ee5e67c881b1e0a5616f950/app/models/lead.rb#L404-L410 so the previous version of the api call never returned anything in the `leads: in` section.

(One other technical point: internally, TaxonWorks allows setting an otu on internal lead nodes, but those otus are never exposed via the api, so the new query here ignores those internal leads having otu.)