### PR TITLE
Support spatially filtering on CE GAs #4073

### DIFF
--- a/app/javascript/vue/components/Filter/Facets/shared/FacetGeographic.vue
+++ b/app/javascript/vue/components/Filter/Facets/shared/FacetGeographic.vue
@@ -90,6 +90,17 @@
     <RadialFilterAttribute
       :parameters="{ shape_id: params.geo_shape_id }"
     />
+
+    <label
+      v-if="showGeographicAreaCheckbox"
+      data-help="For collecting events that have no georeferences, match against geographic area instead."
+    >
+      <input
+        type="checkbox"
+        v-model="params.geo_ce_geographic_area"
+      />
+      Include Geographic Area shapes
+    </label>
   </FacetContainer>
 </template>
 
@@ -102,7 +113,7 @@ import FacetContainer from '@/components/Filter/Facets/FacetContainer.vue'
 import VBtn from '@/components/ui/VBtn/index.vue'
 import VIcon from '@/components/ui/VIcon/index.vue'
 import { GeographicArea, Gazetteer } from '@/routes/endpoints'
-import { ref, watch, onBeforeMount } from 'vue'
+import { computed, ref, watch, onBeforeMount } from 'vue'
 
 const props = defineProps({
   inputId: {
@@ -119,7 +130,12 @@ const props = defineProps({
   noDescendants: {
     type: Boolean,
     default: false
-  }
+  },
+
+  geographicAreaCheckbox: {
+    type: Boolean,
+    default: true
+  },
 })
 
 let TABS // fib
@@ -156,6 +172,11 @@ const shapes = ref([])
 const geoMode = ref(GEOGRAPHIC_OPTIONS.Spatial)
 const mapGeoJson = ref([])
 const view = ref(TABS.Shape)
+
+const showGeographicAreaCheckbox = computed(() => {
+  return props.geographicAreaCheckbox &&
+    (geoMode.value  == GEOGRAPHIC_OPTIONS.Spatial || view.value == TABS.Map)
+})
 
 watch(geoMode, (newVal) => {
   params.value.geo_mode =

--- a/app/javascript/vue/tasks/asserted_distributions/filter/components/FilterView.vue
+++ b/app/javascript/vue/tasks/asserted_distributions/filter/components/FilterView.vue
@@ -1,5 +1,8 @@
 <template>
-  <FacetGeographic v-model="params" />
+  <FacetGeographic
+    v-model="params"
+    :geographic-area-checkbox="false"
+  />
   <FacetAssertedDistributionShapeType v-model="params" />
   <FacetWKT v-model="params" />
   <FacetTaxonName

--- a/lib/queries/biological_association/filter.rb
+++ b/lib/queries/biological_association/filter.rb
@@ -20,6 +20,7 @@ module Queries
         :geo_mode,
         :geo_shape_id,
         :geo_shape_type,
+        :geo_ce_geographic_area,
         :object_biological_property_id,
         :object_object_global_id,
         :object_taxon_name_id,
@@ -152,6 +153,7 @@ module Queries
       attr_accessor :geo_mode
       attr_accessor :geo_shape_id
       attr_accessor :geo_shape_type
+      attr_accessor :geo_ce_geographic_area
 
       # @return [nil, 'Otu', 'CollectionObject']
       #  limit subject to a type
@@ -180,10 +182,11 @@ module Queries
         @collection_object_id = params[:collection_object_id]
         @descendants = boolean_param(params, :descendants)
         @exclude_taxon_name_relationship = boolean_param(params, :exclude_taxon_name_relationship)
-        @geo_json = params[:geo_json]
-        @geo_mode = params[:geo_mode]
-        @geo_shape_id = params[:geo_shape_id]
         @geo_shape_type = params[:geo_shape_type]
+        @geo_shape_id = integer_param(params, :geo_shape_id)
+        @geo_mode = boolean_param(params, :geo_mode)
+        @geo_ce_geographic_area = boolean_param(params, :geo_ce_geographic_area)
+        @geo_json = params[:geo_json]
         @object_biological_property_id = params[:object_biological_property_id]
         @object_object_global_id = params[:object_object_global_id]
         @object_taxon_name_id = params[:object_taxon_name_id]
@@ -338,6 +341,7 @@ module Queries
           :geo_mode,
           :geo_shape_id,
           :geo_shape_type,
+          :geo_ce_geographic_area,
           :wkt,
         ].each
           .each do |p|
@@ -354,6 +358,7 @@ module Queries
           :geo_mode,
           :geo_shape_id,
           :geo_shape_type,
+          :geo_ce_geographic_area,
           :otu_id,
           :wkt,
         ].each do |p|

--- a/lib/queries/collecting_event/filter.rb
+++ b/lib/queries/collecting_event/filter.rb
@@ -42,6 +42,7 @@ module Queries
         :geo_json,
         :geographic_area,
         :geo_mode,
+        :geo_ce_geographic_area,
         :geo_shape_id,
         :geo_shape_type,
         :georeferences,
@@ -263,9 +264,9 @@ module Queries
         # Spatial.
         i = ::Queries.union(::GeographicItem, [a,b])
 
-        ::CollectingEvent
-          .joins(:geographic_items)
-          .where(::GeographicItem.covered_by_geographic_items_sql(i))
+        collecting_events_for_geographic_item_condition(
+          ::GeographicItem.covered_by_geographic_items_sql(i)
+        )
       end
 
       def collecting_event_geo_facet_by_type(shape_string, shape_ids)
@@ -364,13 +365,37 @@ module Queries
       def spatial_query(geometry_type, wkt)
         case geometry_type
         when 'Point'
-          ::CollectingEvent
+          a = ::CollectingEvent
             .joins(:geographic_items)
             .where(::GeographicItem.within_radius_of_wkt_sql(wkt, radius))
+
+          if geo_ce_geographic_area
+            b = ::CollectingEvent
+              .joins(geographic_area: [:geographic_items])
+              .left_joins(:georeferences)
+              .where(georeferences: { id: nil })
+              .where(::GeographicItem.within_radius_of_wkt_sql(wkt, radius))
+
+            return referenced_klass_union([a,b])
+          end
+
+          a
         when 'Polygon', 'MultiPolygon', 'GeometryCollection'
-          ::CollectingEvent
+          a = ::CollectingEvent
             .joins(:geographic_items)
             .where(::GeographicItem.covered_by_wkt_sql(wkt))
+
+          if geo_ce_geographic_area
+            b = ::CollectingEvent
+              .joins(geographic_area: [:geographic_items])
+              .left_joins(:georeferences)
+              .where(georeferences: { id: nil })
+              .where(::GeographicItem.covered_by_wkt_sql(wkt))
+
+            return referenced_klass_union([a,b])
+          end
+
+          a
         else
           nil
         end

--- a/lib/queries/concerns/geo.rb
+++ b/lib/queries/concerns/geo.rb
@@ -25,6 +25,13 @@ module Queries::Concerns::Geo
     #     false - non-spatial match matching against geo_shape descendants
     attr_accessor :geo_mode
 
+    # @return [Boolean, nil]
+    # If true then spatial searches that match against geographic items of
+    # georeferences should, when there are no georeferences, instead match
+    # against the default geographic item of the collecting event's Geographic
+    # Area (if one is set).
+    attr_accessor :geo_ce_geographic_area
+
     def geo_shape_type
       [@geo_shape_type].flatten.compact
     end
@@ -38,6 +45,7 @@ module Queries::Concerns::Geo
     @geo_shape_type = params[:geo_shape_type]
     @geo_shape_id = integer_param(params, :geo_shape_id)
     @geo_mode = boolean_param(params, :geo_mode)
+    @geo_ce_geographic_area = boolean_param(params, :geo_ce_geographic_area)
   end
 
   def param_shapes_by_type
@@ -104,5 +112,28 @@ module Queries::Concerns::Geo
     end
 
     a
+  end
+
+  def collecting_events_for_geographic_item_condition(geographic_item_condition_sql)
+    # Through georeferences.
+    a = ::CollectingEvent
+      .joins(:geographic_items)
+      .where(geographic_item_condition_sql)
+
+    if !geo_ce_geographic_area
+      a
+    else
+      # Through geographic area.
+      # (Note a union b is the same with/out the georef join here since CE
+      # GAs contain all of their georefs - but speed doesn't seem to change
+      # much either way.)
+      b = ::CollectingEvent
+        .joins(geographic_area: [:geographic_items])
+        .left_joins(:georeferences)
+        .where(georeferences: { id: nil })
+        .where(geographic_item_condition_sql)
+
+      ::Queries.union(::CollectingEvent, [a,b])
+    end
   end
 end

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -284,17 +284,17 @@ module Queries
         referenced_klass_union([q1, q2]).distinct # Not needed, union should be distinct
       end
 
-      def from_geographic_items(geographic_items_sql)
-        ces = ::CollectingEvent
-          .joins(:geographic_items)
-          .where(geographic_items_sql)
+      def from_geographic_items(geographic_items_where_sql)
+        ces = collecting_events_for_geographic_item_condition(
+          geographic_items_where_sql
+        )
 
         q1 = ::Otu
           .joins(collection_objects: [:collecting_event])
           .where(collecting_events: ces.all, project_id:)
 
         ads = ::Queries::AssertedDistribution::Filter
-          .from_geographic_items(geographic_items_sql)
+          .from_geographic_items(geographic_items_where_sql)
 
         q2 = ::Otu
           .joins(:asserted_distributions)

--- a/spec/lib/queries/biological_association/filter_spec.rb
+++ b/spec/lib/queries/biological_association/filter_spec.rb
@@ -176,6 +176,26 @@ describe Queries::BiologicalAssociation::Filter, type: :model, group: [:filter] 
     expect(q.all).to contain_exactly( ba2, ba3 )
   end
 
+  specify '#geo_shape_id #geo_mode = true (spatial) #geo_ce_geographic_area' do
+    a = FactoryBot.create(:level1_geographic_area)
+    s = a.geographic_items << GeographicItem.create!(
+      geography: RspecGeoHelpers.make_polygon( RSPEC_GEO_FACTORY.point(10, 10),0,0, 5.0, 5.0 )
+    )
+
+    o3.update!(collecting_event: FactoryBot.create(:valid_collecting_event, geographic_area: a))
+
+    o = {
+      geo_shape_id: a.id,
+      geo_shape_type: 'GeographicArea',
+      geo_mode: true,
+      geo_ce_geographic_area: true
+    }
+
+    q = query.new(o)
+
+    expect(q.all).to contain_exactly( ba2, ba3 )
+  end
+
   specify '#wkt & #taxon_name_id 2' do
     o4 = Specimen.create!
     ba4 = BiologicalAssociation.create!(biological_association_subject: o2, biological_association_object: o4, biological_relationship: r2)

--- a/spec/lib/queries/collecting_event/filter_spec.rb
+++ b/spec/lib/queries/collecting_event/filter_spec.rb
@@ -194,6 +194,17 @@ describe Queries::CollectingEvent::Filter, type: :model, group: [:collecting_eve
       FactoryBot.create(:geographic_item, geography: wkt_polygon)
     }
 
+    let(:ga_polygon) {
+      GeographicArea.create!(
+        parent: FactoryBot.create(:earth_geographic_area),
+        name: 'over the sea',
+        geographic_area_type: FactoryBot.create(:valid_geographic_area_type),
+        data_origin: 'under the heath',
+        geographic_areas_geographic_items_attributes:
+          [ { geographic_item: gi_polygon } ]
+      )
+    }
+
     let(:gz_polygon) {
       FactoryBot.create(:gazetteer,
         geographic_item: gi_polygon,
@@ -228,5 +239,22 @@ describe Queries::CollectingEvent::Filter, type: :model, group: [:collecting_eve
       expect(query.all.map(&:id)).to contain_exactly(ce1.id)
     end
 
+    specify '#geo_ce_geographic_area' do
+      ce2.update!(geographic_area: ga_polygon)
+
+      query.geo_ce_geographic_area = true
+      query.geo_shape_id = gz_polygon.id
+      query.geo_shape_type = 'Gazetteer'
+      query.geo_mode = true
+      expect(query.all.map(&:id)).to contain_exactly(ce1.id, ce2.id)
+    end
+
+    specify '#geo_ce_geographic_area #geo_json' do
+      ce2.update!(geographic_area: ga_polygon)
+
+      query.geo_json = geo_json_polygon
+      query.geo_ce_geographic_area = true
+      expect(query.all.map(&:id)).to contain_exactly(ce1.id, ce2.id)
+    end
   end
 end

--- a/spec/lib/queries/otu/filter_spec.rb
+++ b/spec/lib/queries/otu/filter_spec.rb
@@ -333,6 +333,30 @@ describe Queries::Otu::Filter, type: :model, group: [:geo, :collection_objects, 
     expect(q.all).to contain_exactly( o1 )
   end
 
+  specify '#geo_ce_geographic_area' do
+    ga = GeographicArea.create!(
+      parent: FactoryBot.create(:earth_geographic_area),
+      name: 'under the heath',
+      geographic_area_type: FactoryBot.create(:valid_geographic_area_type),
+      data_origin: 'over the sea',
+      geographic_areas_geographic_items_attributes:
+        [ { geographic_item: FactoryBot.create(:geographic_item, geography: 'POLYGON ((5 5, 15 5, 15 15, 5 15, 5 5))') } ]
+    )
+
+    Specimen.create!(
+      collecting_event: FactoryBot.create(:valid_collecting_event, geographic_area: ga),
+      taxon_determinations_attributes: [{otu: o2}]
+    )
+
+    o1 # not this one
+    q.geo_ce_geographic_area = true
+    q.geo_mode = true
+    q.geo_shape_id = ga.id
+    q.geo_shape_type = 'GeographicArea'
+
+    expect(q.all).to contain_exactly( o2 )
+  end
+
   specify '#wkt against georeference' do
     o1
     s = Specimen.create(


### PR DESCRIPTION
<img width="400" height="334" alt="image" src="https://github.com/user-attachments/assets/3a3bb6c9-fbdd-4e1e-8306-5e349b235e81" />
<img width="400" height="421" alt="image" src="https://github.com/user-attachments/assets/031d6e73-df34-44bd-b7b9-e1ac9650015a" />

With the checkbox checked, spatial queries return results matching against both georeferences and CE geographic area when there are no georefs. (You can't match against only CE GA.) I included a help bubble on the checkbox but I still feel like the text in the screenshot coule be improved?

This should apply to all of the filters that reference CEs: BA, CE, CO, FO, OTU.

@mjy I think the code should be 'fine', but can you take a look to see if this is the way we want to do this, i.e. with a separate checkbox? Spatial queries basically take twice as long with the checkbox checked (and I don't see how to combine the queries; we're joining CE to GI in two different ways and then unioning the result).