### PR TITLE
Fix basisOfRecord callback compute failures

### DIFF
--- a/app/models/dwc_occurrence.rb
+++ b/app/models/dwc_occurrence.rb
@@ -224,32 +224,11 @@ class DwcOccurrence < ApplicationRecord
   end
 
   def basis
-    case dwc_occurrence_object_type
-    when 'CollectionObject'
-      if dwc_occurrence_object.is_fossil?
-        return 'FossilSpecimen'
-      else
-        return 'PreservedSpecimen'
-      end
-    when 'AssertedDistribution'
-      # Used to fork b/b Source::Human and Source::Bibtex:
-      case dwc_occurrence_object.source&.type || dwc_occurrence_object.sources.order(cached_nomenclature_date: :DESC).first.type
-      when 'Source::Bibtex'
-        return 'MaterialCitation'
-      when 'Source::Human'
-        return 'HumanObservation'
-      else # Not recommended at this point
-        return 'Occurrence'
-      end
-    when 'FieldOccurrence'
-      if dwc_occurrence_object.machine_output?
-        return 'MachineObservation'
-      else
-        return 'HumanObservation'
-      end
+    if dwc_occurrence_object&.respond_to?(:dwc_occurrence_basis)
+      dwc_occurrence_object.dwc_occurrence_basis
+    else
+      'Undefined'
     end
-
-    'Undefined'
   end
 
   def uuid_identifier_scope


### PR DESCRIPTION
STR:
1. Create a CO
2. Add a fossil biocuration class to that CO with URI='http://rs.tdwg.org/dwc/terms/FossilSpecimen' and save.
3. Run background jobs to update CO.dwco

Expected: DWCO.basisOfRecord == 'FossilSpecimen'
Actual: DWCO.basisOfRecord == 'PreservedSpecimen', and that's how DwCA exports it

The background job triggers a callback to recompute CO.dwc_occurrence because biocuration classes affect those values, but that path calls IsDwcOccurrence#set_dwc_occurrence, which calls update_columns on dwc_attributes, which previously didn't include a computation of basisOfRecord. 

The basisOfRecord computation *was* only on DwcOccurrence, and there it only happens on before_validate - that never happens in the above case because set_dwc_occurrence only does CO.dwc_occurrence#update_column.