### PR TITLE
4553 Fix lost otu api autocomplete results

### DIFF
--- a/spec/lib/queries/otu/autocomplete_spec.rb
+++ b/spec/lib/queries/otu/autocomplete_spec.rb
@@ -74,6 +74,22 @@ describe Queries::Otu::Autocomplete, type: :model do
         expect(r.last[:label_target].id).to eq(c.id)
         expect(r.last[:label_target].class.name).to eq('Combination')
       end
+
+      specify "combination doesn't displace its valid name" do
+        c = Combination.create!(genus: genus, species:)
+
+        q = Queries::Otu::Autocomplete.new(
+          'Erasmoneura vulnerata',
+          having_taxon_name_only: true,
+          project_id: project_id
+        )
+
+        r = q.api_autocomplete_extended
+
+        expect(r.count).to eq(2)
+        expect([r.first[:label_target].id, r.second[:label_target].id])
+          .to contain_exactly(c.id, species.id)
+      end
     end
 
     context 'DEPRECATED(?)' do


### PR DESCRIPTION
From the commit message:

At https://github.com/SpeciesFileGroup/taxonworks/blob/1b7f9f01a6ca0baafafb52716281d48c7c985279/lib/queries/otu/autocomplete.rb#L180
`otus = scope_autocomplete(otus).includes(:taxon_name)`

(AI fueled) Rails-speculation: scope_autocomplete was doing `otus = otus.joins(:taxon_name)...` already, and then we said to `.includes(:taxon_name)`, so rails thinks the `.includes` needs to be a join instead of an eager load (that part's not clear to me, but *is* what I saw in byebug).

The join creates duplicates on otu.id (because multiple invalid names have the same valid otu id), so rails de-dups those duplicated rows and we return from the includes with rows that had useful data in their non-otu table now excluded from search results. In the cases raised in the issue, valid name results were lost, but I don't think that's always the case - it depends on ordering of results returned from TaxonName::Query which I think(?) is random right now.

Now we no longer do the otus.joins(:taxon_name) in scope_autocomplete - which on its own is enough to fix the issue (since .includes then takes the preload route instead of eager_load), and to future-proof we just always do preload since we know we can create dup results that we need to retain.