### PR TITLE
Make BatchByFilterScope controller concern DataControllerConfiguratio…

### DIFF
--- a/app/controllers/attributions_controller.rb
+++ b/app/controllers/attributions_controller.rb
@@ -1,6 +1,6 @@
 class AttributionsController < ApplicationController
   include DataControllerConfiguration::ProjectDataControllerConfiguration
-  include BatchByFilterScope
+  include DataControllerConfiguration::BatchByFilterScope
 
   before_action :set_attribution, only: [:show, :edit, :update, :destroy]
   after_action -> { set_pagination_headers(:attributions) }, only: [:index, :api_index ], if: :json_request?

--- a/app/controllers/concerns/data_controller_configuration/batch_by_filter_scope.rb
+++ b/app/controllers/concerns/data_controller_configuration/batch_by_filter_scope.rb
@@ -1,9 +1,11 @@
 # Users must implement batch_by_filter_scop_params, which should require a
 # `batch_params` key and permit batch parameters specific to the model.
-module BatchByFilterScope
+module DataControllerConfiguration::BatchByFilterScope
   extend ActiveSupport::Concern
 
   included do
+    include DataControllerConfiguration
+
     # POST
     def batch_by_filter_scope
       klass = controller_path.classify.constantize

--- a/app/controllers/confidences_controller.rb
+++ b/app/controllers/confidences_controller.rb
@@ -13,7 +13,7 @@ confidence_level_id
 
 class ConfidencesController < ApplicationController
   include DataControllerConfiguration::ProjectDataControllerConfiguration
-  include BatchByFilterScope
+  include DataControllerConfiguration::BatchByFilterScope
 
   before_action :set_confidence, only: [:edit, :update, :destroy]
   after_action -> { set_pagination_headers(:confidences) }, only: [:index, :api_index ], if: :json_request?

--- a/app/controllers/identifiers_controller.rb
+++ b/app/controllers/identifiers_controller.rb
@@ -1,6 +1,6 @@
 class IdentifiersController < ApplicationController
   include DataControllerConfiguration::ProjectDataControllerConfiguration
-  include BatchByFilterScope
+  include DataControllerConfiguration::BatchByFilterScope
 
   before_action :set_identifier, only: [:update, :destroy, :show]
 

--- a/app/controllers/protocol_relationships_controller.rb
+++ b/app/controllers/protocol_relationships_controller.rb
@@ -1,6 +1,6 @@
 class ProtocolRelationshipsController < ApplicationController
   include DataControllerConfiguration::ProjectDataControllerConfiguration
-  include BatchByFilterScope
+  include DataControllerConfiguration::BatchByFilterScope
 
   before_action :set_protocol_relationship, only: [:show, :edit, :update, :destroy]
 


### PR DESCRIPTION
…n #4188

It's just a little awkward here since `DataControllerConfiguration::ProjectDataControllerConfiguration` also includes `DataControllerConfiguration`, but Ruby protects us there from double include, and I think in general this is the right thing for BatchByFilterScope to do.