### PR TITLE
Protect against GAs with no shape in spatial filters

### DIFF
--- a/app/javascript/vue/components/Filter/Facets/shared/FacetGeographic.vue
+++ b/app/javascript/vue/components/Filter/Facets/shared/FacetGeographic.vue
@@ -42,14 +42,19 @@
             v-for="(shape, index) in shapes"
             :key="shape.id"
           >
-            <span
-              :class="{
-                subtle:
-                  params.geo_mode ===
-                    GEOGRAPHIC_OPTIONS.Spatial && !shape.has_shape
-              }"
-              v-html="shape.name"
-            />
+            <span>
+              <span
+                v-html="shape.name"
+              />
+              <VIcon
+                v-if="geoMode === GEOGRAPHIC_OPTIONS.Spatial && !shape.has_shape"
+                color="attention"
+                name="attention"
+                small
+                title="This has no shape and so won't participate in spatial search"
+                class="separate-left center_text"
+              />
+            </span>
             <VBtn
               circle
               color="primary"
@@ -205,7 +210,6 @@ watch(
 watch(
   [shapes, geoMode],
   () => {
-    // TODO: revisit, simplify
     if (geoMode.value === GEOGRAPHIC_OPTIONS.Spatial) {
       params.value.geo_shape_id =
         shapes.value

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -279,7 +279,13 @@ module Queries
           i = ::Queries.union(::GeographicItem, [a,b])
           u = ::Queries::GeographicItem.st_union_text(i).to_a.first
 
-          return from_wkt(u['st_astext'])
+          if u['st_astext'].nil?
+            # Normally shouldn't be the case unless we were passed some bad
+            # params.
+            return ::AssertedDistribution.none
+          else
+            return from_wkt(u['st_astext'])
+          end
         end
 
         referenced_klass_union([a,b])

--- a/lib/queries/collecting_event/filter.rb
+++ b/lib/queries/collecting_event/filter.rb
@@ -260,9 +260,16 @@ module Queries
           i = ::Queries.union(::GeographicItem, [a,b])
           u = ::Queries::GeographicItem.st_union_text(i).to_a.first
 
-          return from_wkt(
-            u['st_astext'], u['st_geometrytype'].delete_prefix!('ST_')
-          )
+          if u['st_astext'].nil? || u['st_geometrytype'].nil?
+            # Normally shouldn't be the case unless we were passed some bad
+            # params.
+            return ::CollectingEvent.none
+          else
+            return from_wkt(
+              u['st_astext'], u['st_geometrytype'].delete_prefix!('ST_')
+            )
+          end
+
         end
 
         referenced_klass_union([a,b])

--- a/lib/queries/concerns/geo.rb
+++ b/lib/queries/concerns/geo.rb
@@ -4,8 +4,6 @@ require_dependency Rails.root.to_s + '/lib/queries/geographic_item/filter.rb'
 #
 # !! You must call set_geo_params in initialize()
 #
-# Concern specs are in
-#   spec/lib/queries/source/filter_spec.rb
 module Queries::Concerns::Geo
   extend ActiveSupport::Concern
 
@@ -87,9 +85,15 @@ module Queries::Concerns::Geo
     a = nil
 
     case geo_mode
-    # exact and spatial start the same
-    when nil, true
+    when nil # exact
       a = shape.where(id: ids)
+    when true #spatial
+      if shape_string == 'GeographicArea'
+        # In spatial mode GAs must have shape.
+        a = shape.joins(:geographic_items).where(id: ids)
+      else
+        a = shape.where(id: ids)
+      end
     when false # descendants
       if shape_string == 'Gazetteer'
         # For Gazetteers, descendants is the same as exact

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -431,9 +431,15 @@ module Queries
           i = ::Queries.union(::GeographicItem, [a,c])
           u = ::Queries::GeographicItem.st_union_text(i).to_a.first
 
-          return from_wkt(
-            u['st_astext'], u['st_geometrytype'].delete_prefix!('ST_')
-          )
+          if u['st_astext'].nil? || u['st_geometrytype'].nil?
+            # Normally shouldn't be the case unless we were passed some bad
+            # params.
+            return ::Otu.none
+          else
+            return from_wkt(
+              u['st_astext'], u['st_geometrytype'].delete_prefix!('ST_')
+            )
+          end
         end
 
         referenced_klass_union([a,b,c])


### PR DESCRIPTION
This is for an exception on production from doing a spatial CE filter with a GA that has no shape and getting:
```
A NoMethodError occurred in collecting_events#index:

  undefined method 'delete_prefix!' for nil
  lib/queries/collecting_event/filter.rb:264:in 'Queries::CollectingEvent::Filter#collecting_event_geo_facet'
```

I can't see how to make this happen through the UI, but if you: do a spatial search with one GA *having* shape, then edit your url to make the GA one *without* a shape and submit, you get the 500.