### PR TITLE
Handle OPTIONS preflight to fix CORS error in vue-open-editor function

### DIFF
--- a/config/rspack/rules/devServer.js
+++ b/config/rspack/rules/devServer.js
@@ -20,6 +20,11 @@ module.exports = (webpackConfig) => {
           res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
           res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
 
+          if (req.method === 'OPTIONS') {
+            res.statusCode = 204
+            return res.end()
+          }
+
           return openInEditor()(req, res, next)
         })
 


### PR DESCRIPTION
@jlpereira could you take a look please? The open-editor-from-vue-dev-panel broke again - I don't really know if there are any additional concerns with this patch, but I can dig more if needed, i.e. feel free to send back to me.

Fix by Claude:

```
 The issue is that your __open-in-editor middleware sets CORS headers but doesn't handle the OPTIONS preflight request that Firefox sends. When Firefox does a cross-origin fetch, it first sends an OPTIONS request, which falls through to launch-editor-middleware instead of getting a proper CORS preflight response.

● Update(config/rspack/rules/devServer.js)
  ⎿  Added 5 lines
      20            res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
      21            res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
      22
      23 +          if (req.method === 'OPTIONS') {
      24 +            res.statusCode = 204
      25 +            return res.end()
      26 +          }
      27 +
      28            return openInEditor()(req, res, next)
      29          })
      30

● The fix adds handling for the OPTIONS preflight request. Firefox (unlike Chrome in some cases) strictly sends a CORS preflight before the actual GET request. Without an explicit response to that OPTIONS request, launch-editor-middleware doesn't know what to do with it and the request fails.

  Restart your shakapacker-dev-server for this to take effect.
```