### PR TITLE
Make origin_citation dependent: :destroy (like other citations)

### DIFF
--- a/app/models/concerns/shared/citations.rb
+++ b/app/models/concerns/shared/citations.rb
@@ -23,7 +23,7 @@ module Shared::Citations
     has_many :sources, -> { distinct }, through: :citations, inverse_of: :citations
     has_many :subsequent_sources, -> { distinct },  through: :subsequent_citations, source: :source
 
-    has_one :origin_citation, -> {where(is_original: true)}, as: :citation_object, class_name: 'Citation', inverse_of: :citation_object
+    has_one :origin_citation, -> {where(is_original: true)}, as: :citation_object, class_name: 'Citation', inverse_of: :citation_object, dependent: :destroy
 
     has_one :source, through: :origin_citation, inverse_of: :origin_citations
 


### PR DESCRIPTION
a) In line with the existing:
`has_many :citations, as: :citation_object, dependent: :destroy, inverse_of: :citation_object, validate: true`

b) Should fix the following exception - note especially `"origin_citation_attributes" => {"id" => nil, "source_id" => 127713, "pages" => nil}}` on a TN that *has* an origin citation already
```
An ActiveRecord::RecordNotSaved occurred in taxon_names#update:

  Failed to remove the existing associated origin_citation. The record failed to save after its foreign key was set to nil.
  app/controllers/taxon_names_controller.rb:57:in 'block in TaxonNamesController#update'

-------------------------------
Github link:
-------------------------------

  https://github.com/SpeciesFileGroup/taxonworks/blob/beb7a25bc/app/controllers/taxon_names_controller.rb#L57

-------------------------------
Request:
-------------------------------

  * URL        : https://sfg.taxonworks.org/taxon_names/1316361.json
  * HTTP Method: PATCH
  * Parameters : {"taxon_name" => {"id" => 1316361, "name" => "Alligaticeras", "parent_id" => 1316360, "rank_class" => "NomenclaturalRank::Iczn::GenusGroup::Genus", "year_of_publication" => nil, "verbatim_author" => nil, "etymology" => nil, "feminine_name" => nil, "masculine_name" => nil, "neuter_name" => nil, "roles_attributes" => [], "verbatim_name" => nil, "type" => "Protonym", "origin_citation_attributes" => {"id" => nil, "source_id" => 127713, "pages" => nil}}, "extend" => ["origin_citation", "parent", "roles", "ancestor_ids", "children", "type_taxon_name_relationship"], "controller" => "taxon_names", "action" => "update", "id" => "1316361", "format" => "json"}
```