### PR TITLE
Add custom password option for database exports

### DIFF
--- a/app/controllers/tasks/projects/data_controller.rb
+++ b/app/controllers/tasks/projects/data_controller.rb
@@ -12,7 +12,8 @@ class Tasks::Projects::DataController < ApplicationController
   end
 
   def sql_download
-    download = ::Export::ProjectData::Sql.download_async(sessions_current_project)
+    custom_password = params[:custom_password].presence
+    download = ::Export::ProjectData::Sql.download_async(sessions_current_project, custom_password: custom_password)
     redirect_to download_path(download)
   end
 

--- a/app/jobs/download_project_sql_job.rb
+++ b/app/jobs/download_project_sql_job.rb
@@ -9,9 +9,9 @@ class DownloadProjectSqlJob < ApplicationJob
     2
   end
 
-  def perform(target_project, download)
+  def perform(target_project, download, custom_password: nil)
     begin
-      download.source_file_path = ::Export::ProjectData::Sql.export(target_project)
+      download.source_file_path = ::Export::ProjectData::Sql.export(target_project, custom_password: custom_password)
       download.save!
       download
     rescue => ex

--- a/app/views/tasks/projects/data/index.html.erb
+++ b/app/views/tasks/projects/data/index.html.erb
@@ -8,7 +8,7 @@
     <h3> Export SQL </h3>
     <p><em>Generate a downloadable copy of the database (PostgreSQL dump) with all data referenced in this project. Includes Community data like Sources, People, and Repositories.</em></p>
 
-    <p><em>All exported user passwords are set to</em> 'taxonworks', <em><strong>so DO NOT ALLOW PUBLIC ACCESS TO THE EXPORTED DATABASE</strong></em>.</p>
+    <p><em>All exported user passwords will be set to your custom password or the default</em> 'taxonworks', <em><strong>so DO NOT ALLOW PUBLIC ACCESS TO THE EXPORTED DATABASE</strong></em>.</p>
 
     <p> Restorable with <b>psql -U :username -d :database -f dump.sql</b>. Requires database to be created without tables (<b>rails db:create</b>) </p>
     <p>To import into a <code>docker compose</code> development environment:</p>
@@ -21,6 +21,14 @@
 
     <div>
       <%= form_tag(generate_sql_download_task_path, method: :get) do %>
+        <div class="field">
+          <%= label_tag :custom_password, 'Custom password (optional):' %>
+          <%= password_field_tag :custom_password, nil, 
+              placeholder: "Default: taxonworks",
+              class: 'normal-input',
+              autocomplete: 'new-password' %>
+          <p class="feedback feedback-info"><em>Leave blank to use the default password 'taxonworks'</em></p>
+        </div>
         <%= submit_tag :Generate, class: ['normal-input', :button, 'button-default'] -%>
       <% end %>
     </div>


### PR DESCRIPTION
Allow users to specify a custom password when exporting SQL dumps instead of always using the hardcoded 'taxonworks' password. The default behavior remains unchanged - if no password is provided, it falls back to 'taxonworks'.

- Add password input field to the export UI
- Update controller to accept custom password parameter
- Modify background job to pass password through
- Update export logic to use custom password throughout

🤖 Generated with [Claude Code](https://claude.ai/code)

<img width="844" alt="image" src="https://github.com/user-attachments/assets/0f4d7d8a-480a-45c4-afcd-ac8d23277d77" />
