### PR TITLE
Support removing virtual identifier prefix when switching to non-virtual namespace

### DIFF
--- a/app/controllers/identifiers_controller.rb
+++ b/app/controllers/identifiers_controller.rb
@@ -183,7 +183,8 @@ class IdentifiersController < ApplicationController
   end
 
   def batch_by_filter_scope_params
-    params.require(:params).permit(:namespace_id, identifier_types: [])
+    params.require(:params).permit(:namespace_id, :virtual_namespace_prefix,
+      identifier_types: [])
   end
 
 end

--- a/app/javascript/vue/components/radials/mass/components/Annotator/Identifier/IdentifierMain.vue
+++ b/app/javascript/vue/components/radials/mass/components/Annotator/Identifier/IdentifierMain.vue
@@ -15,7 +15,8 @@
         :identifier-types="identifierTypes"
         :filter-query="filterQuery()"
         :object-type="objectType"
-        v-model="namespace"
+        v-model:namespace="namespace"
+        v-model:virtual-namespace-prefix="virtualNamespacePrefix"
         class="namespace-select"
       />
 
@@ -120,6 +121,7 @@ const identifierTypes = ref(
     : []
   )
 const namespace = ref(null)
+const virtualNamespacePrefix = ref(null)
 
 const updateEnabled = computed(() => {
   return identifierTypes.value.length && !!(namespace.value)
@@ -144,6 +146,7 @@ async function makeBatchRequest() {
     params: {
       identifier_types: identifierTypes.value,
       namespace_id: namespace.value.id,
+      virtual_namespace_prefix: virtualNamespacePrefix.value,
     }
   }
 

--- a/app/models/concerns/shared/batch_by_filter_scope.rb
+++ b/app/models/concerns/shared/batch_by_filter_scope.rb
@@ -32,9 +32,9 @@ module Shared::BatchByFilterScope
       c = q.count
       async = c > async_cutoff ? true : false
 
-      # Careful, c is the count of model objects being processed, but there may be
-      # multiple attributes processed per model object; in that case receivers
-      # will need to update r.total_attempted as needed.
+      # Careful, c is the count of model objects being processed, but there may
+      # be multiple attributes processed per model object; in that case
+      # receivers will need to update r.total_attempted as needed.
       r.total_attempted = c
       r.async = async
 

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -114,10 +114,13 @@ class Identifier < ApplicationRecord
     @namespaces = q.all
       .joins(identifiers: :namespace)
       .where(identifiers: {type: identifier_types})
-      .select('namespaces.short_name')
+      .select('namespaces.short_name, namespaces.verbatim_short_name')
       .order('namespaces.short_name')
       .distinct
-      .pluck('namespaces.short_name')
+      .pluck('namespaces.id', 'namespaces.short_name', 'namespaces.verbatim_short_name', 'is_virtual')
+      .map { |id, short_name, verbatim_short_name, is_virtual| {
+        id:, short_name:, verbatim_short_name:, is_virtual:
+      }}
   end
 
   def self.process_batch_by_filter_scope(
@@ -138,6 +141,9 @@ class Identifier < ApplicationRecord
     elsif params[:identifier_types].empty?
       r.errors['no identifier types provided'] = 1
       return r
+    elsif params[:virtual_namespace_prefix] && Namespace.find(params[:namespace_id]).is_virtual
+      r.errors["Can't currently delete virtual prefix and change to virtual namespace"] = 1
+      return r
     end
 
     case mode.to_sym
@@ -157,19 +163,42 @@ class Identifier < ApplicationRecord
           user_id:
         )
       else
+        prefix = params[:virtual_namespace_prefix]
         Identifier
           .with(a: query.select(:id))
           .joins('JOIN a ON identifiers.identifier_object_id = a.id AND ' \
                  "identifiers.identifier_object_type = '#{query.klass}'")
           .where(type: params[:identifier_types])
+          .joins(:namespace)
+          .select('identifiers.*, namespaces.is_virtual AS is_virtual')
           #.where.not(namespace_id: params.namespace_id)
           .distinct
           .find_each do |o|
-            o.update(namespace_id: params[:namespace_id])
-            if o.valid?
-              r.updated.push o.id
-            else
-              r.not_updated.push o.id
+            if params[:virtual_namespace_prefix]
+              if (
+                o.is_virtual &&
+                o.identifier.start_with?(prefix) &&
+                o.identifier.length > prefix.length
+              )
+                o.identifier = o.identifier.delete_prefix(prefix)
+                o.namespace_id = params[:namespace_id]
+
+                if o.save
+                  r.updated.push o.id
+                else
+                  r.not_updated.push o.id
+                end
+              else # this identifier is excluded by virtual_namespace_prefix
+                r.not_updated.push o.id
+              end
+            else # no virtual worries, just namespace_id replacement
+              o.namespace_id = params[:namespace_id]
+
+              if o.save
+                r.updated.push o.id
+              else
+                r.not_updated.push o.id
+              end
             end
           end
       end


### PR DESCRIPTION

<img width="1226" height="495" alt="image" src="https://github.com/user-attachments/assets/fdafbdb4-3073-404e-b086-60dd893bcf1a" />


Your prefix-to-be-removed can be any string. From the help bubble for the 'Delete virtual prefix' input:

>For query result identifiers that have a virtual namespace, remove the supplied prefix from the identifier while changing the namespace. *Only available when the new namespace is not virtual.* When present only rows with the given prefix are operated on.
