### PR TITLE
Match source against alternate author spellings in autocomplete #4617

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 ### Added
 
 - subject/object type to indexed biological associations endpoint
+- Source autocomplete now matches on alternate author names [#4617]
 
 ### Fixed
 
@@ -20,6 +21,8 @@ This project <em>does not yet</em> adheres to [Semantic Versioning](https://semv
 ### Changed
 
 - Autocomplete list wraps the text instead of applying ellipses by default.
+
+[#4617]: https://github.com/SpeciesFileGroup/taxonworks/issues/4617
 
 ## [0.56.0] - 2025-11-12
 

--- a/db/migrate/20251212204901_add_index_to_alternate_values_on_attribute_and_value.rb
+++ b/db/migrate/20251212204901_add_index_to_alternate_values_on_attribute_and_value.rb
@@ -1,0 +1,5 @@
+class AddIndexToAlternateValuesOnAttributeAndValue < ActiveRecord::Migration[7.2]
+  def change
+    add_index :alternate_values, [:alternate_value_object_attribute, :value]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_04_222441) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_12_204901) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -61,6 +61,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_04_222441) do
     t.integer "alternate_value_object_id", null: false
     t.string "alternate_value_object_type", null: false
     t.integer "project_id"
+    t.index ["alternate_value_object_attribute", "value"], name: "index_alternate_values_on_attribute_and_value"
     t.index ["alternate_value_object_id", "alternate_value_object_type"], name: "index_alternate_values_on_alternate_value_object_id_and_type"
     t.index ["created_by_id"], name: "index_alternate_values_on_created_by_id"
     t.index ["language_id"], name: "index_alternate_values_on_language_id"


### PR DESCRIPTION
Notes:
* Alternate values are added one at a time, so the index is expected to have "no" performance impact on creation. Will certainly speed up searches for alternate_values on source authors (and titles) though.
* most autocomplete facets match against cached_author_string; the alternate value matches are simply against whatever is in the source author alternate value field
* went with separate queries for alternate value matches, placed directly after the corresponding non-alternate-value query. As usual we'll have to see how this plays out in practice with regards to placement/overflow.

Performance:

With 1,000 (added-by-claude) alternate values for source on author in the local 3i db (18,357 total table count), here's EXPLAIN for the first alt value query returning 10 results: 
```
SQL:
SELECT sources.* FROM "sources" INNER JOIN "alternate_values" ON "alternate_values"."alternate_value_object_type" = 'Source' AND "alternate_values"."alternate_value_object_id" = "sources"."id" WHERE (alternate_values.alternate_value_object_attribute = 'author' AND alternate_values.value ILIKE 'Smith') LIMIT 20

Limit  (cost=4.86..24.11 rows=1 width=2165) (actual time=0.133..0.386 rows=10 loops=1)
  ->  Nested Loop  (cost=4.86..24.11 rows=1 width=2165) (actual time=0.133..0.385 rows=10 loops=1)
        ->  Bitmap Heap Scan on alternate_values  (cost=4.44..15.67 rows=1 width=4) (actual time=0.123..0.350 rows=10 loops=1)
              Recheck Cond: ((alternate_value_object_attribute)::text = 'author'::text)
              Filter: ((value ~~* 'Smith'::text) AND ((alternate_value_object_type)::text = 'Source'::text))
              Rows Removed by Filter: 949
              Heap Blocks: exact=33
              ->  Bitmap Index Scan on idx_on_alternate_value_object_attribute_value_fc5a1a12bc  (cost=0.00..4.43 rows=3 width=0) (actual time=0.044..0.044 rows=1719 loops=1)
                    Index Cond: ((alternate_value_object_attribute)::text = 'author'::text)
        ->  Index Scan using sources_pkey on sources  (cost=0.42..8.44 rows=1 width=2165) (actual time=0.003..0.003 rows=1 loops=10)
              Index Cond: (id = alternate_values.alternate_value_object_id)
Planning Time: 0.360 ms
Execution Time: 0.399 ms <---
```
0.4ms for the query.

Here are actual timing results for 100 runs:
If a search term triggers ALL 5 alternate facets before finding results:
```
  autocomplete_exact_author_year_letter_alternate: 0.04ms
  autocomplete_exact_author_year_alternate: 0.01ms
  autocomplete_start_author_year_alternate: 0.01ms
  autocomplete_exact_author_alternate: 0.39ms
  autocomplete_start_of_author_alternate: 0.27ms

Total worst-case overhead: 0.73ms
```

There are 5 new alternate value queries, say each incurs 2ms of network latency, total is then ~11ms, shouldn't be noticeable.