### PR TITLE
Reset some of the conditions under which cached maps are created

### DIFF
--- a/app/helpers/otus_helper.rb
+++ b/app/helpers/otus_helper.rb
@@ -223,7 +223,7 @@ module OtusHelper
       }
     }
 
-    if otu.taxon_name && otu.taxon_name.is_protonym? && !otu.taxon_name.is_species_rank?
+    if otu.is_cached_mapped?
       add_aggregate_geo_json(otu, h)
     else
       otus.each do |o|

--- a/app/models/cached_map_item.rb
+++ b/app/models/cached_map_item.rb
@@ -25,10 +25,6 @@
 #     if True then the the shape could not be mapped, by any translation method, to a shape allowable
 #     for this CachedMapItemType
 #
-# @!attribute is_absent
-#   @return [Boolean, nil]
-#     if True then the corresponding AssertedDistributions have is_absent true
-#
 # @!attribute level0_geographic_name
 #   @return [String, nil]
 #      the level 0 name

--- a/app/models/cached_map_item.rb
+++ b/app/models/cached_map_item.rb
@@ -300,6 +300,10 @@ class CachedMapItem < ApplicationRecord
       otu_id = o.otus.left_joins(:taxon_determinations).where(taxon_determinations: { position: 1 }).distinct.pluck(:id)
     end
 
+    otu = nil
+    return h if otu_id.nil? || (otu = Otu.find_by(id: otu_id)).nil?
+    return h if !otu.is_cached_mapped?
+
     # Some AssertedDistribution don't have shapes
     if geographic_item_id
       h[:origin_geographic_item_id] = geographic_item_id

--- a/app/models/cached_map_item.rb
+++ b/app/models/cached_map_item.rb
@@ -288,6 +288,9 @@ class CachedMapItem < ApplicationRecord
 
     case base_class_name
     when 'AssertedDistribution'
+      if o.is_absent == true
+        return h
+      end
       if o.asserted_distribution_object_type == 'Otu'
         otu_id = [o.asserted_distribution_object_id]
       else

--- a/app/models/concerns/shared/maps.rb
+++ b/app/models/concerns/shared/maps.rb
@@ -127,8 +127,6 @@ module Shared::Maps
       ::DEFAULT_CACHED_MAP_BUILD_TYPES.each do |map_type|
         stubs = CachedMapItem.stubs(self, map_type)
 
-        # Georeferences with no CollectionObjects will hit here
-        #  TODO: do we still register this?
         return true if stubs[:otu_id].empty?
 
         name_hierarchy = {}

--- a/app/models/otu.rb
+++ b/app/models/otu.rb
@@ -546,6 +546,11 @@ class Otu < ApplicationRecord
     ::Queries::DwcOccurrence::Filter.new(otu_id: id).all
   end
 
+  # Whether or not cached maps are created for this otu.
+  def is_cached_mapped?
+    taxon_name && taxon_name.is_protonym? && !taxon_name.is_species_rank?
+  end
+
   protected
 
   def check_required_fields

--- a/app/models/otu/maps.rb
+++ b/app/models/otu/maps.rb
@@ -18,13 +18,7 @@ module Otu::Maps
     end
 
     # All the OTUs feeding into this map.
-    otu_scope = nil
-
-    if self.taxon_name_id.present?
-      otu_scope = Otu.select(:id).descendant_of_taxon_name(taxon_name_id)
-    else
-      otu_scope = Otu.select(:id).where(id:)
-    end
+    otu_scope = Otu.select(:id).descendant_of_taxon_name(taxon_name_id)
 
     if gj = CachedMap.calculate_union(otu_scope, cached_map_type:)
       map = CachedMap.create!(

--- a/app/views/tasks/cached_maps/report/items_by_otu.html.erb
+++ b/app/views/tasks/cached_maps/report/items_by_otu.html.erb
@@ -34,7 +34,6 @@
       <%# tag.td(i.geographic_item.quick_geographic_name_hierarchy ) %>
       <%# tag.td( CachedMapItem.cached_map_name_hierarchy(i.geographic_item_id)) %>
       <%= tag.td(i.untranslated ? tag.em('True', class: [:feedback, 'feedback-thin', 'feedback-warning']) : nil  ) %>
-      <%= tag.td(i.is_absent) %>
     </tr>
   <% end %>
 </table>

--- a/db/migrate/20250808191356_remove_is_absent_from_cached_map_items.rb
+++ b/db/migrate/20250808191356_remove_is_absent_from_cached_map_items.rb
@@ -1,0 +1,5 @@
+class RemoveIsAbsentFromCachedMapItems < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :cached_map_items, :is_absent, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_11_195046) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_08_191356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -227,7 +227,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_11_195046) do
     t.bigint "geographic_item_id", null: false
     t.string "type"
     t.integer "reference_count"
-    t.boolean "is_absent"
     t.string "level0_geographic_name"
     t.string "level1_geographic_name"
     t.string "level2_geographic_name"
@@ -777,6 +776,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_11_195046) do
     t.boolean "is_public"
     t.string "type"
     t.integer "total_records"
+    t.string "sha2"
     t.index ["created_by_id"], name: "index_downloads_on_created_by_id"
     t.index ["filename"], name: "index_downloads_on_filename"
     t.index ["project_id"], name: "index_downloads_on_project_id"

--- a/spec/models/cached_map_item_spec.rb
+++ b/spec/models/cached_map_item_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe CachedMapItem, type: :model, group: [:geo, :cached_map] do
       Delayed::Worker.new.work_off
       expect(CachedMapItem.count).to eq(0)
     end
+
+    specify 'Asserted distribution is_absent == true' do
+      FactoryBot.create(:valid_asserted_distribution, asserted_distribution_object: Otu.new(taxon_name: FactoryBot.create(:relationship_species, parent: FactoryBot.create(:root_taxon_name))), is_absent: true)
+
+      Delayed::Worker.new.work_off
+      expect(CachedMapItem.count).to eq(0)
+    end
   end
 
 end

--- a/spec/models/cached_map_spec.rb
+++ b/spec/models/cached_map_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CachedMap, type: :model, group: [:geo, :cached_map] do
   end
 
   context '#synced?' do
-    let(:otu) { FactoryBot.create(:valid_otu) }
+    let(:otu) { Otu.create!(taxon_name: FactoryBot.create(:relationship_genus, parent: FactoryBot.create(:root_taxon_name))) }
 
     let(:ad) {
       AssertedDistribution.create!(


### PR DESCRIPTION
@mjy I think we've discussed all of these, but could you sanity check me here - we're *NOT* going to produce cached maps for:
* otus without a taxon name
* otus whose taxon name is a Combination
* otus whose Protonym taxon name is species group
* Asserted Distributions with `is_absent == true`