### PR TITLE
4464 refactor spatial search to not go through wkt

### DIFF
--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -640,7 +640,8 @@ class GeographicItem < ApplicationRecord
     # !! CURRENTLY ASSUMES no geographic_item_id crosses the anti-meridian. This
     # is true for GA and AD shapes, but not necessarily for GEOREF shapes.
     def covered_by_geographic_items_sql(geographic_item_scope)
-      f = geographic_item_scope.select(
+      #f = geographic_item_scope.select(
+      f = ::GeographicItem.where(id: geographic_item_scope).select(
         '(ST_DUMP(geography::geometry)).geom AS the_geom'
       )
 

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -639,9 +639,8 @@ class GeographicItem < ApplicationRecord
 
     # !! CURRENTLY ASSUMES no geographic_item_id crosses the anti-meridian. This
     # is true for GA and AD shapes, but not necessarily for GEOREF shapes.
-    def covered_by_geographic_items_sql(geographic_item_scope)
-      #f = geographic_item_scope.select(
-      f = ::GeographicItem.where(id: geographic_item_scope).select(
+    def covered_by_geographic_items_sql(geographic_item_id)
+      f = ::GeographicItem.where(id: geographic_item_id).select(
         '(ST_DUMP(geography::geometry)).geom AS the_geom'
       )
 
@@ -656,7 +655,17 @@ class GeographicItem < ApplicationRecord
         ') AS f'
       )
 
-      "geography && (#{geom}) AND " + subset_of_sql(geom).to_sql
+      precheck = "geography && (#{geom}) AND "
+      # Russia and U.S.A. both have land just either side of the anti-meridian,
+      # so doing a pre-bounding box check actually checks against basically
+      # every shape in the northern hemisphere (i.e. the spatial index helps
+      # very little), which turns out to be quite slow even though it's just
+      # rectangle intersection.
+      if geographic_item_id.include?(192) || geographic_item_id.include?(30449)
+        precheck = ''
+      end
+
+      precheck + subset_of_sql(geom).to_sql
     end
 
     #

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -639,16 +639,7 @@ class GeographicItem < ApplicationRecord
 
     # !! CURRENTLY ASSUMES no geographic_item_id crosses the anti-meridian. This
     # is true for GA and AD shapes, but not necessarily for GEOREF shapes.
-    def covered_by_geographic_items_sql(geographic_item_scope, one_shape)
-      if one_shape
-        bounding_box_match =
-          "geography && (#{geographic_item_scope.select(:geography).to_sql})"
-
-        return bounding_box_match + ' AND ' +
-          # TODO change back to .arel
-          subset_of_sql(Arel.sql(geographic_item_scope.select(:geography).to_sql)).to_sql
-      end
-
+    def covered_by_geographic_items_sql(geographic_item_scope)
       f = geographic_item_scope.select(
         '(ST_DUMP(geography::geometry)).geom AS the_geom'
       )
@@ -656,8 +647,8 @@ class GeographicItem < ApplicationRecord
       # Trying out ST_Union here instead of our more traditional ST_Collect
       # since, e.g. a geographic_item (like a Gaz AD shape) that crosses the
       # border of Canada and the U.S. would *not* be contained by
-      # ST_Collect(Canada, U.S.).
-      # THIS MAY BE SLOW.
+      # ST_Collect(Canada, U.S.). This is unexpectedly fast in tests, but be
+      # wary here with new use cases.
       geom = Arel.sql(
         'SELECT ST_Union(f.the_geom) AS single_geometry FROM (' +
           f.to_sql +

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -639,10 +639,8 @@ class GeographicItem < ApplicationRecord
 
     # !! CURRENTLY ASSUMES no geographic_item_id crosses the anti-meridian. That
     # is true for GA and Gaz shapes, but not necessarily for GEOREF shapes.
-    def covered_by_geographic_items_sql(*geographic_item_id)
-      geographic_item_id = geographic_item_id.flatten
-
-      f = ::GeographicItem.where(id: geographic_item_id).select(
+    def covered_by_geographic_items_sql(geographic_item_scope)
+      f = ::GeographicItem.from(geographic_item_scope).select(
         '(ST_DUMP(geography::geometry)).geom AS the_geom'
       )
 

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -639,7 +639,7 @@ class GeographicItem < ApplicationRecord
 
     # !! CURRENTLY ASSUMES no geographic_item_id crosses the anti-meridian. This
     # is true for GA and AD shapes, but not necessarily for GEOREF shapes.
-    def covered_by_geographic_items_sql(geographic_item_id)
+    def covered_by_geographic_items_sql(*geographic_item_id)
       f = ::GeographicItem.where(id: geographic_item_id).select(
         '(ST_DUMP(geography::geometry)).geom AS the_geom'
       )

--- a/app/models/geographic_item.rb
+++ b/app/models/geographic_item.rb
@@ -596,7 +596,7 @@ class GeographicItem < ApplicationRecord
       geographic_item_ids.flatten!
 
       Arel.sql(
-        "SELECT ST_Collect(f.the_geom) AS single_geometry
+        "SELECT ST_Union(f.the_geom) AS single_geometry
           FROM (
             SELECT (
               ST_DUMP(geography::geometry)
@@ -635,6 +635,15 @@ class GeographicItem < ApplicationRecord
           st_geom_from_text_sql(wkt)
         )
       end
+    end
+
+    # !! CURRENTLY ASSUMES no geographic_item_id crosses the anti-meridian. This
+    # is true for GA and AD shapes, but !! not necessarily for GEOREF shapes !!
+    # !!.
+    def covered_by_geographic_items_sql(*geographic_item_ids)
+      geom = items_as_one_geometry_sql(geographic_item_ids)
+
+      subset_of_sql(geom)
     end
 
     #

--- a/app/views/asserted_distributions/index.json.jbuilder
+++ b/app/views/asserted_distributions/index.json.jbuilder
@@ -1,3 +1,21 @@
+if extend_response_with('otu')
+  if extend_response_with('taxonomy')
+    @asserted_distributions = @asserted_distributions.includes(otu: :taxon_name)
+  else
+    @asserted_distributions = @asserted_distributions.includes(:otu)
+  end
+end
+
+if extend_response_with('asserted_distribution_shape')
+  @asserted_distributions =
+    @asserted_distributions.includes(:asserted_distribution_shape)
+end
+
+if extend_response_with('citations')
+  @asserted_distributions =
+    @asserted_distributions.includes(:citations)
+end
+
 json.array!(@asserted_distributions) do |asserted_distribution|
   json.partial! '/asserted_distributions/attributes', asserted_distribution: asserted_distribution
 end

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -175,8 +175,7 @@ module Queries
           .joins(:geographic_areas)
           .where(geographic_items_sql)
 
-        j = ::GeographicArea
-          .joins(:geographic_items).where(geographic_items: i).pluck(:id)
+        j = ::GeographicArea.joins(:geographic_items).merge(i).pluck(:id)
 
         # TODO: There are only 58 GAs with shape that have a descendant without
         # shape: could this be a lookup table instead?
@@ -196,7 +195,7 @@ module Queries
         i = ::GeographicItem.joins(:gazetteers).where(geographic_items_sql)
 
         gazetteer_ids = ::Gazetteer
-          .joins(:geographic_item).where(geographic_item: i).pluck(:id)
+          .joins(:geographic_item).merge(i).pluck(:id)
 
         if gazetteer_ids.empty?
           return ::AssertedDistribution.none

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -295,9 +295,7 @@ module Queries
         i = ::Queries.union(::GeographicItem, [a,b])
 
         from_geographic_items(
-          ::GeographicItem.covered_by_geographic_items_sql(
-            i, at_most_one_geo_shape
-          )
+          ::GeographicItem.covered_by_geographic_items_sql(i)
         )
       end
 

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -182,28 +182,29 @@ module Queries
         # shape: could this be a lookup table instead?
         k = ::GeographicArea.descendants_of(j).pluck(:id) # Add children that might not be caught because they don't have shapes
 
-        geographic_area_ids = (j + k).uniq.join(',')
+        geographic_area_ids = (j + k).uniq
         if geographic_area_ids.empty?
           return ::AssertedDistribution.none
         end
 
         ::AssertedDistribution
-          .where("asserted_distributions.asserted_distribution_shape_id IN (#{geographic_area_ids}) AND asserted_distributions.asserted_distribution_shape_type = 'GeographicArea'")
+          .where(asserted_distribution_shape_id: geographic_area_ids,
+            asserted_distribution_shape_type: 'GeographicArea')
       end
 
       def self.gazetteers_for_geographic_items(geographic_items_sql)
         i = ::GeographicItem.joins(:gazetteers).where(geographic_items_sql)
 
-        j = ::Gazetteer
+        gazetteer_ids = ::Gazetteer
           .joins(:geographic_item).where(geographic_item: i).pluck(:id)
 
-        gazetteer_ids = j.join(',')
         if gazetteer_ids.empty?
           return ::AssertedDistribution.none
         end
 
         ::AssertedDistribution
-          .where("asserted_distributions.asserted_distribution_shape_id IN (#{gazetteer_ids}) AND asserted_distributions.asserted_distribution_shape_type = 'Gazetteer'")
+          .where(asserted_distribution_shape_id: gazetteer_ids,
+            asserted_distribution_shape_type: 'Gazetteer')
       end
 
       # Shape is a Hash in GeoJSON format
@@ -299,7 +300,7 @@ module Queries
         # Spatial.
         i = ::Queries.union(::GeographicItem, [a,b])
         self.class.from_geographic_items(
-          ::GeographicItem.covered_by_geographic_items_sql(i.pluck(:id))
+          ::GeographicItem.covered_by_geographic_items_sql(i)
         )
       end
 

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -183,6 +183,10 @@ module Queries
         k = ::GeographicArea.descendants_of(j).pluck(:id) # Add children that might not be caught because they don't have shapes
 
         geographic_area_ids = (j + k).uniq.join(',')
+        if geographic_area_ids.empty?
+          return ::AssertedDistribution.none
+        end
+
         ::AssertedDistribution
           .where("asserted_distributions.asserted_distribution_shape_id IN (#{geographic_area_ids}) AND asserted_distributions.asserted_distribution_shape_type = 'GeographicArea'")
       end
@@ -193,8 +197,13 @@ module Queries
         j = ::Gazetteer
           .joins(:geographic_item).where(geographic_item: i).pluck(:id)
 
+        gazetteer_ids = j.join(',')
+        if gazetteer_ids.empty?
+          return ::AssertedDistribution.none
+        end
+
         ::AssertedDistribution
-          .where("asserted_distributions.asserted_distribution_shape_id IN (#{j.join(',')}) AND asserted_distributions.asserted_distribution_shape_type = 'Gazetteer'")
+          .where("asserted_distributions.asserted_distribution_shape_id IN (#{gazetteer_ids}) AND asserted_distributions.asserted_distribution_shape_type = 'Gazetteer'")
       end
 
       # Shape is a Hash in GeoJSON format

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -287,15 +287,18 @@ module Queries
           'Gazetteer', gazetteer_shapes
         )
 
-        if geo_mode == true # spatial
-          i = ::Queries.union(::GeographicItem, [a,b])
-
-          return from_geographic_items(
-            ::GeographicItem.covered_by_geographic_items_sql(i.pluck(:id))
-          )
+        if geo_mode != true # exact or descendants
+          return referenced_klass_union([a,b])
         end
 
-        referenced_klass_union([a,b])
+        # Spatial.
+        i = ::Queries.union(::GeographicItem, [a,b])
+
+        from_geographic_items(
+          ::GeographicItem.covered_by_geographic_items_sql(
+            i, at_most_one_geo_shape
+          )
+        )
       end
 
       def asserted_distribution_geo_facet_by_type(shape_string, shape_ids)

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -299,7 +299,7 @@ module Queries
         # Spatial.
         i = ::Queries.union(::GeographicItem, [a,b])
         self.class.from_geographic_items(
-          ::GeographicItem.covered_by_geographic_items_sql(i.to_a)
+          ::GeographicItem.covered_by_geographic_items_sql(i.pluck(:id))
         )
       end
 

--- a/lib/queries/collecting_event/filter.rb
+++ b/lib/queries/collecting_event/filter.rb
@@ -265,7 +265,7 @@ module Queries
 
         ::CollectingEvent
           .joins(:geographic_items)
-          .where(::GeographicItem.covered_by_geographic_items_sql(i.pluck(:id)))
+          .where(::GeographicItem.covered_by_geographic_items_sql(i))
       end
 
       def collecting_event_geo_facet_by_type(shape_string, shape_ids)

--- a/lib/queries/collecting_event/filter.rb
+++ b/lib/queries/collecting_event/filter.rb
@@ -265,7 +265,7 @@ module Queries
 
         ::CollectingEvent
           .joins(:geographic_items)
-          .where(::GeographicItem.covered_by_geographic_items_sql(i))
+          .where(::GeographicItem.covered_by_geographic_items_sql(i.pluck(:id)))
       end
 
       def collecting_event_geo_facet_by_type(shape_string, shape_ids)

--- a/lib/queries/concerns/geo.rb
+++ b/lib/queries/concerns/geo.rb
@@ -40,6 +40,11 @@ module Queries::Concerns::Geo
     @geo_mode = boolean_param(params, :geo_mode)
   end
 
+  # There could be 0 if none of the supplied GAs have a shape.
+  def at_most_one_geo_shape
+    geo_shape_id.length < 2
+  end
+
   def param_shapes_by_type
     geographic_area_ids = []
     gazetteer_ids = []

--- a/lib/queries/concerns/geo.rb
+++ b/lib/queries/concerns/geo.rb
@@ -40,11 +40,6 @@ module Queries::Concerns::Geo
     @geo_mode = boolean_param(params, :geo_mode)
   end
 
-  # There could be 0 if none of the supplied GAs have a shape.
-  def at_most_one_geo_shape
-    geo_shape_id.length < 2
-  end
-
   def param_shapes_by_type
     geographic_area_ids = []
     gazetteer_ids = []

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -454,7 +454,7 @@ module Queries
         i = ::Queries.union(::GeographicItem, [a,c])
 
         from_geographic_items(
-          ::GeographicItem.covered_by_geographic_items_sql(i.pluck(:id))
+          ::GeographicItem.covered_by_geographic_items_sql(i)
         )
       end
 

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -284,6 +284,25 @@ module Queries
         referenced_klass_union([q1, q2]).distinct # Not needed, union should be distinct
       end
 
+      def from_geographic_items(geographic_items_sql)
+        ces = ::CollectingEvent
+          .joins(:geographic_items)
+          .where(geographic_items_sql)
+
+        q1 = ::Otu
+          .joins(collection_objects: [:collecting_event])
+          .where(collecting_events: ces.all, project_id:)
+
+        ads = ::Queries::AssertedDistribution::Filter
+          .from_geographic_items(geographic_items_sql)
+
+        q2 = ::Otu
+          .joins(:asserted_distributions)
+          .where(asserted_distributions: ads.all, project_id:)
+
+        referenced_klass_union([q1,q2])
+      end
+
       def geo_json_facet
         return nil if geo_json.blank?
         return ::Otu.none if roll_call
@@ -427,22 +446,16 @@ module Queries
 
         c, _d = otu_geo_facet_by_type('Gazetteer', gazetteer_shapes)
 
-        if geo_mode == true # spatial
-          i = ::Queries.union(::GeographicItem, [a,c])
-          u = ::Queries::GeographicItem.st_union_text(i).to_a.first
-
-          if u['st_astext'].nil? || u['st_geometrytype'].nil?
-            # Normally shouldn't be the case unless we were passed some bad
-            # params.
-            return ::Otu.none
-          else
-            return from_wkt(
-              u['st_astext'], u['st_geometrytype'].delete_prefix!('ST_')
-            )
-          end
+        if geo_mode != true # exact or descendants
+          return referenced_klass_union([a,b,c])
         end
 
-        referenced_klass_union([a,b,c])
+        # Spatial.
+        i = ::Queries.union(::GeographicItem, [a,c])
+
+        from_geographic_items(
+          ::GeographicItem.covered_by_geographic_items_sql(i)
+        )
       end
 
       def otu_geo_facet_by_type(shape_string, shape_ids)

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -454,7 +454,7 @@ module Queries
         i = ::Queries.union(::GeographicItem, [a,c])
 
         from_geographic_items(
-          ::GeographicItem.covered_by_geographic_items_sql(i)
+          ::GeographicItem.covered_by_geographic_items_sql(i.pluck(:id))
         )
       end
 

--- a/spec/lib/queries/asserted_distribution/filter_spec.rb
+++ b/spec/lib/queries/asserted_distribution/filter_spec.rb
@@ -11,8 +11,8 @@ describe Queries::AssertedDistribution::Filter, type: :model, group: [:geo, :col
   let(:ad2) { FactoryBot.create(:valid_asserted_distribution, otu: o2) }
   let(:ad_gz) { FactoryBot.create(:valid_gazetteer_asserted_distribution, otu: o1) }
 
-  let(:small_polygon) { RspecGeoHelpers.make_polygon( RSPEC_GEO_FACTORY.point(10, 10),0,0, 5.0, 5.0 ) }
-  let(:big_polygon) { RspecGeoHelpers.make_polygon( RSPEC_GEO_FACTORY.point(10, 10),0,0, 10.0, 10.0 ) }
+  let(:small_polygon) { RspecGeoHelpers.make_polygon( RSPEC_GEO_FACTORY.point(10, 10), 0, 0, 5.0, 5.0 ) }
+  let(:big_polygon) { RspecGeoHelpers.make_polygon( RSPEC_GEO_FACTORY.point(10, 10), 0, 0, 10.0, 10.0 ) }
 
   let(:small_geo_area) do
     a = FactoryBot.create(:level1_geographic_area)
@@ -197,7 +197,7 @@ describe Queries::AssertedDistribution::Filter, type: :model, group: [:geo, :col
     [ad1, ad2, ad_gz]
 
     big_polygon_neighbor = RspecGeoHelpers.make_polygon(
-      RSPEC_GEO_FACTORY.point(15, 10),0,0, 10.0, 10.0
+      RSPEC_GEO_FACTORY.point(15, 10), 0, 0, 10.0, 10.0
     )
 
     big_geo_area_neighbor = FactoryBot.create(:valid_gazetteer,
@@ -207,7 +207,7 @@ describe Queries::AssertedDistribution::Filter, type: :model, group: [:geo, :col
     # Interior to union of big_polygon and big_polygon_neighbor, but not to either
     # on its own:
     i = RspecGeoHelpers.make_polygon(
-      RSPEC_GEO_FACTORY.point(12, 7),0,0, 5.0, 5.0
+      RSPEC_GEO_FACTORY.point(12, 7), 0, 0, 10.0, 5.0
     )
 
     a = AssertedDistribution.create!(otu: o1,

--- a/spec/models/geographic_item_spec.rb
+++ b/spec/models/geographic_item_spec.rb
@@ -830,14 +830,16 @@ describe GeographicItem, type: :model, group: [:geo, :shared_geo] do
     context '::covered_by_geographic_items_sql' do
       specify 'shape covers itself' do
         expect(GeographicItem.where(
-          GeographicItem.covered_by_geographic_items_sql(donut)
-        )).to include(donut)
+          GeographicItem.covered_by_geographic_items_sql(
+            GeographicItem.where(id: donut.id)
+        ))).to include(donut)
       end
 
       specify 'finds all subshapes' do
         expect(GeographicItem.where(
-          GeographicItem.covered_by_geographic_items_sql(donut)
-        )).to contain_exactly(
+          GeographicItem.covered_by_geographic_items_sql(
+            GeographicItem.where(id: donut.id)
+        ))).to contain_exactly(
           donut, donut_interior_bottom_left_multi_line,
           donut_left_interior_edge, donut_bottom_interior_edge,
           donut_left_interior_edge_point
@@ -847,16 +849,16 @@ describe GeographicItem, type: :model, group: [:geo, :shared_geo] do
       specify 'contains shapes across input boundaries' do
         expect(GeographicItem.where(
           GeographicItem.covered_by_geographic_items_sql(
-            box, rectangle_intersecting_box
-          )
-        )).to include(box_rectangle_line)
+            GeographicItem.where(id: [box.id, rectangle_intersecting_box.id])
+        ))).to include(box_rectangle_line)
       end
 
       specify 'works with multiple inputs' do
         donut_centroid # not this one
         expect(GeographicItem.where(
-          GeographicItem.covered_by_geographic_items_sql(donut, box)
-        )).to contain_exactly(donut, box)
+          GeographicItem.covered_by_geographic_items_sql(
+            GeographicItem.where(id: [donut.id, box.id])
+        ))).to contain_exactly(donut, box)
       end
     end
 

--- a/spec/models/geographic_item_spec.rb
+++ b/spec/models/geographic_item_spec.rb
@@ -827,6 +827,39 @@ describe GeographicItem, type: :model, group: [:geo, :shared_geo] do
       end
     end
 
+    context '::covered_by_geographic_items_sql' do
+      specify 'shape covers itself' do
+        expect(GeographicItem.where(
+          GeographicItem.covered_by_geographic_items_sql(donut)
+        )).to include(donut)
+      end
+
+      specify 'finds all subshapes' do
+        expect(GeographicItem.where(
+          GeographicItem.covered_by_geographic_items_sql(donut)
+        )).to contain_exactly(
+          donut, donut_interior_bottom_left_multi_line,
+          donut_left_interior_edge, donut_bottom_interior_edge,
+          donut_left_interior_edge_point
+        )
+      end
+
+      specify 'contains shapes across input boundaries' do
+        expect(GeographicItem.where(
+          GeographicItem.covered_by_geographic_items_sql(
+            box, rectangle_intersecting_box
+          )
+        )).to include(box_rectangle_line)
+      end
+
+      specify 'works with multiple inputs' do
+        donut_centroid # not this one
+        expect(GeographicItem.where(
+          GeographicItem.covered_by_geographic_items_sql(donut, box)
+        )).to contain_exactly(donut, box)
+      end
+    end
+
     context '::st_buffer_st_within_sql' do
       before { [equator_point_long_0, equator_point_long_20,
         equator_point_long_30].each }

--- a/spec/support/shared_contexts/shared_basic_geo.rb
+++ b/spec/support/shared_contexts/shared_basic_geo.rb
@@ -65,15 +65,15 @@ shared_context 'stuff for GeographicItem tests' do
   # about their location in space; for that see distance spec shapes below
   #
   #    donut              box                    distant_point
-  #  ---------         ---------                       #
-  #  |       |         |       |
-  #  | &---- |         |   %%%%%%%%%
-  #  | &   | |         |   %   |   %
+  #  ---------         ------&--                       #
+  #  |       |         |     & |
+  #  | &---- |         |   %%&%%%%%%
+  #  | &   | |         |   % & |   %
   #  | # # | |         &&&&#&&&&   %
-  #  | &   | |         |   %   |   %  rectangle_intersecting_box
+  #  | &   | |         |   % & |   %  rectangle_intersecting_box
   #  | &&&&& |         |   % # |   %
-  #  |#      |         |   %   |   %
-  #  ---------         ----%%%%%%%%%
+  #  |#      |         |   % & |   %
+  #  ---------         ----%%&%%%%%%
   #
   #  # = point, & = line
   #
@@ -85,6 +85,8 @@ shared_context 'stuff for GeographicItem tests' do
   #
   #  Rectangle shapes: rectangle_intersecting_box,
   #    box_rectangle_intersection_point
+  #
+  #  box_rectangle_line is contained in their union but not either on its own
   #
   #  box_rectangle_union is what it says as a single polygon
   #
@@ -261,6 +263,17 @@ shared_context 'stuff for GeographicItem tests' do
     i = "POINT (#{i_x} #{i_y})"
 
     FactoryBot.create(:geographic_item, geography: i)
+  }
+
+  ### A line contained in the union of box and rectangle, but not contained in
+  # either on its own.
+  let(:box_rectangle_line) {
+    x = box_llc_x + 3 * box_w / 4
+    top_y = box_llc_y + box_h
+    bottom_y = box_llc_y
+
+    line = "LINESTRING (#{x} #{top_y} 0, #{x} #{bottom_y} 0)"
+    FactoryBot.create(:geographic_item, geography: line)
   }
 
   ### The union of the box and rectangle polygons as a single polygon


### PR DESCRIPTION
* `filter.rb`s changed: AD, OTU, CE; all other spatial searches go through those in some way.

* I'm instantiating arrays of (potentially) tens of thousands of AD ids here, because it's (seems to be) faster than a monolithic query: is that bad?

* on dev this is ~8x faster than pre-pr code on Filter AD, but it does (currently) make more queries, so we'll see how it goes on production.

* I added `.includes` on the results of Filter AD - hopefully that will speed things up as well

* One note on the use of the new-ish `test_shape && geography` pattern: Russia and U.S.A. both have land close to either side of the anti-meridian, so their bounding boxes (for practical purposes) both essentially cover the entire northern hemisphere, so in those two cases at least adding the `&&` bounding box test makes things slower instead of faster (because the spatial index doesn't help much there).