### PR TITLE
Add Otu inventory endpoint and catalog for enumerating related citati…

### DIFF
--- a/app/controllers/otus_controller.rb
+++ b/app/controllers/otus_controller.rb
@@ -3,7 +3,7 @@ class OtusController < ApplicationController
 
   before_action :set_otu, only: [
     :show, :edit, :update, :destroy, :collection_objects, :navigation,
-    :breadcrumbs, :timeline, :coordinate, :distribution,
+    :breadcrumbs, :timeline, :inventory, :coordinate, :distribution,
     :api_show, :api_taxonomy_inventory, :api_type_material_inventory,
     :api_nomenclature_citations, :api_distribution, :api_content, :api_dwc_inventory, :api_dwc_gallery, :api_key_inventory, :api_determined_to_rank]
 
@@ -48,6 +48,11 @@ class OtusController < ApplicationController
   # GET /otus/1/timeline.json
   def timeline
     @catalog = Catalog::Timeline.new(targets: [@otu])
+  end
+
+  # GET /otus/1/inventory.json
+  def inventory
+    @catalog = Catalog::Inventory.new(targets: [@otu])
   end
 
   # GET /otus/1/navigation.json

--- a/app/javascript/vue/routes/endpoints/Otu.js
+++ b/app/javascript/vue/routes/endpoints/Otu.js
@@ -29,7 +29,9 @@ export const Otu = {
 
   navigation: (id) => AjaxCall('get', `/${controller}/${id}/navigation`),
 
-  timeline: (id) => AjaxCall('get', `/${controller}/${id}/timeline`),
+  timeline: (id) => AjaxCall('get', `/${controller}/${id}/timeline.json`),
+
+  inventory: (id) => AjaxCall('get', `/${controller}/${id}/inventory.json`),
 
   filter: (params) => AjaxCall('post', `/${controller}/filter.json`, params),
 

--- a/app/javascript/vue/tasks/otu/browse/components/timeline/Timeline.vue
+++ b/app/javascript/vue/tasks/otu/browse/components/timeline/Timeline.vue
@@ -334,6 +334,7 @@ export default {
             this.nomenclature = response.body
             this.isLoading = false
           })
+          Otu.inventory(this.otu.id)
         }
       },
       immediate: true

--- a/app/views/otus/inventory.json.jbuilder
+++ b/app/views/otus/inventory.json.jbuilder
@@ -1,0 +1,29 @@
+json.reference_object @catalog.reference_object_global_id
+json.reference_object_valid_taxon_name @catalog.reference_object_valid_taxon_name_global_id
+
+json.metadata do
+  json.count_items @catalog.items.count
+  json.count_entries @catalog.entries.count
+
+  json.entries do
+    json.array! @catalog.entries do |ce|
+      json.metadata ce.to_json
+    end
+  end
+end
+
+json.sources @catalog.sources_to_json
+json.topics @catalog.topics_to_json
+
+json.items do
+  json.array! @catalog.items_chronologically do |i|
+    json.label_html send(i.html_helper, i)
+    json.nomenclature_date i.nomenclature_date
+    json.data_attributes i.data_attributes
+    json.topics do
+      json.array! i.topics.collect{|t| t.metamorphosize.to_global_id.to_s}
+    end
+  end
+end
+
+

--- a/config/routes/data.rb
+++ b/config/routes/data.rb
@@ -640,6 +640,7 @@ resources :otus do
 
   member do
     get :timeline, defaults: {format: :json}
+    get :inventory, defaults: {format: :json}
     get :navigation, defaults: {format: :json}
     get :breadcrumbs, defaults: {format: :json}
     get :coordinate, defaults: {format: :json}

--- a/lib/application_enumeration.rb
+++ b/lib/application_enumeration.rb
@@ -134,5 +134,28 @@ module ApplicationEnumeration
     raise TaxonWorks::Error, "Unknown relationship type for #{relation.name}."
   end
 
+  def self.citable_relations(klass, relationship_type = :all)
+    types = relationship_type == :all ?
+      [:has_many, :has_one, :belongs_to] : [relationship_type]
+
+    h = {}
+
+    types.each do |t|
+      h[t] = klass.reflect_on_all_associations(t).filter_map do |r|
+        if r.klass.ancestors.include?(Shared::Citations)
+          if t == :has_many
+            r.plural_name.to_sym
+          else
+            r.name.to_sym
+          end
+        else
+          nil
+        end
+      end
+    end
+
+    h
+  end
+
 
 end

--- a/lib/catalog/inventory.rb
+++ b/lib/catalog/inventory.rb
@@ -1,0 +1,11 @@
+class Catalog::Inventory < ::Catalog
+
+  def build
+    catalog_targets.each do |t|
+      @entries.push(Catalog::Otu::InventoryEntry.new(t))
+    end
+    true
+  end
+
+end
+

--- a/lib/catalog/otu/inventory_entry.rb
+++ b/lib/catalog/otu/inventory_entry.rb
@@ -1,0 +1,48 @@
+# A Catalog::Entry that contains the biological history of an otu via associated
+# data of that otu (images, asserted distributions, observations, etc.).
+class Catalog::Otu::InventoryEntry < ::Catalog::Entry
+
+  def initialize(otu)
+    super(otu)
+    true
+  end
+
+  def build
+    from_self
+    true
+  end
+
+  def to_html_method
+    :otu_catalog_entry_item_to_html
+  end
+
+  def from_self
+    a = ::Otu.coordinate_otus(object.id).load
+    b = ApplicationEnumeration.citable_relations(Otu).values.flatten(1)
+
+    a.each do |o|
+      b.each do |r|
+        association = o.send(r)
+        association = [association] if !association.is_a?(Enumerable)
+        association.each do |x|
+          x.citations.each do |c|
+            @items << Catalog::Otu::InventoryEntryItem.new(
+              object: x,
+              base_object: o,
+              citation: c,
+              nomenclature_date: c.source&.cached_nomenclature_date,
+              current_target: entry_item_matches_target?(o, object)
+            )
+          end
+        end
+      end
+    end
+  end
+
+  # @return [Boolean]
+  #   this is the MM result
+  def entry_item_matches_target?(item_object, reference_object)
+    item_object.taxon_name_id == reference_object.taxon_name_id
+  end
+
+end

--- a/lib/catalog/otu/inventory_entry_item.rb
+++ b/lib/catalog/otu/inventory_entry_item.rb
@@ -1,0 +1,8 @@
+class Catalog::Otu::InventoryEntryItem < ::Catalog::EntryItem
+
+  def html_helper
+    :otu_catalog_entry_item_tag
+  end
+
+end
+

--- a/lib/catalog/timeline.rb
+++ b/lib/catalog/timeline.rb
@@ -4,7 +4,7 @@ require_dependency Rails.root.to_s + '/lib/catalog/otu/entry.rb'
 # A Catalog::Timeline is a catalog that merges biolgological concepts (OTUs) with their nomenclature.
 #
 # Filtering intent:
-#   Level 1: [Nomenclature (origin != 'otu'), Protonym (origin == 'protonym', OTU (biology), origin == 'otu'] - mutually exclusive
+#   Level 1: [Nomenclature (origin != 'otu'), Protonym (origin == 'protonym', OTU (biology), origin == 'otu']
 #   Level 2 (All): [First (is_first: true,) Valid (is_valid: true)]
 #
 # Visualizing intent:

--- a/spec/lib/application_enumeration_spec.rb
+++ b/spec/lib/application_enumeration_spec.rb
@@ -17,4 +17,26 @@ describe 'ApplicationEnumeration' do
     expect(ae.data_models).to include(TypeMaterial)
   end
 
+  specify '.citable_relations :all keys' do
+    h = ae.citable_relations(Otu)
+    expect(h.keys).to contain_exactly(:has_many, :has_one, :belongs_to)
+  end
+
+  specify '.citable_relations has_many' do
+    h = ae.citable_relations(Otu, :has_many)
+    expect(h[:has_many]).to include(:images, :confidences, :collection_objects)
+    expect(h[:has_many]).not_to include(:pinboard_items)
+  end
+
+  specify '.citable_relations has_one' do
+    h = ae.citable_relations(Lead, :has_one)
+    expect(h[:has_one]).to include(:taxon_name) # through otu
+    # TODO find a klass with a good uncitable has_one
+  end
+
+  specify '.citable_relations belongs_to' do
+    h = ae.citable_relations(CollectionObject, :belongs_to)
+    expect(h[:belongs_to]).to include(:collecting_event)
+    expect(h[:belongs_to]).not_to include(:user)
+  end
 end

--- a/spec/lib/catalog/inventory_spec.rb
+++ b/spec/lib/catalog/inventory_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+#require 'catalog/nomenclature/entry'
+
+describe Catalog::Inventory, group: :catalogs, type: :spinup do
+
+  let!(:root) { Project.find(Current.project_id).send(:create_root_taxon_name) }
+  let!(:genus) { Protonym.create!(parent: root, name: 'Aus', rank_class: Ranks.lookup(:iczn, :genus) )}
+  let!(:otu) { Otu.create!(name: 'something', taxon_name: genus) }
+
+  let!(:source1) { FactoryBot.create(:valid_source_bibtex, year: 2019) }
+  let!(:source2) { FactoryBot.create(:valid_source_bibtex, year: 2020) }
+  let!(:citation2) { Citation.create!(is_original: true, source: source2,
+    citation_object: )}
+  let!(:ad) { AssertedDistribution.create!(otu:, asserted_distribution_shape: FactoryBot.create(:valid_geographic_area), source: source1)} # 'citation1'
+  let!(:co) { FactoryBot.create(:valid_collection_object) }
+  let!(:td) { TaxonDetermination.create!(taxon_determination_object: co, otu:)}
+  let!(:citation2) { Citation.create!(is_original: true, source: source2,
+    citation_object: co)}
+
+  let(:c) { Catalog::Inventory.new(targets: [otu]) }
+
+  specify '#items' do
+    expect(c.items.count).to eq(2)
+  end
+
+  specify 'all_dates' do
+    expect(Catalog.year_metadata(c.sources, c.items)).to eq({
+      2019 => 1,
+      2020 => 1
+    })
+  end
+
+  specify 'citation origins' do
+    origins = c.items.map { |i| i.data_attributes['history-origin'] }
+    expect(origins).to contain_exactly('asserted distribution', 'specimen')
+  end
+end
+
+


### PR DESCRIPTION
…ons #4423

This is (currently, mostly) complementary to timeline: it enumerates all citations on objects *associated with* otus that are coordinate with a given otu.

Expecting this to need more work:
* doesn't yet follow associations on the taxon names (only otus) of the otu and its coordinate otus.
* I'm not really clear yet on if/how it will be combined with `timeline`, or if it has all of the information we'll want.
* (It currently loads its data, but doesn't display it, in Browse Otu, for testing.)