### PR TITLE
Switch to pp_sql-logging-on only in dev console; never in logs

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,13 +2,6 @@ class ApplicationRecord < ActiveRecord::Base
   # Required here due to the eager load before config/routes.rb
   include NilifyBlanks
 
-  # Prettify SQL in console
-  # !! Do not use, it will break queries since we use .to_sql in constructing
-  # queries and prettify currently does things like turning `)::float` into
-  # `) : : float`.
-  # Use .pp_sql in place of .to_sql where you want prettified output.
-  #include PpSql::ToSqlBeautify if defined?(Rails::Console)
-
   self.abstract_class = true
 
   # Will run block on transaction, repeating 3 times if failed due to ActiveRecord:DeadLock exception.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,13 +3,17 @@ TaxonWorks::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # See https://github.com/kvokka/pp_sql
-  # Necessary since we use .to_sql during the creation of many of our queries
-  # and currently pp_sql prettifies things like `)::float` to
+  # Have to turn this off since we use .to_sql during the creation of many of
+  # our queries and currently pp_sql prettifies things like `)::float` to
   # `) : : float`.
   # Use .pp_sql in place of .to_sql where you want prettified output.
   PpSql.rewrite_to_sql_method = false
-  # Logger formatting applies to rails s output as well as console output.
-  #PpSql.add_rails_logger_formatting = false
+  # Logger formatting applies to rails s output as well as console output and
+  # background job log output; it can be very slow when you're doing things like
+  # querying on wkt of large shapes.
+  # Console prettifying is turned back on only in dev in the pp_sql.rb
+  # initializer.
+  PpSql.add_rails_logger_formatting = false
 
   config.active_storage.service = :local
 

--- a/config/initializers/vendor/pp_sql.rb
+++ b/config/initializers/vendor/pp_sql.rb
@@ -1,4 +1,17 @@
 if Rails.env.development? && defined?(Rails::Console)
   require 'pp_sql'
-  PpSql.add_rails_logger_formatting = true
+
+  if ENV['RAILS_PP_SQL_CONSOLE_LOGGING']
+    PpSql.add_rails_logger_formatting = true
+  end
+
+  def pp(bool)
+    if bool == true || bool == false
+      puts "PpSql logging is now set to #{bool}."
+    else
+      puts "Boolean input value required."
+    end
+
+    PpSql.add_rails_logger_formatting = bool
+  end
 end

--- a/config/initializers/vendor/pp_sql.rb
+++ b/config/initializers/vendor/pp_sql.rb
@@ -1,7 +1,7 @@
 if Rails.env.development? && defined?(Rails::Console)
   require 'pp_sql'
 
-  if ENV['RAILS_PP_SQL_CONSOLE_LOGGING']
+  if ENV['TW_PP_SQL_CONSOLE_LOGGING']
     PpSql.add_rails_logger_formatting = true
   end
 

--- a/config/initializers/vendor/pp_sql.rb
+++ b/config/initializers/vendor/pp_sql.rb
@@ -1,0 +1,4 @@
+if Rails.env.development? && defined?(Rails::Console)
+  require 'pp_sql'
+  PpSql.add_rails_logger_formatting = true
+end


### PR DESCRIPTION
I discovered that pp_sql is active during background jobs because I had a job that timed out on

```
Could not log "sql.active_record" event. AnbtSql::FormatterException: execution expired (Delayed::Worker.max_run_time is only 14400 seconds) ["/home/klein/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/anbt-sql-formatter-0.1.2/lib/anbt-sql-formatter/coarse-tokenizer.rb:141:in 'String#[]'", "/home/klein/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/anbt-sql-formatter-0.1.2/lib/anbt-sql-formatter/coarse-tokenizer.rb:141:in 'CoarseTokenizer#shift_to_buf'", "/home/klein/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/anbt-sql-formatter-0.1.2/lib/anbt-sql-formatter/coarse-tokenizer.rb:129:in 'CoarseTokenizer#tokenize'", "/home/klein/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/anbt-sql-formatter-0.1.2/lib/anbt-sql-formatter/parser.rb:283:in 'AnbtSql::Parser#parse'", "/home/klein/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/anbt-sql-formatter-0.1.2/lib/anbt-sql-formatter/formatter.rb:55:in 'AnbtSql::Formatter#format'", "/home/klein/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/pp_sql-2.1.0/lib/pp_sql.rb:56:in 'PpSql::LogSubscriberPrettyPrint#sql'", "/home/klein/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/activesupport-7.2.2.1/lib/active_support/subscriber.rb:138:in 'ActiveSupport::Subscriber#call'" ...
```

AnbtSql is pp_sql's parser(?) - the background job was processing large shapes, like 1,000,000+ vertex shapes, it looks like it timed out tokenizing one of those (it never got past the first shape). Without pp the job completed.

Another similar experience I had the other day was filtering COs in Brazil, the query took about 6 minutes, I think because it was logging Brazil's wkt shape, probably multiple times. Without pp that query takes about a second.