### PR TITLE
New taxon name: focus inputs

### DIFF
--- a/app/javascript/vue/components/role_picker.vue
+++ b/app/javascript/vue/components/role_picker.vue
@@ -474,6 +474,7 @@ function addOrganization(organization) {
 }
 defineExpose({
   addPerson,
-  addOrganization
+  addOrganization,
+  focus() { autocompleteRef.value?.setFocus() }
 })
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/app.vue
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div>
-      <NavHeader />
+      <NavHeader @section-clicked="focusSectionComponent" />
       <div class="flexbox horizontal-center-content align-start">
         <div class="item full_width">
           <VSpinner
@@ -41,11 +41,12 @@
             v-if="isLoading"
           />
           <template
-            v-for="{ component, title, isAvailableFor } in SectionComponents"
+            v-for="({ component, title, isAvailableFor }, index) in SectionComponents"
             :key="title"
           >
             <component
               v-if="isAvailableFor(taxon)"
+              :ref="el => { if (el) sectionRefs[index] = el; else delete sectionRefs[index] }"
               class="margin-medium-bottom"
               :is="component"
             />
@@ -82,6 +83,7 @@ defineOptions({
 const KEY_STORAGE_AUTOSAVE = 'task::NewTaxonName::Autosave'
 
 const store = useStore()
+const sectionRefs = {}
 
 const isLoading = ref()
 const shortcuts = ref([
@@ -191,6 +193,13 @@ function loadTaxon(taxon) {
     `/tasks/nomenclature/new_taxon_name?taxon_name_id=${taxon.id}`,
     '_self'
   )
+}
+
+function focusSectionComponent(index) {
+  const component = sectionRefs[index]
+  if (!component) return
+  component.$el?.querySelector('a[name]')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  component.focus?.()
 }
 
 function focusSearch() {

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/Author.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/Author.vue
@@ -90,6 +90,12 @@ export default {
   },
 
   watch: {
+    tabIndex: {
+      handler() {
+        this.$nextTick(() => this.$refs.activeTab?.focus?.())
+      }
+    },
+
     taxon: {
       handler(newVal, oldVal) {
         if (newVal.id && !oldVal.id) {

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/Author.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/Author.vue
@@ -14,7 +14,10 @@
         use-index
         v-model="tabIndex"
       />
-      <component :is="componentName" />
+      <component
+        :is="componentName"
+        ref="activeTab"
+      />
     </template>
   </block-layout>
 </template>
@@ -97,6 +100,10 @@ export default {
   },
 
   methods: {
+    focus() {
+      this.$refs.activeTab?.focus?.()
+    },
+
     setTabView() {
       if (this.verbatimFieldsWithData) {
         return TAB.Verbatim

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorPeople.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorPeople.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="flex-separate">
     <role-picker
+      ref="rolePicker"
       v-model="roles"
       @create="updateLastChange"
       @delete="updateLastChange"
@@ -69,6 +70,10 @@ export default {
   },
 
   methods: {
+    focus() {
+      this.$refs.rolePicker?.focus()
+    },
+
     cloneFromSource() {
       const authors = []
       const peopleIds = this.roles.map((role) => role.person.id)

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorSource.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorSource.vue
@@ -2,6 +2,7 @@
   <div class="full_width">
     <div class="horizontal-left-content full_width gap-small">
       <VAutocomplete
+        ref="autocomplete"
         url="/sources/autocomplete"
         min="3"
         param="term"
@@ -66,7 +67,7 @@ import { ActionNames } from '../../store/actions/actions'
 import { GetterNames } from '../../store/getters/getters'
 import { MutationNames } from '../../store/mutations/mutations'
 import { useStore } from 'vuex'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import VAutocomplete from '@/components/ui/Autocomplete.vue'
 import ButtonPinned from '@/components/ui/Button/ButtonPinned.vue'
@@ -76,6 +77,14 @@ import PdfButton from '@/components/ui/Button/ButtonPdf'
 import CitationPages from '../citationPages.vue'
 import SoftValidation from '@/components/soft_validations/objectValidation.vue'
 import FormCitationClone from '@/components/Form/FormCitation/FormCitationClone.vue'
+
+const autocomplete = ref(null)
+
+function focus() {
+  autocomplete.value?.setFocus()
+}
+
+defineExpose({ focus })
 
 let autosave = null
 

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorSource.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorSource.vue
@@ -80,12 +80,6 @@ import FormCitationClone from '@/components/Form/FormCitation/FormCitationClone.
 
 const autocomplete = ref(null)
 
-function focus() {
-  autocomplete.value?.setFocus()
-}
-
-defineExpose({ focus })
-
 let autosave = null
 
 const store = useStore()
@@ -141,4 +135,10 @@ function removeSource(id) {
     store.dispatch(ActionNames.RemoveSource, id)
   }
 }
+
+function focus() {
+  autocomplete.value?.setFocus()
+}
+
+defineExpose({ focus })
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorVerbatim.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorVerbatim.vue
@@ -29,12 +29,6 @@ import { vNumberOnly } from '@/directives/index.js'
 
 const verbatimAuthorInput = ref(null)
 
-function focus() {
-  verbatimAuthorInput.value?.focus()
-}
-
-defineExpose({ focus })
-
 const store = useStore()
 
 const verbatimAuthor = computed({
@@ -52,4 +46,10 @@ const verbatimYear = computed({
     store.commit(MutationNames.UpdateLastChange)
   }
 })
+
+function focus() {
+  verbatimAuthorInput.value?.focus()
+}
+
+defineExpose({ focus })
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorVerbatim.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorVerbatim.vue
@@ -3,6 +3,7 @@
     <div class="field label-above">
       <label>Verbatim author</label>
       <input
+        ref="verbatimAuthorInput"
         type="text"
         class="w-96"
         v-model="verbatimAuthor"
@@ -21,10 +22,18 @@
 
 <script setup>
 import { useStore } from 'vuex'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { GetterNames } from '../../store/getters/getters'
 import { MutationNames } from '../../store/mutations/mutations'
 import { vNumberOnly } from '@/directives/index.js'
+
+const verbatimAuthorInput = ref(null)
+
+function focus() {
+  verbatimAuthorInput.value?.focus()
+}
+
+defineExpose({ focus })
 
 const store = useStore()
 

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorMain.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorMain.vue
@@ -8,12 +8,22 @@
   />
   <component
     :is="componentName"
+    ref="activeTab"
     v-model="combination"
   />
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, nextTick } from 'vue'
+
+const activeTab = ref(null)
+
+defineExpose({
+  focus() {
+    tabIndex.value = 0
+    nextTick(() => activeTab.value?.focus?.())
+  }
+})
 import {
   NOMENCLATURE_CODE_BOTANY,
   NOMENCLATURE_CODE_ZOOLOGY

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorMain.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorMain.vue
@@ -14,20 +14,8 @@
 </template>
 
 <script setup>
-import { computed, ref, nextTick } from 'vue'
-
-const activeTab = ref(null)
-
-defineExpose({
-  focus() {
-    tabIndex.value = 0
-    nextTick(() => activeTab.value?.focus?.())
-  }
-})
-import {
-  NOMENCLATURE_CODE_BOTANY,
-  NOMENCLATURE_CODE_ZOOLOGY
-} from '@/constants/index.js'
+import { computed, ref } from 'vue'
+import { NOMENCLATURE_CODE_BOTANY } from '@/constants/index.js'
 import SwitchComponent from '@/components/ui/VSwitch.vue'
 import AuthorPerson from './AuthorPeople.vue'
 import AuthorSource from './AuthorSource.vue'
@@ -37,10 +25,6 @@ const TAB = {
   Source: AuthorSource,
   Verbatim: AuthorVerbatim,
   Person: AuthorPerson
-}
-
-function getTabLabel(label, hasData) {
-  return label + (hasData ? ' ✓' : '')
 }
 
 const props = defineProps({
@@ -58,6 +42,8 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue'])
 
 const tabIndex = ref(0)
+const activeTab = ref(null)
+
 const combination = computed({
   get: () => props.modelValue,
   set: (value) => emit('update:modelValue', value)
@@ -81,4 +67,12 @@ const sections = computed(() =>
       ]
     : []
 )
+
+function getTabLabel(label, hasData) {
+  return label + (hasData ? ' ✓' : '')
+}
+
+defineExpose({
+  focus() { activeTab.value?.focus?.() }
+})
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorMain.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorMain.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch, nextTick } from 'vue'
 import { NOMENCLATURE_CODE_BOTANY } from '@/constants/index.js'
 import SwitchComponent from '@/components/ui/VSwitch.vue'
 import AuthorPerson from './AuthorPeople.vue'
@@ -71,6 +71,8 @@ const sections = computed(() =>
 function getTabLabel(label, hasData) {
   return label + (hasData ? ' ✓' : '')
 }
+
+watch(tabIndex, () => nextTick(() => activeTab.value?.focus?.()))
 
 defineExpose({
   focus() { activeTab.value?.focus?.() }

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorPeople.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorPeople.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="flex-separate">
     <role-picker
+      ref="rolePicker"
       v-model="roles"
       :role-type="ROLE_TAXON_NAME_AUTHOR"
     />
@@ -21,6 +22,9 @@ import { ROLE_TAXON_NAME_AUTHOR } from '@/constants/index.js'
 import RolePicker from '@/components/role_picker.vue'
 import VBtn from '@/components/ui/VBtn/index.vue'
 
+const rolePicker = ref(null)
+const source = ref(null)
+
 const props = defineProps({
   modelValue: {
     type: Object,
@@ -28,7 +32,6 @@ const props = defineProps({
   }
 })
 const emit = defineEmits(['update:modelValue'])
-const source = ref(null)
 
 const combination = computed({
   get: () => props.modelValue,
@@ -79,4 +82,8 @@ if (sourceId) {
     source.value = body
   })
 }
+
+defineExpose({
+  focus() { rolePicker.value?.focus() }
+})
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorSource.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorSource.vue
@@ -4,6 +4,7 @@
       class="horizontal-left-content full_width margin-medium-bottom gap-small"
     >
       <VAutocomplete
+        ref="autocomplete"
         class="full_width"
         url="/sources/autocomplete"
         min="3"
@@ -82,6 +83,12 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+
+const autocomplete = ref(null)
+
+defineExpose({
+  focus() { autocomplete.value?.setFocus() }
+})
 import { Source, Citation } from '@/routes/endpoints'
 import VAutocomplete from '@/components/ui/Autocomplete.vue'
 import VPin from '@/components/ui/Button/ButtonPinned.vue'

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorVerbatim.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/Author/AuthorVerbatim.vue
@@ -3,6 +3,7 @@
     <div class="field label-above">
       <label>Verbatim author</label>
       <input
+        ref="verbatimAuthorInput"
         type="text"
         v-model="combination.verbatim_author">
     </div>
@@ -17,7 +18,9 @@
 
 <script setup>
 
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+
+const verbatimAuthorInput = ref(null)
 
 const props = defineProps({
   modelValue: {
@@ -31,6 +34,10 @@ const emit = defineEmits(['update:modelValue'])
 const combination = computed({
   get: () => props.modelValue,
   set: value => emit('update:modelValue', value)
+})
+
+defineExpose({
+  focus() { verbatimAuthorInput.value?.focus() }
 })
 
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/CombinationMain.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/CombinationMain.vue
@@ -36,12 +36,11 @@
         <CombinationVerbatim v-model="currentCombination.verbatim_name" />
       </div>
       <template v-if="Object.keys(combination).length">
-        <div ref="citationRef">
-          <CombinationCitation
-            :taxon="taxon"
-            v-model="citationData"
-          />
-        </div>
+        <CombinationCitation
+          ref="citationComponent"
+          :taxon="taxon"
+          v-model="citationData"
+        />
         <hr class="divisor" />
 
         <template v-if="isBotanyCode">
@@ -121,10 +120,10 @@ import makeCitationObject from '@/factory/Citation.js'
 import DisplayList from '@/components/displayList.vue'
 
 const store = useStore()
-const citationRef = ref(null)
+const citationComponent = ref(null)
 
 defineExpose({
-  focus() { citationRef.value?.querySelector('input')?.focus() }
+  focus() { citationComponent.value?.focus() }
 })
 const combination = ref({})
 const combinationList = computed(
@@ -169,7 +168,7 @@ const isICN = computed(
 
 const onSetCurrent = (item) => {
   combination.value = item
-  nextTick(() => citationRef.value?.querySelector('input')?.focus())
+  nextTick(() => citationComponent.value?.focus())
 }
 
 const saveCombination = () => {

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/CombinationMain.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/CombinationMain.vue
@@ -121,10 +121,6 @@ import DisplayList from '@/components/displayList.vue'
 
 const store = useStore()
 const citationComponent = ref(null)
-
-defineExpose({
-  focus() { citationComponent.value?.focus() }
-})
 const combination = ref({})
 const combinationList = computed(
   () => store.getters[GetterNames.GetCombinations]
@@ -322,5 +318,9 @@ watch(currentCombinationId, async (newId) => {
     : []
 
   queueClassification.value = []
+})
+
+defineExpose({
+  focus() { citationComponent.value?.focus() }
 })
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/CombinationMain.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Combination/CombinationMain.vue
@@ -11,7 +11,7 @@
         v-if="!isCurrentTaxonInCombination"
         :combination-ranks="combinationRanks"
         :manual-mode="isManualMode"
-        @on-set="(item) => (combination = item)"
+        @on-set="onSetCurrent"
       />
       <CombinationRank
         v-for="(group, groupName) in combinationRanks"
@@ -36,10 +36,12 @@
         <CombinationVerbatim v-model="currentCombination.verbatim_name" />
       </div>
       <template v-if="Object.keys(combination).length">
-        <CombinationCitation
-          :taxon="taxon"
-          v-model="citationData"
-        />
+        <div ref="citationRef">
+          <CombinationCitation
+            :taxon="taxon"
+            v-model="citationData"
+          />
+        </div>
         <hr class="divisor" />
 
         <template v-if="isBotanyCode">
@@ -96,7 +98,7 @@
 </template>
 
 <script setup>
-import { ref, computed, reactive, watch } from 'vue'
+import { ref, computed, reactive, watch, nextTick } from 'vue'
 import { useStore } from 'vuex'
 import { GetterNames } from '../../store/getters/getters.js'
 import { ActionNames } from '../../store/actions/actions.js'
@@ -119,6 +121,11 @@ import makeCitationObject from '@/factory/Citation.js'
 import DisplayList from '@/components/displayList.vue'
 
 const store = useStore()
+const citationRef = ref(null)
+
+defineExpose({
+  focus() { citationRef.value?.querySelector('input')?.focus() }
+})
 const combination = ref({})
 const combinationList = computed(
   () => store.getters[GetterNames.GetCombinations]
@@ -159,6 +166,11 @@ const combinationRanks = computed(() =>
 const isICN = computed(
   () => store.getters[GetterNames.GetNomenclaturalCode] === 'icn'
 )
+
+const onSetCurrent = (item) => {
+  combination.value = item
+  nextTick(() => citationRef.value?.querySelector('input')?.focus())
+}
 
 const saveCombination = () => {
   const combObj = Object.assign(

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/SubsequentNameForm/SubsequentNameForm.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/SubsequentNameForm/SubsequentNameForm.vue
@@ -89,17 +89,12 @@ import EditTaxonName from './EditTaxonName'
 import FormCitation from '@/components/Form/FormCitation.vue'
 import VConfidence from '@/components/ui/Button/ButtonConfidence.vue'
 
-const nameInput = ref(null)
-
-defineExpose({
-  focus() { nameInput.value?.focus() }
-})
-
 const store = useStore()
 
 const name = ref('')
 const relationship = ref()
 const citation = ref({})
+const nameInput = ref(null)
 
 const taxon = computed(() => store.getters[GetterNames.GetTaxon])
 
@@ -166,4 +161,8 @@ function resetForm() {
   citation.value = {}
   relationship.value = null
 }
+
+defineExpose({
+  focus() { nameInput.value?.focus() }
+})
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/SubsequentNameForm/SubsequentNameForm.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/SubsequentNameForm/SubsequentNameForm.vue
@@ -16,6 +16,7 @@
       <div v-else>
         <div class="horizontal-left-content gap-small margin-medium-bottom">
           <input
+            ref="nameInput"
             placeholder="Type a name..."
             type="text"
             v-model="name"
@@ -87,6 +88,12 @@ import BlockLayout from '@/components/layout/BlockLayout'
 import EditTaxonName from './EditTaxonName'
 import FormCitation from '@/components/Form/FormCitation.vue'
 import VConfidence from '@/components/ui/Button/ButtonConfidence.vue'
+
+const nameInput = ref(null)
+
+defineExpose({
+  focus() { nameInput.value?.focus() }
+})
 
 const store = useStore()
 

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/basicInformation.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/basicInformation.vue
@@ -165,6 +165,10 @@ export default {
   },
 
   methods: {
+    focus() {
+      this.$refs.inputTaxonname.focus()
+    },
+
     existError: function (type) {
       return this.errors && this.errors.hasOwnProperty(type)
     },

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/classification.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/classification.vue
@@ -23,6 +23,7 @@
       <div v-if="!taxonRelation">
         <div class="horizontal-left-content">
           <autocomplete
+            ref="taxonSearch"
             url="/taxon_names/autocomplete"
             label="label_html"
             min="2"
@@ -155,6 +156,10 @@ export default {
     }
   },
   methods: {
+    focus() {
+      this.$refs.taxonSearch?.setFocus()
+    },
+
     setInsertaeSedis: function () {
       this.taxonRelation = this.parent
     },

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/etymology.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/etymology.vue
@@ -9,7 +9,7 @@
     </template>
     <template #body>
       <markdown-editor
-        @blur="updateLastChange"
+        @blur="onBlur"
         class="edit-content"
         v-model="etymology"
         :configs="config"
@@ -45,15 +45,28 @@ export default {
   },
   data() {
     return {
+      etymologyAtFocus: undefined,
       config: {
         status: false,
         spellChecker: false
       }
     }
   },
+  mounted() {
+    this.etymologyAtFocus = this.etymology
+  },
+
   methods: {
     focus() {
+      this.etymologyAtFocus = this.etymology
       this.$refs.etymologyText?.setFocus()
+    },
+
+    onBlur(currentValue) {
+      if (currentValue !== this.etymologyAtFocus) {
+        this.etymologyAtFocus = currentValue
+        this.$store.commit(MutationNames.UpdateLastChange)
+      }
     },
 
     updateLastChange() {

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/etymology.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/etymology.vue
@@ -45,7 +45,7 @@ export default {
   },
   data() {
     return {
-      etymologyAtFocus: undefined,
+      etymologySnapshot: undefined,
       config: {
         status: false,
         spellChecker: false
@@ -53,18 +53,17 @@ export default {
     }
   },
   mounted() {
-    this.etymologyAtFocus = this.etymology
+    this.etymologySnapshot = this.etymology
   },
 
   methods: {
     focus() {
-      this.etymologyAtFocus = this.etymology
       this.$refs.etymologyText?.setFocus()
     },
 
     onBlur(currentValue) {
-      if (currentValue !== this.etymologyAtFocus) {
-        this.etymologyAtFocus = currentValue
+      if (currentValue !== this.etymologySnapshot) {
+        this.etymologySnapshot = currentValue
         this.$store.commit(MutationNames.UpdateLastChange)
       }
     },

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/etymology.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/etymology.vue
@@ -52,6 +52,10 @@ export default {
     }
   },
   methods: {
+    focus() {
+      this.$refs.etymologyText?.setFocus()
+    },
+
     updateLastChange() {
       this.$store.commit(MutationNames.UpdateLastChange)
     }

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/navHeader.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/navHeader.vue
@@ -115,6 +115,10 @@ function getTitle(title) {
 .taxonname {
   font-weight: 300;
 }
+.context-menu a {
+  cursor: pointer;
+}
+
 .unsaved li {
   a:first-child {
     padding-left: 0px;

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/navHeader.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/navHeader.vue
@@ -10,8 +10,7 @@
             <a
               data-turbolinks="false"
               :class="{ active: activePosition == index }"
-              :href="'#' + getTitle(title).toLowerCase().replace(' ', '-')"
-              @click="activePosition = index"
+              @click.prevent="onNavClick(index)"
               >{{ getTitle(title) }}
             </a>
           </li>
@@ -60,6 +59,7 @@ import { RouteNames } from '@/routes/routes'
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
 
+const emit = defineEmits(['section-clicked'])
 const store = useStore()
 const unsavedChanges = computed(() => {
   return (
@@ -75,6 +75,11 @@ const isAutosaveActive = computed(() => store.getters[GetterNames.GetAutosave])
 const parentId = computed(() => parent.value?.id)
 
 const activePosition = ref(0)
+
+function onNavClick(index) {
+  activePosition.value = index
+  emit('section-clicked', index)
+}
 
 function createNew(id) {
   const url = `${RouteNames.NewTaxonName}?parent_id=${id}`

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/navHeader.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/navHeader.vue
@@ -115,6 +115,7 @@ function getTitle(title) {
 .taxonname {
   font-weight: 300;
 }
+
 .context-menu a {
   cursor: pointer;
 }

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/quickTaxonName.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/quickTaxonName.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="horizontal-left-content">
     <VAutocomplete
+      ref="autocomplete"
       url="/taxon_names/autocomplete"
       label="label_html"
       display="label"
@@ -89,6 +90,12 @@ const props = defineProps({
 const emit = defineEmits(['select'])
 
 const store = useStore()
+
+const autocomplete = ref(null)
+
+defineExpose({
+  focus() { autocomplete.value?.setFocus() }
+})
 
 const ranksList = ref([])
 const confirmInput = ref('')

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/relationshipPicker.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/relationshipPicker.vue
@@ -23,6 +23,7 @@
       <div v-if="!taxonRelation">
         <div class="horizontal-left-content">
           <autocomplete
+            ref="taxonSearch"
             url="/taxon_names/autocomplete"
             label="label_html"
             min="2"
@@ -91,6 +92,7 @@
           <div class="separate-top">
             <autocomplete
               v-if="view === 'Advanced'"
+              ref="advancedSearch"
               :array-list="objectLists.allList"
               label="subject_status_tag"
               min="3"
@@ -251,6 +253,14 @@ export default {
     }
   },
   methods: {
+    focus() {
+      if (!this.taxonRelation) {
+        this.$refs.taxonSearch?.setFocus()
+      } else if (this.view === 'Advanced') {
+        this.$refs.advancedSearch?.setFocus()
+      }
+    },
+
     setInsertaeSedis() {
       this.isInsertaeSedis = true
       this.taxonRelation = this.parent

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/type.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/type.vue
@@ -170,10 +170,6 @@ const TAB = {
 
 const quickTaxonName = ref(null)
 
-defineExpose({
-  focus() { quickTaxonName.value?.focus() }
-})
-
 const store = useStore()
 
 const shortcuts = ref([
@@ -370,4 +366,8 @@ function switchComprehensive() {
     '_self'
   )
 }
+
+defineExpose({
+  focus() { quickTaxonName.value?.focus() }
+})
 </script>

--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/type.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/type.vue
@@ -27,6 +27,7 @@
           />
         </div>
         <QuickTaxonName
+          ref="quickTaxonName"
           v-if="
             !showForThisGroup(
               ['SpeciesGroup', 'SpeciesAndInfraspeciesGroup'],
@@ -166,6 +167,12 @@ const TAB = {
   common: 'Common',
   showAll: 'Show all'
 }
+
+const quickTaxonName = ref(null)
+
+defineExpose({
+  focus() { quickTaxonName.value?.focus() }
+})
 
 const store = useStore()
 


### PR DESCRIPTION
@jlpereira Could you take a look when you get a chance? This is more maintenance I guess, but New Taxon Name seems pretty stable and as a user I find these 'put-the-cursor-where-it-needs-to-be-next' touches super nice.
* Focuses the relevant input when a link in the navBar is clicked:
<img width="912" height="131" alt="image" src="https://github.com/user-attachments/assets/1c5776e4-3177-4f5f-ae04-fd29d5c7fe5e" />

* Same when you click on 'Set as current' in Subsequent Combination, or when you click on Author-selection tabs
* I initially added focus-on-pages-input when you click 'Clone from last citation', but now I'm thinking it's maybe possible (and better) to do those all at once across all TW (either by making the citation form a slot or by having the 'clone last' own the citation form ... not sure)?
* "Fix" the etymology section so that it doesn't re-save every time you blur that input, even when you didn't change anything (this was really confusing me for a while with auto-save off because I'd be in that input and alt+s to save, and then later i'd scroll up and click out of etymology and all of a sudden it would say I have unsaved data seemingly "out of nowhere")