### PR TITLE
Fix async case of georef create for Filter CE #4401

### DIFF
--- a/app/controllers/collecting_events_controller.rb
+++ b/app/controllers/collecting_events_controller.rb
@@ -132,8 +132,10 @@ class CollectingEventsController < ApplicationController
   def batch_update
     if r = CollectingEvent.batch_update(
         preview: params[:preview],
-        collecting_event: collecting_event_params.merge(by: sessions_current_user_id),
-        collecting_event_query: params[:collecting_event_query])
+        collecting_event: collecting_event_params,
+        collecting_event_query: params[:collecting_event_query],
+        user_id: sessions_current_user_id,
+        project_id: sessions_current_project_id)
       render json: r.to_json, status: :ok
     else
       render json: {}, status: :unprocessable_entity

--- a/app/models/collecting_event.rb
+++ b/app/models/collecting_event.rb
@@ -1078,13 +1078,14 @@ class CollectingEvent < ApplicationRecord
 
     # @return [Hash, false]
     def batch_update(params)
-
       request = QueryBatchRequest.new(
         klass: 'CollectingEvent',
         object_filter_params: params[:collecting_event_query],
         object_params: params[:collecting_event],
         async_cutoff: params[:async_cutoff] || 26,
         preview: params[:preview],
+        project_id: params[:project_id],
+        user_id: params[:user_id]
       )
 
       request.cap = 5000

--- a/app/models/concerns/shared/query_batch_update.rb
+++ b/app/models/concerns/shared/query_batch_update.rb
@@ -10,7 +10,16 @@ module Shared::QueryBatchUpdate
   # @params params [Hash]
   #   the attributes to update
   # @params result [BatchResponse]
-  def query_update(params, response = nil)
+  def query_update(
+    params, response = nil, async_project_id = nil, async_user_id = nil
+  )
+    if async_project_id && Current.project_id.nil?
+      Current.project_id = async_project_id
+    end
+    if async_user_id && Current.user_id.nil?
+      Current.user_id = async_user_id
+    end
+
     begin
       update!( params )
       response.updated.push self.id if response
@@ -37,7 +46,11 @@ module Shared::QueryBatchUpdate
 
       if request.run_async?
         a.all.find_each do |o|
-          o.delay(run_at: Proc.new { 1.second.from_now }, queue: :query_batch_update).query_update(request.object_params)
+          o
+            .delay(run_at: Proc.new { 1.second.from_now }, queue: :query_batch_update)
+            .query_update(
+              request.object_params, nil, request.project_id, request.user_id
+            )
         end
       else
         self.transaction do

--- a/lib/query_batch_request.rb
+++ b/lib/query_batch_request.rb
@@ -45,6 +45,10 @@ class QueryBatchRequest
   #   Not used in async
   attr_accessor :total_attempted
 
+  attr_accessor :project_id
+
+  attr_accessor :user_id
+
   def initialize(params)
     @async = params[:async]
     @async_cutoff = params[:async_cutoff]
@@ -54,6 +58,8 @@ class QueryBatchRequest
     @object_filter_params = params[:object_filter_params]
     @object_params = params[:object_params]
     @preview = params[:preview]
+    @project_id = params[:project_id]
+    @user_id = params[:user_id]
 
     @mode = params[:mode]
   end


### PR DESCRIPTION
STR:
1) Check a bunch (say > 25) of CEs in Filter CE.
2) Run the Set Georef task on them; it should run async. 3) Check your CEs for their new georefs, find no new ones.

The issue is that, although we're adding a `by:` value to the top level of the CE params we want to create on our filter results, we're *not* adding it to the individual georef_attributes array items, which is where it, along with project_id, is needed to create those georefs in the background.

```ruby
collecting_event: {
  georeferences_attributes: [
    {
      geographic_item_id: georef2.geographic_item.id,
      type: 'Georeference::VerbatimData',
    },
    {
      geographic_item_id: georef3.geographic_item.id,
      type: 'Georeference::Leaflet',
    }
  ],
  by: ...
}
```

To fix I updated QueryBatchRequest/query_batch_update to hold/use project_id and user_id as Current in async jobs. (We could pass the georef we're copying from's project_id, but not its update_by_id; and we could add both pieces of data in the controller to each embedded object; this solve both cases at once in a clean way I think(?)).