### PR TITLE
Fix some (occasional) 500s around Crossref lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ _development/
 
 .claude/
 claude/
+.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Filter Collecting Event can return an error from the Matching Identifiers facet when the "Internal" type is set but none of the identifiers provided are internal (i.e. numeric)
 - Unable to delete descriptor character states from the New Descriptor interface
 - Don't label 0-column matrices as image matrices in the Observation Matrix Hub
+- Handle bad BibTeX and html returned during New Source's CrossRef lookup
+- Handle `%` in New Source's CrossRef lookup
 
 [#4851]: https://github.com/SpeciesFileGroup/taxonpages/issues/4851
 [#4852]: https://github.com/SpeciesFileGroup/taxonpages/issues/4852

--- a/app/controllers/tasks/sources/new_source_controller.rb
+++ b/app/controllers/tasks/sources/new_source_controller.rb
@@ -13,6 +13,12 @@ class Tasks::Sources::NewSourceController < ApplicationController
       @source ||= Source::Bibtex.new
       render '/sources/show'
     end
+  rescue Vendor::Serrano::CrossrefBibtexParseError => e
+    render json: {
+      error: 'Crossref returned BibTeX that could not be parsed.',
+      doi: e.doi,
+      bibtex: e.bibtex
+    }, status: :unprocessable_content
   end
 
   protected

--- a/app/javascript/vue/tasks/sources/new_source/components/crossRef.vue
+++ b/app/javascript/vue/tasks/sources/new_source/components/crossRef.vue
@@ -142,7 +142,8 @@ function getSource() {
 
   AjaxCall(
     'get',
-    `/tasks/sources/new_source/crossref_preview.json?citation=${citation.value}`
+    '/tasks/sources/new_source/crossref_preview.json',
+    { params: { citation: citation.value } }
   )
     .then(({ body }) => {
       if (body.title) {

--- a/app/javascript/vue/tasks/sources/new_source/components/crossRef.vue
+++ b/app/javascript/vue/tasks/sources/new_source/components/crossRef.vue
@@ -52,6 +52,38 @@ doi:10.1145/3274442
         v-model="citation"
         placeholder="DOI or citation to find..."
       />
+
+      <div
+        v-if="errorDetails"
+        class="crossref-error-details margin-large-top"
+      >
+        <p>{{ errorDetails.error }}</p>
+        <button
+          type="button"
+          class="button button-default normal-input"
+          @click="showErrorDetails = !showErrorDetails"
+        >
+          {{ showErrorDetails ? 'Hide error details' : 'Show error details' }}
+        </button>
+        <div v-if="showErrorDetails">
+          <p v-if="errorDetails.doi">
+            DOI:
+            <a
+              :href="doiUrl(errorDetails.doi)"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ errorDetails.doi }}
+            </a>
+          </p>
+          <div
+            v-if="errorDetails.bibtex"
+            class="crossref-error-bibtex"
+          >
+            {{ errorDetails.bibtex }}
+          </div>
+        </div>
+      </div>
     </template>
     <template #footer>
       <div class="flex-separate separate-top">
@@ -91,6 +123,8 @@ const store = useSourceStore()
 const citation = ref('')
 const found = ref(true)
 const isSearching = ref(false)
+const errorDetails = ref(null)
+const showErrorDetails = ref(false)
 
 const textareaRef = useTemplateRef('textarea')
 
@@ -103,6 +137,8 @@ onMounted(() => {
 function getSource() {
   isSearching.value = true
   store.reset()
+  errorDetails.value = null
+  showErrorDetails.value = false
 
   AjaxCall(
     'get',
@@ -134,7 +170,18 @@ function getSource() {
         )
       }
     })
-    .catch(() => {})
+    .catch((error) => {
+      found.value = false
+      const body = error?.response?.body
+
+      if (body?.bibtex) {
+        errorDetails.value = {
+          error: body.error,
+          doi: body.doi,
+          bibtex: body.bibtex.trim()
+        }
+      }
+    })
     .finally(() => {
       isSearching.value = false
     })
@@ -147,6 +194,10 @@ function setVerbatim() {
   })
   emit('close', true)
 }
+
+function doiUrl(doi) {
+  return `https://doi.org/${encodeURI(doi)}`
+}
 </script>
 
 <style scoped>
@@ -155,5 +206,11 @@ function setVerbatim() {
 }
 textarea {
   height: 100px;
+}
+
+.crossref-error-bibtex {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: monospace;
 }
 </style>

--- a/lib/vendor/serrano.rb
+++ b/lib/vendor/serrano.rb
@@ -92,7 +92,7 @@ module Vendor
       begin
         if format == 'bibtex'
           bibtex = ::Serrano.content_negotiation(ids: unurize_doi(doi), format: "bibtex") unless doi.nil?
-          return bibtex =~ /^\s*@/ ? bibtex : nil
+          return bibtex =~ /\A\s*@/ ? bibtex : nil
         elsif format == 'citeproc'
           citeproc = ::Serrano.content_negotiation(ids: unurize_doi(doi), format: "citeproc-json") unless doi.nil?
           return citeproc

--- a/lib/vendor/serrano.rb
+++ b/lib/vendor/serrano.rb
@@ -60,39 +60,31 @@ module Vendor
       citation&.strip!
       return false if citation.length < 6
 
-    # begin
+      doi = citation_is_valid_doi?(citation) ? citation : resolve_doi(citation)
+      return Source::Verbatim.new(verbatim: citation) if doi.nil?
 
-        doi = citation_is_valid_doi?(citation) ? citation : resolve_doi(citation)
-        return Source::Verbatim.new(verbatim: citation) if doi.nil?
+      # check string encoding, if not UTF-8, check if compatible with UTF-8,
+      # if so convert to UTF-8 and parse with latex, else use type verbatim
+      a = get_bibtex_string(doi, 'bibtex')
 
-        # check string encoding, if not UTF-8, check if compatible with UTF-8,
-        # if so convert to UTF-8 and parse with latex, else use type verbatim
-        a = get_bibtex_string(doi, 'bibtex')
+      b = ::Utilities::Strings.encode_with_utf8(a) if a
 
-        b = ::Utilities::Strings.encode_with_utf8(a) if a
-
-        if b
-
-          begin
-            bibtex = Source::Bibtex.new_from_bibtex(BibTeX::Bibliography.parse(b, filter: CrossRefLaTeX.instance).first)
-          rescue BibTeX::ParseError => e
-            # Handle year not being parsable but otherwise OK
-            unless e.message.include?('Failed to parse BibTeX on value "year"')
-              raise CrossrefBibtexParseError.new(doi: doi, bibtex: b, message: e.message)
-            end
-            true
+      if b
+        begin
+          bibtex = Source::Bibtex.new_from_bibtex(BibTeX::Bibliography.parse(b, filter: CrossRefLaTeX.instance).first)
+        rescue BibTeX::ParseError => e
+          # Handle year not being parsable but otherwise OK
+          unless e.message.include?('Failed to parse BibTeX on value "year"')
+            raise CrossrefBibtexParseError.new(doi: doi, bibtex: b, message: e.message)
           end
-
-          citeproc = get_bibtex_string(doi, 'citeproc')
-          bibtex_from_citproc(citeproc, bibtex)
-        else
-          Source::Verbatim.new(verbatim: a ? a : citation)
+          true
         end
 
-    #   rescue BibTeX::ParseError
-    #     return false
-    #   end
-
+        citeproc = get_bibtex_string(doi, 'citeproc')
+        bibtex_from_citeproc(citeproc, bibtex)
+      else
+        Source::Verbatim.new(verbatim: a ? a : citation)
+      end
     end
 
     # @return [String, nil] ; format == 'bibtex' or 'citeproc'
@@ -112,7 +104,7 @@ module Vendor
       end
     end
 
-    def self.bibtex_from_citproc(c, b)
+    def self.bibtex_from_citeproc(c, b)
       return nil unless c.present? && b.present?
       c = JSON.parse(c)
 

--- a/lib/vendor/serrano.rb
+++ b/lib/vendor/serrano.rb
@@ -4,6 +4,16 @@ module Vendor
   module Serrano
     CUTOFF = 50.0
 
+    class CrossrefBibtexParseError < StandardError
+      attr_reader :doi, :bibtex
+
+      def initialize(doi:, bibtex:, message:)
+        super(message)
+        @doi = doi
+        @bibtex = bibtex
+      end
+    end
+
     # @return [Float]
     def self.cutoff
       CUTOFF
@@ -52,9 +62,12 @@ module Vendor
 
     # begin
 
+        doi = citation_is_valid_doi?(citation) ? citation : resolve_doi(citation)
+        return Source::Verbatim.new(verbatim: citation) if doi.nil?
+
         # check string encoding, if not UTF-8, check if compatible with UTF-8,
         # if so convert to UTF-8 and parse with latex, else use type verbatim
-        a = get_bibtex_string(citation, 'bibtex')
+        a = get_bibtex_string(doi, 'bibtex')
 
         b = ::Utilities::Strings.encode_with_utf8(a) if a
 
@@ -65,12 +78,12 @@ module Vendor
           rescue BibTeX::ParseError => e
             # Handle year not being parsable but otherwise OK
             unless e.message.include?('Failed to parse BibTeX on value "year"')
-              raise e
+              raise CrossrefBibtexParseError.new(doi: doi, bibtex: b, message: e.message)
             end
             true
           end
 
-          citeproc = get_bibtex_string(citation, 'citeproc')
+          citeproc = get_bibtex_string(doi, 'citeproc')
           bibtex_from_citproc(citeproc, bibtex)
         else
           Source::Verbatim.new(verbatim: a ? a : citation)
@@ -83,23 +96,13 @@ module Vendor
     end
 
     # @return [String, nil] ; format == 'bibtex' or 'citeproc'
-    def self.get_bibtex_string(citation, format = 'bibtex')
+    def self.get_bibtex_string(doi, format = 'bibtex')
       begin
-        # Convert citation to DOI if it isn't already
-        if !citation_is_valid_doi?(citation)
-          # First item should be the one with highest score/relevance: https://github.com/CrossRef/rest-api-doc#sort-order
-          res = ::Serrano.works(query: citation, limit: 1)&.dig("message", "items")&.first
-          # citation = Serrano.works(query: citation)&.dig("message", "items")&.max_by { |i| i["score"] }&.dig("DOI") unless citation_is_valid_doi?(citation)
-
-          score = res&.dig("score") || -1.0
-          citation = (score >= CUTOFF) ? res&.dig("DOI") : nil
-        end
-
         if format == 'bibtex'
-          bibtex = ::Serrano.content_negotiation(ids: unurize_doi(citation), format: "bibtex") unless citation.nil?
+          bibtex = ::Serrano.content_negotiation(ids: unurize_doi(doi), format: "bibtex") unless doi.nil?
           return bibtex =~ /^\s*@/ ? bibtex : nil
         elsif format == 'citeproc'
-          citeproc = ::Serrano.content_negotiation(ids: unurize_doi(citation), format: "citeproc-json") unless citation.nil?
+          citeproc = ::Serrano.content_negotiation(ids: unurize_doi(doi), format: "citeproc-json") unless doi.nil?
           return citeproc
         else
           return nil
@@ -177,6 +180,13 @@ module Vendor
       doi = Identifier::Global::Doi.new(identifier: citation)
       doi.valid?
       !doi.errors.has_key?(:identifier)
+    end
+
+    def self.resolve_doi(citation)
+      # First item should be the one with highest score/relevance: https://github.com/CrossRef/rest-api-doc#sort-order
+      res = ::Serrano.works(query: citation, limit: 1)&.dig('message', 'items')&.first
+      score = res&.dig('score') || -1.0
+      score >= CUTOFF ? res&.dig('DOI') : nil
     end
 
   end

--- a/spec/controllers/tasks/sources/new_source_controller_spec.rb
+++ b/spec/controllers/tasks/sources/new_source_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe Tasks::Sources::NewSourceController, type: :controller do
+  render_views
+
+  before(:each) do
+    sign_in
+  end
+
+  let(:citation) { 'A new species of the spittlebug genus Ariptyelus Matsumura, 1940(Hemiptera: Cercopoidea: Aphrophoridae) from Luzon, Philippines' }
+
+  describe 'GET crossref_preview' do
+    specify 'renders the source payload when Crossref parsing succeeds' do
+      source = Source::Bibtex.new(title: 'Resolved title')
+
+      allow(Vendor::Serrano).to receive(:new_from_citation).with(citation: citation).and_return(source)
+
+      get :crossref_preview, params: { citation: citation }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+
+      expect(body['title']).to eq('Resolved title')
+    end
+
+    specify 'returns a user-facing error with DOI and BibTeX when Crossref returns unparsable BibTeX' do
+      allow(Vendor::Serrano).to receive(:new_from_citation).with(citation: citation).and_raise(
+        Vendor::Serrano::CrossrefBibtexParseError.new(
+          doi: '10.3956/2026-102.1.37',
+          bibtex: '@article{Thompson_2026, Jr._Yap_2026, ...}',
+          message: 'Failed to parse BibTeX'
+        )
+      )
+
+      get :crossref_preview, params: { citation: citation }, format: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      body = JSON.parse(response.body)
+
+      expect(body['error']).to eq('Crossref returned BibTeX that could not be parsed.')
+      expect(body['doi']).to eq('10.3956/2026-102.1.37')
+      expect(body['bibtex']).to eq('@article{Thompson_2026, Jr._Yap_2026, ...}')
+    end
+  end
+end

--- a/spec/lib/vendor/serrano_spec.rb
+++ b/spec/lib/vendor/serrano_spec.rb
@@ -29,13 +29,11 @@ describe Vendor::Serrano, type: :model, group: [:sources] do
       specify 'when DOI resolution fails it returns verbatim without fetching bibtex' do
         allow(described_class).to receive(:citation_is_valid_doi?).with(citation).and_return(false)
         allow(described_class).to receive(:resolve_doi).with(citation).and_return(nil)
-        allow(described_class).to receive(:get_bibtex_string)
 
         s = Vendor::Serrano.new_from_citation(citation: citation)
 
         expect(s).to be_a(Source::Verbatim)
         expect(s.verbatim).to eq(citation)
-        expect(described_class).not_to have_received(:get_bibtex_string)
       end
 
       specify 'when parsed bibtex fails it raises an error that includes the resolved DOI' do

--- a/spec/lib/vendor/serrano_spec.rb
+++ b/spec/lib/vendor/serrano_spec.rb
@@ -36,6 +36,23 @@ describe Vendor::Serrano, type: :model, group: [:sources] do
         expect(s.verbatim).to eq(citation)
       end
 
+      specify 'when content negotiation returns HTML with a later @ line it is rejected as non-bibtex' do
+        doi = '10.12101/j.issn.1004-390X(n).202209026'
+        html_response = <<~HTML
+          <!DOCTYPE html>
+          <html>
+            <body>
+              <p>Example page</p>
+              @media screen { body { color: black; } }
+            </body>
+          </html>
+        HTML
+
+        allow(::Serrano).to receive(:content_negotiation).with(ids: described_class.unurize_doi(doi), format: 'bibtex').and_return(html_response)
+
+        expect(described_class.get_bibtex_string(doi, 'bibtex')).to be_nil
+      end
+
       specify 'when parsed bibtex fails it raises an error that includes the resolved DOI' do
         doi = '10.3956/2026-102.1.37'
         malformed_bibtex = '@article{Thompson_2026, Jr._Yap_2026, title={Broken}}'

--- a/spec/lib/vendor/serrano_spec.rb
+++ b/spec/lib/vendor/serrano_spec.rb
@@ -25,6 +25,60 @@ describe Vendor::Serrano, type: :model, group: [:sources] do
           expect(s.class).to eq(Source::Bibtex)
         }
       end
+
+      specify 'when DOI resolution fails it returns verbatim without fetching bibtex' do
+        allow(described_class).to receive(:citation_is_valid_doi?).with(citation).and_return(false)
+        allow(described_class).to receive(:resolve_doi).with(citation).and_return(nil)
+        allow(described_class).to receive(:get_bibtex_string)
+
+        s = Vendor::Serrano.new_from_citation(citation: citation)
+
+        expect(s).to be_a(Source::Verbatim)
+        expect(s.verbatim).to eq(citation)
+        expect(described_class).not_to have_received(:get_bibtex_string)
+      end
+
+      specify 'when parsed bibtex fails it raises an error that includes the resolved DOI' do
+        doi = '10.3956/2026-102.1.37'
+        malformed_bibtex = '@article{Thompson_2026, Jr._Yap_2026, title={Broken}}'
+
+        allow(described_class).to receive(:citation_is_valid_doi?).with(citation).and_return(false)
+        allow(described_class).to receive(:resolve_doi).with(citation).and_return(doi)
+        allow(described_class).to receive(:get_bibtex_string).with(doi, 'bibtex').and_return(malformed_bibtex)
+
+        expect { Vendor::Serrano.new_from_citation(citation: citation) }
+          .to raise_error(Vendor::Serrano::CrossrefBibtexParseError) { |error|
+            expect(error.doi).to eq(doi)
+            expect(error.bibtex).to eq(malformed_bibtex)
+          }
+      end
+
+      specify 'when citeproc enrichment is available it still populates fields on the resolved source' do
+        doi = '10.3956/2026-102.1.37'
+        bibtex_text = <<~BIB
+          @article{Test2026,
+            title = {Resolved title}
+          }
+        BIB
+        citeproc_text = {
+          'container-title' => 'The Pan-Pacific Entomologist',
+          'publisher' => 'Pacific Coast Entomological Society',
+          'issued' => { 'date-parts' => [[2026]] }
+        }.to_json
+
+        allow(described_class).to receive(:citation_is_valid_doi?).with(citation).and_return(false)
+        allow(described_class).to receive(:resolve_doi).with(citation).and_return(doi)
+        allow(described_class).to receive(:get_bibtex_string).with(doi, 'bibtex').and_return(bibtex_text)
+        allow(described_class).to receive(:get_bibtex_string).with(doi, 'citeproc').and_return(citeproc_text)
+
+        s = Vendor::Serrano.new_from_citation(citation: citation)
+
+        expect(s).to be_a(Source::Bibtex)
+        expect(s.title).to eq('Resolved title')
+        expect(s.journal).to eq('The Pan-Pacific Entomologist')
+        expect(s.publisher).to eq('Pacific Coast Entomological Society')
+        expect(s.year).to eq(2026)
+      end
     end
 
     context 'from DOI text' do


### PR DESCRIPTION
These fixes all came from 500 emails (only roughly 6 since last June), see the commit messages for more details:
* Catch and report to user when Crossref returns invalid bibtex:
<img width="761" height="665" alt="image" src="https://github.com/user-attachments/assets/b9fe88c8-5d5d-4555-908b-fb5a124df886" />

* handle the case where a Crossref redirect returns an html page (in this case an error page)
* handle the case where the user input to Crossref includes `%`, as in RSI like `%a blah`