### PR TITLE
Refactor taxon stats to reduce query count

### DIFF
--- a/app/helpers/taxon_names_helper.rb
+++ b/app/helpers/taxon_names_helper.rb
@@ -386,7 +386,9 @@ module TaxonNamesHelper
     # !! descendants: false is [self and desecendants]
     ::Queries::TaxonName::Filter.new(synonymify: true, descendants: false, taxon_name_id: taxon_name.id).all
       .where(type: 'Protonym')
-      .select(:rank_klass).distinct.pluck(:rank_class).compact.sort{|a,b| RANKS.index(a) <=> RANKS.index(b)}.each do |r|
+      .select(:rank_klass)
+      .distinct
+      .pluck(:rank_class).compact.sort{|a,b| RANKS.index(a) <=> RANKS.index(b)}.each do |r|
 
         n = r.safe_constantize.rank_name.to_sym
         j = i.deep_dup
@@ -401,7 +403,7 @@ module TaxonNamesHelper
         j[:names][:valid] = valid.count
         j[:names][:valid_fossil] = valid
           .joins(:taxon_name_classifications)
-          .where('taxon_name_classifications.type LIKE ?', '%::Fossil%' )
+          .where(taxon_name_classifications: { type: TAXON_NAME_CLASSIFICATIONS_FOR_FOSSILS })
           .count
         j[:names][:valid_extant] = j[:names][:valid] - j[:names][:valid_fossil]
 
@@ -609,7 +611,7 @@ module TaxonNamesHelper
       .map { |child| taxonomic_tree_node(child) }
   end
 
-  def taxonomic_tree(taxon_name, include_ancestors = true) 
+  def taxonomic_tree(taxon_name, include_ancestors = true)
     node = {
       taxon_name: taxonomic_tree_node(taxon_name),
       descendants: taxonomic_tree_descendants(taxon_name)

--- a/app/helpers/taxon_names_helper.rb
+++ b/app/helpers/taxon_names_helper.rb
@@ -447,8 +447,10 @@ module TaxonNamesHelper
         tn.cached_is_valid'.squish
       )
 
-    otus_scope = ::Otu.where("taxon_name_id IN (SELECT id FROM (#{valid_rank.to_sql}))")#.distinct
+    otus_scope = ::Otu.where(taxon_name_id: valid_rank.except(:select).select('tn.id'))
 
+    # This is a little janky, but it's what allows us to avoid an extra query
+    # (and it gives project_id context).
     otus_coordinatified = ::Queries::Otu::Filter.new({}).coordinatify_result(otus_scope)
 
     rows = TaxonName

--- a/app/helpers/taxon_names_helper.rb
+++ b/app/helpers/taxon_names_helper.rb
@@ -374,49 +374,112 @@ module TaxonNamesHelper
   end
 
   def taxon_name_inventory_stats(taxon_name)
-
+    # Code mostly by chatgpt 5 (with comment/naming revsisions)
     d = []
 
-    i = {
-      rank: nil,
-      taxa: {},
-      names: {}
-    }
-
-    # !! descendants: false is [self and desecendants]
-    ::Queries::TaxonName::Filter.new(synonymify: true, descendants: false, taxon_name_id: taxon_name.id).all
+    # Query 1. Get all ranks for ordering
+    ranks = ::Queries::TaxonName::Filter
+      .new(synonymify: true, descendants: false, taxon_name_id: taxon_name.id)
+      .all
       .where(type: 'Protonym')
-      .select(:rank_klass)
       .distinct
-      .pluck(:rank_class).compact.sort{|a,b| RANKS.index(a) <=> RANKS.index(b)}.each do |r|
+      .pluck(:rank_class)
+      .compact
+      .sort_by { |r| RANKS.index(r) || RANKS.length }
 
-        n = r.safe_constantize.rank_name.to_sym
-        j = i.deep_dup
+    return [] if ranks.empty?
 
-        j[:rank] = n
+    # Query 2. VALID
+    valid = ::Queries::TaxonName::Filter.new(
+      validity: true,
+      descendants: false,
+      taxon_name_id: taxon_name.id,
+      taxon_name_type: 'Protonym'
+    ).all
 
-        valid = ::Queries::TaxonName::Filter.new(
-          validity: true, descendants: false, taxon_name_id: taxon_name.id,
-          rank: r, taxon_name_type: 'Protonym'
-        ).all
+    valid_by_rank = valid
+      .group("rank_class")
+      .count
 
-        j[:names][:valid] = valid.count
-        j[:names][:valid_fossil] = valid
-          .joins(:taxon_name_classifications)
-          .where(taxon_name_classifications: { type: TAXON_NAME_CLASSIFICATIONS_FOR_FOSSILS })
-          .count
-        j[:names][:valid_extant] = j[:names][:valid] - j[:names][:valid_fossil]
+    # Query 3. VALID FOSSILS
+    valid_fossil_names_by_rank = valid
+      .joins(:taxon_name_classifications)
+      .where(taxon_name_classifications: { type: TAXON_NAME_CLASSIFICATIONS_FOR_FOSSILS })
+      .group("rank_class")
+      .count
 
-        j[:names][:invalid] = ::Queries::TaxonName::Filter.new(
-          descendants: false, synonymify: true, taxon_name_id: taxon_name.id,
-          rank: r, taxon_name_type: 'Protonym'
-        ).all.that_is_invalid.count
+   # Query 4. INVALID
+   invalid_scope = ::Queries::TaxonName::Filter.new(
+      descendants: false,
+      synonymify: true,
+      taxon_name_id: taxon_name.id,
+      taxon_name_type: 'Protonym'
+    ).all.that_is_invalid
 
-        # This is the number of OTUs behind the ranks at this concept, i.e. a measure of how partitioned the data are beyond valid/invalid categories.
-        j[:taxa] = ::Queries::Otu::Filter.new(coordinatify: true, taxon_name_query: {descendants: false, taxon_name_id: taxon_name.id, rank: r} ).all.count
+    # Count invalid names at the rank of their valid name.
+    invalid_by_rank = TaxonName
+      .from("(#{invalid_scope.to_sql}) invalid")
+      .joins('JOIN taxon_names valid ON valid.id = invalid.cached_valid_taxon_name_id')
+      .group('valid.rank_class')
+      .count
 
-        d.push j
-      end
+    # Query 5: Coordinatified OTU counts
+    # In brief: Let S be the subtree of taxon_name.
+    # 1) To each name in S, assign the rank of its valid name (may be itself).
+    # 2) Coordinatify all otus corresponding to S (expand in both directions
+    #    from S via valid-name-of/invalid-name-of name in S).
+    # 3) Join 2) to 1) via the expansion described in 2).
+    # 4) Group that join by the valid rank assigned to elements of S in 1).
+    # 5) Count by that valid rank.
+    base_scope = ::Queries::TaxonName::Filter.new(
+      descendants: false,
+      taxon_name_id: taxon_name.id,
+      taxon_name_type: 'Protonym'
+    ).all
+
+    # Count invalid names with their valid name's rank.
+    valid_rank = TaxonName
+      .from(base_scope, :tn)
+      .joins('LEFT JOIN taxon_names valid ON valid.id = tn.cached_valid_taxon_name_id')
+      .select(
+        'tn.id,
+        COALESCE(valid.rank_class, tn.rank_class) AS valid_rank,
+        tn.cached_is_valid'.squish
+      )
+
+    otus_scope = ::Otu.where("taxon_name_id IN (SELECT id FROM (#{valid_rank.to_sql}))")#.distinct
+
+    otus_coordinatified = ::Queries::Otu::Filter.new({}).coordinatify_result(otus_scope)
+
+    rows = TaxonName
+      .with(valid_rank:)
+      .from(otus_coordinatified, :o)
+      .joins('JOIN taxon_names tn ON tn.id = o.taxon_name_id')
+      .joins('JOIN valid_rank vr ON tn.id = vr.id OR tn.cached_valid_taxon_name_id = vr.id')
+      .group('vr.valid_rank')
+      .pluck('vr.valid_rank', Arel.sql('COUNT(DISTINCT o.id)'))
+
+    otu_by_rank = rows.each_with_object({}) { |(rank, cnt), h| h[rank] = cnt.to_i }
+
+    # Stitch results per rank
+    ranks.each do |rank_class|
+      n = rank_class.safe_constantize.rank_name.to_sym
+      valid = valid_by_rank[rank_class] || 0
+      valid_fossil = valid_fossil_names_by_rank[rank_class] || 0
+      invalid = invalid_by_rank[rank_class] || 0
+      taxa = otu_by_rank[rank_class] || 0
+
+      d << {
+        rank: n,
+        taxa: taxa,
+        names: {
+          valid: valid,
+          valid_fossil: valid_fossil,
+          valid_extant: valid - valid_fossil,
+          invalid: invalid
+        }
+      }
+    end
 
     d
   end

--- a/config/initializers/constants/model/taxon_name_classifications.rb
+++ b/config/initializers/constants/model/taxon_name_classifications.rb
@@ -129,6 +129,11 @@ TAXON_NAME_CLASSIFICATIONS_FOR_DECORATION ||= [
   TaxonNameClassification::Icvcn::Valid::Unaccepted
 ].flatten.map(&:to_s).freeze
 
+TAXON_NAME_CLASSIFICATIONS_FOR_FOSSILS ||= [
+  TaxonNameClassification::Icn::Fossil,
+  TaxonNameClassification::Iczn::Fossil,
+  TaxonNameClassification::Iczn::Fossil::Ichnotaxon,
+].flatten.map(&:to_s).freeze
 
 # JSON supporting
 module TaxonNameClassificationsHelper

--- a/lib/queries/otu/filter.rb
+++ b/lib/queries/otu/filter.rb
@@ -649,7 +649,7 @@ module Queries
         i = q.joins(:taxon_name).where('taxon_names.id != taxon_names.cached_valid_taxon_name_id').where(project_id:)
         v = q.joins(:taxon_name).where('taxon_names.id = taxon_names.cached_valid_taxon_name_id').where(project_id:)
 
-        # Find valid for invalid
+        # Find all valids related to a q-invalid
         s = 'WITH invalid_otu_result AS (' + i.to_sql + ') ' +
           ::Otu
           .joins('JOIN taxon_names tn1 on otus.taxon_name_id = tn1.cached_valid_taxon_name_id')
@@ -658,7 +658,7 @@ module Queries
 
         a = ::Otu.from('(' + s + ') as otus')
 
-        # Find invalid for valid
+        # Find all invalids related to a q-valid
         t = 'WITH valid_otu_result AS (' + v.to_sql + ') ' +
           ::Otu
           .joins('JOIN taxon_names tn2 on otus.taxon_name_id = tn2.id')
@@ -667,7 +667,7 @@ module Queries
 
         b = ::Otu.from('(' + t + ') as otus')
 
-        referenced_klass_union([a, b, q]).distinct # Unions shouldn't need distinct
+        referenced_klass_union([a, b, q])
       end
 
       def ancestrify_result(q)

--- a/spec/helpers/taxon_names_helper_spec.rb
+++ b/spec/helpers/taxon_names_helper_spec.rb
@@ -28,14 +28,32 @@ describe TaxonNamesHelper, type: :helper do
   end
 
   context 'taxon_name_inventory_stats' do
-    let(:root) { FactoryBot.create(:root_taxon_name) }
-    let(:family) { Protonym.create!(name: 'Cicadellidae', rank_class: Ranks.lookup(:iczn, :family), parent: root) }
+    let!(:root) { FactoryBot.create(:root_taxon_name) }
+    let!(:family) { Protonym.create!(name: 'Cicadellidae', rank_class: Ranks.lookup(:iczn, :family), parent: root) }
+    let!(:family_otu) { Otu.create!(taxon_name: family) }
+
     let!(:genus1) { Protonym.create!(name: 'Erythroneura', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
+    let!(:genus1_otu) { Otu.create!(taxon_name: genus1) }
     let!(:genus2) { Protonym.create!(name: 'Aus', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
+    let!(:genus2_otu) { Otu.create!(taxon_name: genus2) }
     let!(:genus3) { Protonym.create!(name: 'Bus', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
+    let!(:genus3_otu) { Otu.create!(taxon_name: genus3) }
     let!(:genus4) { Protonym.create!(name: 'Cus', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
-    let!(:tnr) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: genus1, object_taxon_name: genus2) }
+    let!(:genus4_otu) { Otu.create!(taxon_name: genus4) }
+    let!(:genus5) { Protonym.create!(name: 'Dus', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
+    let!(:genus5_otu) { Otu.create!(taxon_name: genus5) }
+
+    let!(:genus6) { Protonym.create!(name: 'Fus', rank_class: Ranks.lookup(:iczn, :genus), parent: root) }
+    let!(:genus6_otu) { Otu.create!(taxon_name: genus6) }
+    let!(:genus7) { Protonym.create!(name: 'Gus', rank_class: Ranks.lookup(:iczn, :genus), parent: root) }
+    let!(:genus7_otu) { Otu.create!(taxon_name: genus7) }
+
+    let!(:tnr1) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: genus1, object_taxon_name: genus2) }
+    let!(:tnr2) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: genus5, object_taxon_name: genus6) }
+    let!(:tnr3) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: genus7, object_taxon_name: genus3) }
+
     let!(:tnc) { TaxonNameClassification::Iczn::Fossil.create!(taxon_name: genus4) }
+
     let!(:stats) { taxon_name_inventory_stats(family) }
 
     specify 'count' do
@@ -50,11 +68,12 @@ describe TaxonNamesHelper, type: :helper do
       let!(:g) { stats.find { |r| r[:rank] == :genus } }
 
       specify 'names valid' do
-        expect(g[:names][:valid]).to eq(3)
+        expect(g[:names][:valid]).to eq(3) # g2, g3, g4
       end
 
       specify 'names invalid' do
-        expect(g[:names][:invalid]).to eq(1)
+        # Invalid pulls from outside descendants and self; valid does not.
+        expect(g[:names][:invalid]).to eq(3) # g1, g5, g6
       end
 
       specify 'names valid_extant' do
@@ -64,27 +83,48 @@ describe TaxonNamesHelper, type: :helper do
       specify 'names valid_fossil' do
         expect(g[:names][:valid_fossil]).to eq(1)
       end
+
+      specify 'taxa' do
+        # Pulls in invalids, does not pull in valids, so genus6 is not included.
+        expect(g[:taxa]).to eq(6)
+      end
     end
   end
 
-  context "invalid is counted at valid's rank" do
+  context "invalid is counted at valid's rank only" do
     let!(:root) { FactoryBot.create(:root_taxon_name) }
     let!(:family) { Protonym.create!(name: 'Cicadellidae', rank_class: Ranks.lookup(:iczn, :family), parent: root) }
     let!(:genus1) { Protonym.create!(name: 'Erythroneura', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
+    let!(:genus1_otu) { Otu.create!(taxon_name: genus1) }
     let!(:genus2) { Protonym.create!(name: 'Aus', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
-    let!(:subgenus1) { Protonym.create!(name: 'Bus', rank_class: Ranks.lookup(:iczn, :subgenus), parent: genus1) }
+    let!(:genus2_otu) { Otu.create!(taxon_name: genus2) }
+    let!(:genus3) { Protonym.create!(name: 'Bus', rank_class: Ranks.lookup(:iczn, :genus), parent: family) }
 
-    let!(:tnr) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: subgenus1, object_taxon_name: genus2) }
+    let!(:subgenus1) { Protonym.create!(name: 'Cus', rank_class: Ranks.lookup(:iczn, :subgenus), parent: genus1) }
+    let!(:subgenus1_otu) { Otu.create!(taxon_name: subgenus1) }
+    let!(:subgenus2) { Protonym.create!(name: 'Dus', rank_class: Ranks.lookup(:iczn, :subgenus), parent: root) }
+    let!(:subgenus2_otu) { Otu.create!(taxon_name: subgenus2) }
+    let!(:subgenus3) { Protonym.create!(name: 'Fus', rank_class: Ranks.lookup(:iczn, :subgenus), parent: root) }
+    let!(:subgenus3_otu) { Otu.create!(taxon_name: subgenus3) }
+
+    let!(:tnr1) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: subgenus1, object_taxon_name: genus1) }
+    let!(:tnr2) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: subgenus2, object_taxon_name: genus2) }
+    let!(:tnr3) { TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: genus3, object_taxon_name: subgenus3) }
 
     let!(:stats) { taxon_name_inventory_stats(family) }
     let(:g) { stats.find { |r| r[:rank] == :genus } }
     let(:sg) { stats.find { |r| r[:rank] == :subgenus } }
 
-    specify 'invalid of different rank than valid is counted only at valid rank' do
-      expect(g[:names][:valid]).to eq(2)
-      expect(g[:names][:invalid]).to eq(1)
-      expect(sg[:names][:valid]).to eq(0)
-      expect(sg[:names][:invalid]).to eq(0)
+    specify 'invalid of different rank than valid is counted at valid rank only' do
+      expect(g[:names][:valid]).to eq(2) # g1, g2
+      expect(g[:names][:invalid]).to eq(2) # g3, sg3
+      expect(sg[:names][:valid]).to eq(0) # only invalid sg1 has family as ancestor
+      expect(sg[:names][:invalid]).to eq(1) # sg1 (valid name g1 is in the same family tree, it was counted above)
+    end
+
+    specify "taxa pulls invalid in to valid's rank, does not pull in invalid" do
+      expect(g[:taxa]).to eq(4) # g1, g2, sg1, sg2
+      expect(sg[:taxa]).to eq(0) # g3 doesn't have an otu
     end
   end
 end


### PR DESCRIPTION
Code mainly by chatgpt (5 and previous) with many chatgpt revisions to match previous dev, final cleanup and code renames by me for clarity.
    
Previously we did 4 queries per rank; for a suborder that equated to ~12 * 4 = 50 queries. For a lone species it would have been 4 queries.
We now do 4 queries (plus 1 for ranks, as before) regardless of the # of ranks.
    
According to explain analyze, current timings on taxon Auchenorrhyncha in 3i are:
  Otus query: ~1s
  ranks query: ~0.6s
  invalid query: ~0.3s
  valid query, fossil query: ~0.1s(?)
    
  Total: ~2s
    
We could still improve those, but it would require custom queries instead of going through ::Queries filters (and/or some new indices).
    
Note that we corrected a double count in invalid: previously an invalid name whose valid was of different rank (with both in descendants under consideration) would have been counted both at the invalid rank and at the valid rank
```ruby
j[:names][:invalid] = ::Queries::TaxonName::Filter.new(
  descendants: false, synonymify: true, taxon_name_id: taxon_name.id,
  rank: r, taxon_name_type: 'Protonym'
).all.that_is_invalid.count
```
(if genus `a` is the valid name of subgenus `b` then `b` gets counted as invalid in the subgenus count, that's fine, but at the genus count `synonymify` pulls in `b` through `a` and `a` is invalid, so it gets counted in the genus count as well)

There was a similar double count on the taxa-through-otus computation which is maybe less clear cut, but currently the 'rule' is that valid names pull in invalid 'synonyms' during counts, invalid names do not pull in valid names. That partitions all of the counts cleanly; previously some otu/names were included at multiple ranks.

_All valid counts should be exactly the same._
    
This accounts for the small differences on taxon Auchenorrhyncha in 3i between old stats, where valid counts are all equal:
{rank: :suborder, taxa: 1, names: {valid: 1, valid_fossil: 0, valid_extant: 1, invalid: 8}},
{rank: :infraorder, taxa: 7, names: {valid: 5, valid_fossil: 3, valid_extant: 2, invalid: 2}},
{rank: :parvorder, taxa: 1, names: {valid: 1, valid_fossil: 0, valid_extant: 1, invalid: 0}},
{rank: :superfamily, taxa: 17, names: {valid: 17, valid_fossil: 11, valid_extant: 6, invalid: 0}},
{rank: :family, taxa: 77, names: {valid: 73, valid_fossil: 39, valid_extant: 34, invalid: 28}},
{rank: :subfamily, taxa: 224, names: {valid: 137, valid_fossil: 35, valid_extant: 102, invalid: 66}},
{rank: :tribe, taxa: 924, names: {valid: 470, valid_fossil: 32, valid_extant: 438, invalid: 738}},
{rank: :subtribe, taxa: 208, names: {valid: 116, valid_fossil: 0, valid_extant: 116, invalid: 247}},
{rank: :genus, taxa: 9352, names: {valid: 7005, valid_fossil: 603, valid_extant: 6402, invalid: 4601}},
{rank: :subgenus, taxa: 898, names: {valid: 628, valid_fossil: 0, valid_extant: 628, invalid: 1092}},
{rank: :species, taxa: 57262, names: {valid: 47866, valid_fossil: 1303, valid_extant: 46563, invalid: 55842}},
{rank: :subspecies, taxa: 1902, names: {valid: 1403, valid_fossil: 11, valid_extant: 1392, invalid: 3438}}

and new stats:
{rank: :suborder, taxa: 1, names: {valid: 1, valid_fossil: 0, valid_extant: 1, invalid: 8}},
{rank: :infraorder, taxa: 7, names: {valid: 5, valid_fossil: 3, valid_extant: 2, invalid: 2}},
{rank: :parvorder, taxa: 1, names: {valid: 1, valid_fossil: 0, valid_extant: 1, invalid: 0}},
{rank: :superfamily, taxa: 17, names: {valid: 17, valid_fossil: 11, valid_extant: 6, invalid: 0}},
{rank: :family, taxa: 77, names: {valid: 73, valid_fossil: 39, valid_extant: 34, invalid: 28}},
{rank: :subfamily, taxa: 224, names: {valid: 137, valid_fossil: 35, valid_extant: 102, invalid: 66}},
{rank: :tribe, taxa: 924, names: {valid: 470, valid_fossil: 32, valid_extant: 438, invalid: 738}},
{rank: :subtribe, taxa: 208, names: {valid: 116, valid_fossil: 0, valid_extant: 116, invalid: 247}},
{rank: :genus, taxa: 9353, names: {valid: 7005, valid_fossil: 603, valid_extant: 6402, invalid: 4596}},
{rank: :subgenus, taxa: 897, names: {valid: 628, valid_fossil: 0, valid_extant: 628, invalid: 1090}},
{rank: :species, taxa: 57263, names: {valid: 47866, valid_fossil: 1303, valid_extant: 46563, invalid: 55840}},
{rank: :subspecies, taxa: 1901, names: {valid: 1403, valid_fossil: 11, valid_extant: 1392, invalid: 3435}}