### PR TITLE
Remove pagination params on venn_query #4390

### DIFF
--- a/app/javascript/vue/components/Filter/Facets/shared/FacetDiffMode.vue
+++ b/app/javascript/vue/components/Filter/Facets/shared/FacetDiffMode.vue
@@ -46,9 +46,9 @@
         <input
           type="checkbox"
           :value="true"
-          v-model="params.venn_b_one_page"
+          v-model="params.venn_ignore_pagination"
         />
-        Restrict the B query to the page of results from which you copied the query. If not checked, all results of the B query will be included.
+        <span data-help="If checked, all results of the B query are used. Otherwise only the page of results from which you copied the B query is used.">Ignore pagination</span>
       </label>
     </div>
   </FacetContainer>
@@ -56,7 +56,6 @@
 
 <script setup>
 import FacetContainer from '@/components/Filter/Facets/FacetContainer.vue'
-import { computed } from 'vue'
 
 const VENN_MODES = {
   a: 'Exclude (A not B)',
@@ -64,22 +63,8 @@ const VENN_MODES = {
   b: 'Inverse exclude (B not A)'
 }
 
-const props = defineProps({
-  modelValue: {
-    type: Object,
-    required: true
-  }
-})
-
-const emit = defineEmits(['update:modelValue'])
-
-const params = computed({
-  get() {
-    return props.modelValue
-  },
-
-  set(value) {
-    emit('update:modelValue', value)
-  }
+const params = defineModel({
+  type: Object,
+  default: () => ({})
 })
 </script>

--- a/lib/queries/query/filter.rb
+++ b/lib/queries/query/filter.rb
@@ -235,11 +235,11 @@ module Queries
     attr_accessor :venn_mode
 
     # @return Boolean
-    # When true, the B venn query will use only the single page indicated by
-    # whatever paging parameters are set on the query.
-    # When false, all paging parameters will be removed from the B query and it
+    # When true, all paging parameters will be removed from the B query and it
     # will return its full result set for venn processing.
-    attr_accessor :venn_b_one_page
+    # When false, the B venn query will use only the single page indicated by
+    # whatever paging parameters are set on the query.
+    attr_accessor :venn_ignore_pagination
 
     # @return symbol
     #   must match a existing parameter name (used to check if values provided)
@@ -285,7 +285,7 @@ module Queries
 
       @venn = query_params[:venn]
       @venn_mode = query_params[:venn_mode]
-      @venn_b_one_page = boolean_param(query_params, :venn_b_one_page)
+      @venn_ignore_pagination = boolean_param(query_params, :venn_ignore_pagination)
 
       # !! This is the *only* place Current.project_id should be seen !! It's still not the best
       # way to implement this, but we use it to optimize the scope of sub/nested-queries efficiently.
@@ -756,7 +756,7 @@ module Queries
       end
 
       p = ::Rack::Utils.parse_nested_query(u) # nested supports brackets
-      p = p.except('per', 'page', 'paginate') unless venn_b_one_page
+      p = p.except('per', 'page', 'paginate') if venn_ignore_pagination
 
       a = ActionController::Parameters.new(p)
 

--- a/spec/lib/queries/query/filter_spec.rb
+++ b/spec/lib/queries/query/filter_spec.rb
@@ -62,13 +62,22 @@ describe Queries::Query::Filter, type: [:model] do
       expect(a.all).to contain_exactly(o3)
     end
 
-    specify '#venn_query #venn_b_one_page' do
+    specify '#venn_query includes b pagination by default' do
       v = "http://127.0.0.1:3000/otus/filter.json?otu_id[]=#{o1.id}&otu_id[]=#{o2.id}&otu_id[]=#{o3.id}&paginate=true&page=2&per=1"
 
       a = ::Queries::Otu::Filter.new(
-        otu_id: [o1.id, o2.id, o3.id],
-        venn: v, venn_mode: :a, venn_b_one_page: 'true')
+        otu_id: [o1.id, o2.id, o3.id], venn: v, venn_mode: :a)
       expect(a.all).to contain_exactly(o1, o3)
+    end
+
+    specify '#venn_query #venn_ignore_pagination' do
+      v = "http://127.0.0.1:3000/otus/filter.json?otu_id[]=#{o1.id}&otu_id[]=#{o2.id}&paginate=true&page=2&per=1"
+
+      a = ::Queries::Otu::Filter.new(
+        otu_id: [o1.id, o2.id, o3.id],
+        venn: v, venn_mode: :a, venn_ignore_pagination: true
+      )
+      expect(a.all).to contain_exactly(o3)
     end
   end
 
@@ -80,24 +89,24 @@ describe Queries::Query::Filter, type: [:model] do
     expect(q.venn_query.class).to eq(::Queries::Otu::Filter)
   end
 
-  specify '#venn_query params excludes pagination params by default' do
+  specify '#venn_query params includes pagination params by default' do
     v = 'http://127.0.0.1:3000/otus/filter.json?per=50&name=Ant&extend%5B%5D=taxonomy&page=1&paginate=true'
 
     q = ::Queries::Otu::Filter.new({})
     q.venn = v
     b = q.venn_query
-    expect(b.params).to eq({name: 'Ant'})
+    expect(b.params).to eq({name: 'Ant', paginate: 'true', page: '1', per: '50'})
   end
 
-  specify '#venn_query #venn_b_one_page=true' do
+  specify '#venn_query #venn_ignore_pagination=true' do
     v = 'http://127.0.0.1:3000/otus/filter.json?per=50&name=Ant&extend%5B%5D=taxonomy&page=1&paginate=true'
 
     q = ::Queries::Otu::Filter.new({
       venn: v,
-      venn_b_one_page: 'true'
+      venn_ignore_pagination: 'true'
     })
     b = q.venn_query
-    expect(b.params).to eq({name: 'Ant', paginate: 'true', page: '1', per: '50'})
+    expect(b.params).to eq({name: 'Ant'})
   end
 
   specify '#venn_mode 0' do


### PR DESCRIPTION
This removes them on the :b query; the :a query hasn't had them applied when venn processing occurs; the pagination params of the :a query are added to the venn'ed query after venn processing.