### PR TITLE
Eml file upload, CodeMirror xml edit

### DIFF
--- a/app/javascript/vue/assets/styles/variables/_palette.scss
+++ b/app/javascript/vue/assets/styles/variables/_palette.scss
@@ -50,6 +50,12 @@
 
   --taxon-name-valid-color: #0c2351;
   --taxon-name-invalid-color: #b0783c;
+
+  --code-tag-color: #116611;
+  --code-attribute-color: #0077aa;
+  --code-string-color: #000000;
+  --code-error-color: #cc0000;
+  --code-selection-color: #d7e4f7;
 }
 
 .dark {
@@ -99,6 +105,12 @@
   --feedback-warning-text-color: #cf873b;
   --feedback-warning-bg-color: #37332f;
   --feedback-warning-border-color: #6b461e;
+
+  --code-tag-color: #90ee90;
+  --code-attribute-color: #87ceeb;
+  --code-string-color: #ffffff;
+  --code-error-color: #ff6b6b;
+  --code-selection-color: #264f78;
 
   --taxon-name-valid-color: #b6cfff;
   --taxon-name-invalid-color: #cf873b;

--- a/app/javascript/vue/tasks/projects/dwc_export_preferences/app.vue
+++ b/app/javascript/vue/tasks/projects/dwc_export_preferences/app.vue
@@ -222,10 +222,10 @@
             <br>
           </template>
 
-          <textarea
+          <XmlEditor
             v-model="dataset"
-            rows="44"
-            cols="80"
+            :rows="44"
+            match-tags
           />
         </div>
 
@@ -264,10 +264,10 @@
             <br>
           </template>
 
-          <textarea
+          <XmlEditor
             v-model="additionalMetadata"
-            rows="13"
-            cols="80"
+            :rows="13"
+            match-tags
           />
         </div>
 
@@ -294,6 +294,7 @@ import VIcon from '@/components/ui/VIcon/index.vue'
 import VSpinner from '@/components/ui/VSpinner.vue'
 import Autocomplete from '@/components/ui/Autocomplete.vue'
 import EmlFileLoader from './components/EmlFileLoader.vue'
+import XmlEditor from './components/XmlEditor.vue'
 
 const EXTENSIONS = {
   resource_relationships: 'Resource relationships (biological associations)',
@@ -505,7 +506,7 @@ function validateAndSaveEML() {
         } else {
           errors = 'additional metadata has xml errors, was NOT saved; dataset WAS saved.'
         }
-        TW.workbench.alert.create(errors, 'notice')
+        TW.workbench.alert.create(errors, 'error')
       }
     })
     .catch(() => {})

--- a/app/javascript/vue/tasks/projects/dwc_export_preferences/components/EmlFileLoader.vue
+++ b/app/javascript/vue/tasks/projects/dwc_export_preferences/components/EmlFileLoader.vue
@@ -76,8 +76,6 @@ function handleFileSelected(event) {
         additionalMetadata: additionalMetadataContent
       })
 
-      TW.workbench.alert.create('EML file loaded successfully', 'notice')
-
       resetFileInput()
     } catch (err) {
       TW.workbench.alert.create(err.message || 'Failed to parse EML file', 'error')

--- a/app/javascript/vue/tasks/projects/dwc_export_preferences/components/XmlEditor.vue
+++ b/app/javascript/vue/tasks/projects/dwc_export_preferences/components/XmlEditor.vue
@@ -1,0 +1,121 @@
+<template>
+  <div ref="editorRef" />
+</template>
+
+<script setup>
+import { onMounted, watch, useTemplateRef } from 'vue'
+import CodeMirror from 'codemirror'
+import 'codemirror/mode/xml/xml.js'
+import 'codemirror/addon/edit/matchtags.js'
+import 'codemirror/lib/codemirror.css'
+
+const content = defineModel({
+  type: String,
+  default: ''
+})
+
+const props = defineProps({
+  rows: {
+    type: Number,
+    default: 20
+  },
+  matchTags: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const editorRef = useTemplateRef('editorRef')
+let editor = null
+
+onMounted(() => {
+  const config = {
+    value: content.value || '',
+    mode: 'xml',
+    lineNumbers: true,
+    lineWrapping: true,
+    tabSize: 2,
+    indentWithTabs: false,
+    viewportMargin: Infinity
+  }
+
+  if (props.matchTags) {
+    config.matchTags = { bothTags: true }
+  }
+
+  editor = CodeMirror(editorRef.value, config)
+
+  // Set height based on rows prop (approximate: 20px per row)
+  editor.setSize('100%', `${props.rows * 20}px`)
+
+  editor.on('change', (cm) => {
+    content.value = cm.getValue()
+  })
+})
+
+watch(content, (newValue) => {
+  if (editor && newValue !== editor.getValue()) {
+    // Use replaceRange to update content without moving cursor, to prevent
+    // CodeMirror highlighting the opening tag on load.
+    const lastLine = editor.lastLine()
+    const lastCh = editor.getLine(lastLine)?.length || 0
+    editor.replaceRange(
+      newValue || '',
+      { line: 0, ch: 0 },
+      { line: lastLine, ch: lastCh }
+    )
+  }
+})
+</script>
+
+<style scoped>
+:deep(.CodeMirror) {
+  border: 1px solid var(--border-color);
+  font-family: monospace;
+  height: auto;
+  max-width: 800px;
+  background-color: var(--input-bg-color);
+  color: var(--text-color);
+}
+
+:deep(.CodeMirror-gutters) {
+  background-color: var(--bg-muted);
+  border-right: 1px solid var(--border-color);
+}
+
+:deep(.CodeMirror-linenumber) {
+  color: var(--text-color);
+  opacity: 0.5;
+}
+
+:deep(.cm-tag) {
+  color: var(--code-tag-color);
+}
+
+:deep(.cm-attribute) {
+  color: var(--code-attribute-color);
+}
+
+:deep(.cm-string) {
+  color: var(--code-string-color);
+}
+
+:deep(.CodeMirror-selected) {
+  background-color: var(--code-selection-color) !important;
+}
+
+:deep(.CodeMirror-focused .CodeMirror-selected) {
+  background-color: var(--code-selection-color) !important;
+}
+
+/* Color for matching tags */
+:deep(.CodeMirror-matchingtag) {
+  background-color: rgba(255, 150, 0, 0.3);
+}
+
+/* Error color when a tag doesn't match */
+:deep(.cm-tag.cm-error) {
+  color: var(--code-error-color);
+  background-color: rgba(255, 0, 0, 0.1);
+}
+</style>


### PR DESCRIPTION
Changes:
* Added the option to upload an existing eml file to populate the dataset and additional_metadata inputs:
<img width="895" height="217" alt="image" src="https://github.com/user-attachments/assets/81b35f89-f6c1-4cea-b13f-06d3bac1a2cc" />

* Switched the xml text inputs to use CodeMirror - thanks for the suggestion @jlpereira, this is a *big* improvement!
  * Highlights open/close tag pairs when cursor is on either
  * Highlights mismatched pairs
  * auto-indents when writing your own xml
  * syntax highlighting
  * line numbers (useful when validation fails and tells you which line the error is on)
  
<img width="834" height="391" alt="image" src="https://github.com/user-attachments/assets/b2ecfb63-be5a-475b-b4d4-813db3689dd2" />

