### PR TITLE
De-dup geometry values in OTU geojson helper returns

### DIFF
--- a/app/helpers/asserted_distributions_helper.rb
+++ b/app/helpers/asserted_distributions_helper.rb
@@ -84,13 +84,13 @@ module AssertedDistributionsHelper
   end
 
   # @return [Hash] GeoJSON feature
-  def asserted_distribution_to_geo_json_feature(asserted_distribution)
+  def asserted_distribution_to_geo_json_feature(asserted_distribution, skip_geometry: false)
     return nil if asserted_distribution.nil?
     return nil unless asserted_distribution.has_shape?
 
     return {
       'type' => 'Feature',
-      'geometry' => RGeo::GeoJSON.encode(asserted_distribution.geo_object), # TODO: optimize
+      'geometry' => skip_geometry ? nil : RGeo::GeoJSON.encode(asserted_distribution.geo_object), # TODO: optimize
       'properties' => {
         'base' => {
           'type' => 'AssertedDistribution',

--- a/app/helpers/collecting_events_helper.rb
+++ b/app/helpers/collecting_events_helper.rb
@@ -196,17 +196,23 @@ module CollectingEventsHelper
 
   # @return [GeoJSON::Feature]
   #   the first geographic item of the first georeference on this collecting event
-  def collecting_event_to_geo_json_feature(collecting_event)
+  def collecting_event_to_geo_json_feature(collecting_event, skip_geometry: false)
     return nil if collecting_event.nil?
 
-    a,b,c = collecting_event.geo_json_data
-    return nil if a.nil?
+    if skip_geometry
+      shape_type, shape_id = collecting_event.geo_json_shape_key
+      return nil if shape_type.nil?
+      geometry = nil
+    else
+      geometry, shape_type, shape_id = collecting_event.geo_json_data
+      return nil if geometry.nil?
+    end
 
     l = label_for_collecting_event(collecting_event)
 
     return {
       'type' => 'Feature',
-      'geometry' => a,
+      'geometry' => geometry,
       'properties' => {
         'target' => {
           'type' => 'CollectingEvent',
@@ -219,8 +225,8 @@ module CollectingEventsHelper
           'label' => l
         },
         'shape' => {
-          'type' => b,
-          'id' => c }
+          'type' => shape_type,
+          'id' => shape_id }
       }
     }
   end

--- a/app/helpers/collection_objects_helper.rb
+++ b/app/helpers/collection_objects_helper.rb
@@ -245,9 +245,9 @@ module CollectionObjectsHelper
   # @return [GeoJSON feature, nil]
   # @param base [Boolean]
   #   wehther to annotate the feature properties with TW 'base' attributes
-  def collection_object_to_geo_json_feature(collection_object, base = true)
+  def collection_object_to_geo_json_feature(collection_object, base = true, skip_geometry: false)
     return nil if collection_object.nil?
-    if a = collecting_event_to_geo_json_feature(collection_object.collecting_event)
+    if a = collecting_event_to_geo_json_feature(collection_object.collecting_event, skip_geometry:)
       l = label_for_collection_object(collection_object)
       a['properties']['target'] = {
         'type' => 'CollectionObject',

--- a/app/helpers/field_occurrences_helper.rb
+++ b/app/helpers/field_occurrences_helper.rb
@@ -51,9 +51,9 @@ module FieldOccurrencesHelper
   # @return [GeoJSON feature, nil]
   # @param base [Boolean]
   #   wehther to annotate the feature properties with TW 'base' attributes
-  def field_occurrence_to_geo_json_feature(field_occurrence, base = true)
+  def field_occurrence_to_geo_json_feature(field_occurrence, base = true, skip_geometry: false)
     return nil if field_occurrence.nil?
-    if a = collecting_event_to_geo_json_feature(field_occurrence.collecting_event)
+    if a = collecting_event_to_geo_json_feature(field_occurrence.collecting_event, skip_geometry:)
       l = label_for_field_occurrence(field_occurrence)
       a['properties']['target'] = {
         'type' => 'FieldOccurrence',

--- a/app/helpers/otus_helper.rb
+++ b/app/helpers/otus_helper.rb
@@ -216,8 +216,14 @@ module OtusHelper
     if otu.taxon_name && otu.taxon_name.is_protonym? && !otu.taxon_name.is_species_rank?
       add_aggregate_geo_json(otu, h)
     else
+      seen_shapes = {
+        field_occurrences: {},
+        collection_objects: {},
+        asserted_distributions: {},
+        type_materials: {}
+      }
       otus.each do |o|
-        add_distribution_geo_json(o, h)
+        add_distribution_geo_json(o, h, seen_shapes)
       end
     end
 
@@ -304,7 +310,7 @@ module OtusHelper
 
   end
 
-  def add_distribution_geo_json(otu, target)
+  def add_distribution_geo_json(otu, target, seen_shapes = nil)
     h = target
     o = otu
 
@@ -312,34 +318,47 @@ module OtusHelper
     t = geojson_target_for_otu(otu)
 
     o.current_field_occurrences.each do |f|
-      if g = field_occurrence_to_geo_json_feature(f)
-        g['properties']['target'] = t
-        h['features'].push g
+      shape_key = seen_shapes && f.collecting_event&.geo_json_shape_key
+      g = build_geo_json_feature_deduped(seen_shapes&.fetch(:field_occurrences), shape_key) do |skip_geometry|
+        field_occurrence_to_geo_json_feature(f, skip_geometry:)
       end
+      next unless g
+      g['properties']['target'] = t
+      h['features'].push g
     end
 
     o.current_collection_objects.each do |c|
-      if g = collection_object_to_geo_json_feature(c)
-        g['properties']['target'] = t
-        h['features'].push g
+      shape_key = seen_shapes && c.collecting_event&.geo_json_shape_key
+      g = build_geo_json_feature_deduped(seen_shapes&.fetch(:collection_objects), shape_key) do |skip_geometry|
+        collection_object_to_geo_json_feature(c, skip_geometry:)
       end
+      next unless g
+      g['properties']['target'] = t
+      h['features'].push g
     end
 
     o.asserted_distributions.each do |a|
-      if g = asserted_distribution_to_geo_json_feature(a)
-        g['properties']['target'] = t
-        h['features'].push g
+      shape_key = seen_shapes && [a.asserted_distribution_shape_type, a.asserted_distribution_shape_id]
+      g = build_geo_json_feature_deduped(seen_shapes&.fetch(:asserted_distributions), shape_key) do |skip_geometry|
+        asserted_distribution_to_geo_json_feature(a, skip_geometry:)
       end
+      next unless g
+      g['properties']['target'] = t
+      h['features'].push g
     end
 
     o.type_materials.includes(:protonym).each do |e|
       next unless type_material_is_primary_type(e) && o.taxon_name.cached_is_valid
 
-      if (g = type_material_to_geo_json_feature(e))
-        g['properties']['target'] = t
-        h['features'].push g
+      shape_key = seen_shapes && e.collection_object&.collecting_event&.geo_json_shape_key
+      g = build_geo_json_feature_deduped(seen_shapes&.fetch(:type_materials), shape_key) do |skip_geometry|
+        type_material_to_geo_json_feature(e, skip_geometry:)
       end
+      next unless g
+      g['properties']['target'] = t
+      h['features'].push g
     end
+
     h
   end
 
@@ -429,6 +448,33 @@ module OtusHelper
           .map { |l| { id: l.id, text: l.text } }
       }
     }
+  end
+
+  private
+
+  # Yields once with skip_geometry true or false depending on whether +shape_key+
+  # [shape_type, shape_id] has already been recorded in +seen+.
+  #
+  # First occurrence of a shape: yields skip_geometry=false (full geometry fetched).
+  #   The shape is recorded in +seen+ only if the block returns a non-nil feature,
+  #   so shapes that produce no feature (e.g. no geographic item) are never marked seen.
+  # Subsequent occurrences: yields skip_geometry=true (geometry skipped, nil in feature).
+  #
+  # When +seen+ or +shape_key+ is nil (deduplication disabled or no shape available),
+  # yields skip_geometry=false unconditionally.
+  def build_geo_json_feature_deduped(seen, shape_key)
+    if seen.nil? || shape_key.nil? || shape_key.first.nil?
+      return yield(false)
+    end
+
+    key = "#{shape_key[0]}_#{shape_key[1]}"
+    if seen.key?(key)
+      yield(true)
+    else
+      g = yield(false)
+      seen[key] = true if g
+      g
+    end
   end
 
 end

--- a/app/helpers/type_materials_helper.rb
+++ b/app/helpers/type_materials_helper.rb
@@ -21,9 +21,9 @@ full_original_taxon_name_tag(type_material.protonym)
   # @return [GeoJson feature]
   # @param base [Boolean]
   #
-  def type_material_to_geo_json_feature(type_material, base = true)
+  def type_material_to_geo_json_feature(type_material, base = true, skip_geometry: false)
     return nil if type_material.nil?
-    if a = collection_object_to_geo_json_feature(type_material.collection_object, false)
+    if a = collection_object_to_geo_json_feature(type_material.collection_object, false, skip_geometry:)
       l = label_for_type_material(type_material)
       a['properties']['target'] = {
         'type' => 'TypeMaterial',

--- a/app/models/collecting_event/georeference.rb
+++ b/app/models/collecting_event/georeference.rb
@@ -24,6 +24,27 @@ module CollectingEvent::Georeference
     end
   end
 
+  # Returns [shape_type, shape_id] for the preferred geographic representation
+  # without fetching or computing the geometry. Returns nil if no mappable location exists.
+  # Uses the same precedence logic as geo_json_data.
+  #
+  # Note on georeference deduplication: georeferences are collecting-event-specific objects.
+  # Two collecting events at the same geographic location will have different georeference IDs
+  # and will NOT be deduplicated. Deduplication of georeference shapes only occurs when
+  # multiple records (e.g. collection objects from different OTUs) share the same
+  # collecting event.
+  #
+  # Geographic area deduplication is broader: any two records referencing the same
+  # geographic area share the same shape key regardless of which collecting event they
+  # belong to.
+  def geo_json_shape_key
+    if gr_id = georeferences.order(:position).pluck(:id).first
+      ['Georeference', gr_id]
+    elsif geographic_area_default_geographic_item_id
+      ['GeographicArea', geographic_area_id]
+    end
+  end
+
   # @param [Float] delta_z, will be used to fill in the z coordinate of the point
   # @return [RGeo::Geographic::ProjectedPointImpl, nil]
   #   for the *verbatim* latitude/longitude only

--- a/spec/helpers/otus_helper_spec.rb
+++ b/spec/helpers/otus_helper_spec.rb
@@ -170,6 +170,153 @@ describe OtusHelper, type: :helper do
         expect(gz_feature.dig('properties', 'is_absent')).to eq(true)
       end
     end
+
+    describe 'deduplication via seen_shapes' do
+      let!(:otu2) { FactoryBot.create(:valid_otu) }
+      let!(:shared_ga) { FactoryBot.create(:valid_geographic_area) }
+
+      let!(:ad1) do
+        FactoryBot.create(:valid_geographic_area_asserted_distribution,
+          asserted_distribution_object: otu,
+          asserted_distribution_shape: shared_ga)
+      end
+
+      let!(:ad2) do
+        FactoryBot.create(:valid_geographic_area_asserted_distribution,
+          asserted_distribution_object: otu2,
+          asserted_distribution_shape: shared_ga)
+      end
+
+      before do
+        FactoryBot.create(:valid_geographic_areas_geographic_item, geographic_area: shared_ga)
+      end
+
+      def ad_features_for_shared_ga(h)
+        h['features'].select { |f|
+          f.dig('properties', 'base', 'type') == 'AssertedDistribution' &&
+          f.dig('properties', 'shape', 'id') == shared_ga.id
+        }
+      end
+
+      specify 'includes all records but only fetches geometry once per shape when seen_shapes is provided' do
+        h = helper.geojson_for_otu(otu)
+        seen = { field_occurrences: {}, collection_objects: {}, asserted_distributions: {}, type_materials: {} }
+
+        helper.add_distribution_geo_json(otu, h, seen)
+        helper.add_distribution_geo_json(otu2, h, seen)
+
+        features = ad_features_for_shared_ga(h)
+        expect(features.count).to eq(2)
+        expect(features.count { |f| f['geometry'].present? }).to eq(1)
+        expect(features.count { |f| f['geometry'].nil? }).to eq(1)
+      end
+
+      specify 'includes geometry on all records when seen_shapes is not provided' do
+        h = helper.geojson_for_otu(otu)
+
+        helper.add_distribution_geo_json(otu, h)
+        helper.add_distribution_geo_json(otu2, h)
+
+        features = ad_features_for_shared_ga(h)
+        expect(features.count).to eq(2)
+        expect(features.all? { |f| f['geometry'].present? }).to be(true)
+      end
+
+      # Georeference dedup is narrower than geographic area dedup: it only fires when
+      # records share the *same collecting event* (and thus the same georeference object).
+      # Two collecting events at the same location have distinct georeference IDs and
+      # will not be deduplicated even if they produce identical geometries.
+      describe 'georeference-based shapes (collection objects sharing a collecting event)' do
+        let!(:shared_ce) { FactoryBot.create(:valid_collecting_event) }
+        let!(:shared_gr) { FactoryBot.create(:valid_georeference, collecting_event: shared_ce) }
+
+        let!(:co1) { FactoryBot.create(:valid_specimen, collecting_event: shared_ce) }
+        let!(:co2) { FactoryBot.create(:valid_specimen, collecting_event: shared_ce) }
+
+        before do
+          FactoryBot.create(:taxon_determination, otu: otu,  taxon_determination_object: co1)
+          FactoryBot.create(:taxon_determination, otu: otu2, taxon_determination_object: co2)
+        end
+
+        def co_features_for_shared_gr(h)
+          h['features'].select { |f|
+            f.dig('properties', 'base', 'type') == 'CollectionObject' &&
+            f.dig('properties', 'shape', 'type') == 'Georeference' &&
+            f.dig('properties', 'shape', 'id') == shared_gr.id
+          }
+        end
+
+        specify 'includes all records but only fetches geometry once when OTUs share a collecting event' do
+          h = helper.geojson_for_otu(otu)
+          seen = { field_occurrences: {}, collection_objects: {}, asserted_distributions: {}, type_materials: {} }
+
+          helper.add_distribution_geo_json(otu,  h, seen)
+          helper.add_distribution_geo_json(otu2, h, seen)
+
+          features = co_features_for_shared_gr(h)
+          expect(features.count).to eq(2)
+          expect(features.count { |f| f['geometry'].present? }).to eq(1)
+          expect(features.count { |f| f['geometry'].nil? }).to eq(1)
+        end
+
+        specify 'geo_json_shape_key returns the same shape id as geo_json_data for a georeference' do
+          shape_key = shared_ce.geo_json_shape_key
+          expect(shape_key).to eq(['Georeference', shared_gr.id])
+
+          geometry, shape_type, shape_id = shared_ce.geo_json_data
+          expect(shape_type).to eq('Georeference')
+          expect(shape_id).to eq(shared_gr.id)
+          expect(geometry).to be_present
+        end
+      end
+
+      # When a collecting event has no georeference and falls back to its geographic area,
+      # the shape key is ['GeographicArea', geographic_area_id]. Two *different* collecting
+      # events that reference the same geographic area share that key and deduplicate —
+      # this is the broader and more impactful case for collection objects.
+      describe 'geographic-area-based shapes (collection objects on different CEs sharing a GA)' do
+        let!(:shared_ga) { FactoryBot.create(:valid_geographic_area) }
+
+        # Two separate collecting events, no georeferences, both assigned to shared_ga
+        let!(:ce1) { FactoryBot.create(:valid_collecting_event, geographic_area: shared_ga) }
+        let!(:ce2) { FactoryBot.create(:valid_collecting_event, geographic_area: shared_ga) }
+
+        let!(:co1) { FactoryBot.create(:valid_specimen, collecting_event: ce1) }
+        let!(:co2) { FactoryBot.create(:valid_specimen, collecting_event: ce2) }
+
+        before do
+          FactoryBot.create(:valid_geographic_areas_geographic_item, geographic_area: shared_ga)
+          FactoryBot.create(:taxon_determination, otu: otu,  taxon_determination_object: co1)
+          FactoryBot.create(:taxon_determination, otu: otu2, taxon_determination_object: co2)
+        end
+
+        def co_features_for_shared_ga(h)
+          h['features'].select { |f|
+            f.dig('properties', 'base', 'type') == 'CollectionObject' &&
+            f.dig('properties', 'shape', 'type') == 'GeographicArea' &&
+            f.dig('properties', 'shape', 'id') == shared_ga.id
+          }
+        end
+
+        specify 'includes all records but only fetches geometry once when OTUs have COs on different CEs sharing a GA' do
+          h = helper.geojson_for_otu(otu)
+          seen = { field_occurrences: {}, collection_objects: {}, asserted_distributions: {}, type_materials: {} }
+
+          helper.add_distribution_geo_json(otu,  h, seen)
+          helper.add_distribution_geo_json(otu2, h, seen)
+
+          features = co_features_for_shared_ga(h)
+          expect(features.count).to eq(2)
+          expect(features.count { |f| f['geometry'].present? }).to eq(1)
+          expect(features.count { |f| f['geometry'].nil? }).to eq(1)
+        end
+
+        specify 'geo_json_shape_key returns GeographicArea key when CE has no georeference' do
+          expect(ce1.geo_json_shape_key).to eq(['GeographicArea', shared_ga.id])
+          expect(ce2.geo_json_shape_key).to eq(['GeographicArea', shared_ga.id])
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Note we need to still return all OTUs, we just don't need to return geometries more than once.

Taxonpages and Browse OTU were already de-duping client side and visually/functionally appear unaffected by this change.

AI code and summary:

  Benchmark across 5 OSF OTUs (before → after):

  | OTU    | Features | Nulls | UniqueGeom | Before bytes | After bytes | Reduction |
  |--------|----------|-------|------------|--------------|-------------|-----------|
  | 812683 |      501 |   214 |        263 |   13,432,967 |   6,101,702 |      -55% |
  | 837005 |      135 |    80 |         43 |    2,955,659 |     631,174 |      -79% |
  | 849801 |      224 |    59 |        133 |    3,889,286 |   1,773,223 |      -54% |
  | 849851 |      155 |    45 |         78 |    1,735,797 |     518,953 |      -70% |
  | 926534 |      190 |    61 |         99 |    5,853,542 |   3,273,142 |      -44% |
  | **Total** | **1205** | **459** | **616** | **27,867,251** | **12,298,194** | **-56%** |

  UniqueGeom is the count of distinct geometry strings among non-null features.
  Where UniqueGeom < (Features - Nulls), remaining duplicate geometries are
  cross-category (e.g. the same geographic area cited as both an asserted
  distribution and via a collection object's collecting event). These are not
  deduped as different categories render in different colors.

  Note: visually overlapping shapes can still be legitimate. For example,
  Austria appears as both a TDWG Level 3 and TDWG Level 4 geographic area;
  two records citing different gazetteer levels produce two distinct shape keys
  and both geometries are correctly retained.