### PR TITLE
Permit subclass SV meta declaration to override base class SV declara…

### DIFF
--- a/app/models/taxon_name_relationship/icn/unaccepting/synonym.rb
+++ b/app/models/taxon_name_relationship/icn/unaccepting/synonym.rb
@@ -2,6 +2,15 @@ class TaxonNameRelationship::Icn::Unaccepting::Synonym < TaxonNameRelationship::
 
   NOMEN_URI='http://purl.obolibrary.org/obo/NOMEN_0000372'.freeze
 
+  # Override the base-class metadata for this SV
+  soft_validate(
+    :sv_not_specific_relationship,
+    set: :not_specific_relationship,
+    fix: :sv_fix_specify_synonymy_type,
+    name: 'Not specific relationship',
+    description: 'More specific relationship is preferred, for example "Subjective synonym" instead of "Synonym".'
+  )
+
   def self.disjoint_taxon_name_relationships
     self.parent.disjoint_taxon_name_relationships +
         self.collect_to_s(TaxonNameRelationship::Icn::Unaccepting,
@@ -45,8 +54,12 @@ class TaxonNameRelationship::Icn::Unaccepting::Synonym < TaxonNameRelationship::
   end
 
   def sv_not_specific_relationship
-    soft_validations.add(:type, 'Please specify if this is a homotypic or heterotypic synonym',
-                         fix: :sv_fix_specify_synonymy_type, success_message: 'Synonym updated to being homotypic or heterotypic')
+    soft_validations.add(
+      :type,
+      'Please specify if this is a homotypic or heterotypic synonym',
+      success_message: 'Synonym updated to being homotypic or heterotypic',
+      failure_message: 'Failed to set homotypic or heterotypic'
+    )
   end
 
   def sv_fix_specify_synonymy_type
@@ -63,10 +76,8 @@ class TaxonNameRelationship::Icn::Unaccepting::Synonym < TaxonNameRelationship::
     if self.type_name != new_relationship_name
       self.type = new_relationship_name
       begin
-        TaxonNameRelationship.transaction do
-          self.save
-          return true
-        end
+        self.save
+        return true
       rescue
       end
     end

--- a/app/models/taxon_name_relationship/icnp/unaccepting/synonym.rb
+++ b/app/models/taxon_name_relationship/icnp/unaccepting/synonym.rb
@@ -2,6 +2,15 @@ class TaxonNameRelationship::Icnp::Unaccepting::Synonym < TaxonNameRelationship:
 
   NOMEN_URI='http://purl.obolibrary.org/obo/NOMEN_0000096'.freeze
 
+  # Override the base-class metadata for this SV
+  soft_validate(
+    :sv_not_specific_relationship,
+    set: :not_specific_relationship,
+    fix: :sv_fix_specify_synonymy_type,
+    name: 'Not specific relationship',
+    description: 'More specific relationship is preferred, for example "Subjective synonym" instead of "Synonym".'
+  )
+
   def self.disjoint_taxon_name_relationships
     self.parent.disjoint_taxon_name_relationships +
         self.collect_to_s(TaxonNameRelationship::Icnp::Unaccepting) +
@@ -43,8 +52,12 @@ class TaxonNameRelationship::Icnp::Unaccepting::Synonym < TaxonNameRelationship:
   end
 
   def sv_not_specific_relationship
-    soft_validations.add(:type, 'Please specify if this is a homotypic or heterotypic synonym',
-                         fix: :sv_fix_specify_synonymy_type, success_message: 'Synonym updated to being homotypic or heterotypic')
+    soft_validations.add(
+      :type,
+      'Please specify if this is a homotypic or heterotypic synonym',
+      success_message: 'Synonym updated to being homotypic or heterotypic',
+      failure_message: 'Failed to set homotypic or heterotypic'
+    )
   end
 
   def sv_fix_specify_synonymy_type
@@ -61,10 +74,8 @@ class TaxonNameRelationship::Icnp::Unaccepting::Synonym < TaxonNameRelationship:
     if self.type_name != new_relationship_name
       self.type = new_relationship_name
       begin
-        TaxonNameRelationship.transaction do
-          self.save
-          return true
-        end
+        self.save
+        return true
       rescue
       end
     end

--- a/lib/soft_validation.rb
+++ b/lib/soft_validation.rb
@@ -24,7 +24,7 @@
 # keep the intent of the logic close to the consequences of the logic.
 #
 # Devloper tips:
-# 
+#
 # - Protonym.soft_validation( ) <- all technical metadata and a gross description (the intent), optionally, goes here
 # - @protonym.sv_xyz( ) <- all human guidance (warning, outcomes) goes here, including the attribute to point to in the UI
 # - *fix* method names should not be exposed to the UI
@@ -193,7 +193,7 @@ module SoftValidation
     # @return [Array]
     #   all methods from all sets from self (not superclasses)
     def soft_validation_methods_on_self
-      a = soft_validation_sets[name]&.keys 
+      a = soft_validation_sets[name]&.keys
       return [] if a.nil?
       a.collect{|s| soft_validation_sets[name][s] }.flatten
     end
@@ -223,7 +223,7 @@ module SoftValidation
     #
     # @param except_methods [Array]
     #   Names (symbols) of soft validation methods to exclude.  Ignored if only_methods is provided.
-    #   
+    #
     # @param include_superclass [Boolean]
     #   include validations on superclasses, default is `true`
     #
@@ -278,7 +278,10 @@ module SoftValidation
       # Get rid of explicitly excluded
       methods.delete_if{|m| except_methods.include?(m) }
 
-      methods
+      # De-duplicate methods list, preferring subclass methods over base class.
+      methods.reverse!
+      methods.uniq! { |m| m.name }
+      methods.reverse!
     end
 
     private
@@ -335,7 +338,7 @@ module SoftValidation
   end
 
   # The validation set to fix is set prior to running the fix, at the first step.
-  # It can be refined/restricted there as needed, letting specific contexts (e.g. 
+  # It can be refined/restricted there as needed, letting specific contexts (e.g.
   # access in controller) defined the scope.
   def fix_soft_validations
     return false if !soft_validated?


### PR DESCRIPTION
Written with chatgpt.

Permit subclass SV meta declaration to override base class SV declaration
    
Fixes `fix:` for icn/icnp `:sv_not_specific_relationship` SV - the previous version attempted to add a different `fix:` in the subclass than in the base class, which couldn't be done.
    
Now it can, by overwriting the base class sv with a new subclass declaration (previously declaring in both places would have resulted in two different SVs).
    
STR (e.g.):
  * create two ICNP (or ICN) genera in New Taxon Name
  * synonymize them using 'Junior synonym of' taxon_name_relationship
    
Get a 500. Get a 500 when the page reloads. See no TNR SVs.
    
Exception report:
```
    An ActionView::Template::Error occurred in browse#index:
    
      undefined method 'fix=' for an instance of SoftValidation::SoftValidation
      lib/soft_validation/soft_validation.rb:53:in 'block in SoftValidation::SoftValidation#initialize'
    
    -------------------------------
    Github link:
    -------------------------------
    
      https://github.com/SpeciesFileGroup/taxonworks/blob/ca0670348/lib/soft_validation/soft_validation.rb#L53
    
    -------------------------------
    Request:
    -------------------------------
    
      * URL        : https://sandbox.taxonworks.org/tasks/nomenclature/browse?taxon_name_id=2402420
```
