### PR TITLE
2141 Find all BAs for Browse OTU task, not just those that have the OTU as direct subject/object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,12 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Fix some tests that intermittently fail in our CI (Continuous Integration) environment, add a script to produce a report of such failures [#4891]
 - Added `otu_id` to DwcOccurrence model [#4767]
 - Improved speed of OTU distribution responses
+- [#2141] On the Browse OTU page, display Biological Associations related to an OTU by:
+  - Biological Association -> subject/object is a Collection Object or Field Occurrence -> the Taxon Determination of the Collection Object or Field Occurrence is the OTU in question
+  - Anatomical Part has origin OTU the OTU in question
 
 [#1856]: https://github.com/SpeciesFileGroup/taxonworks/issues/1856
+[#2141]: https://github.com/SpeciesFileGroup/taxonworks/issues/2141
 [#4643]: https://github.com/SpeciesFileGroup/taxonworks/issues/4643
 [#4661]: https://github.com/SpeciesFileGroup/taxonworks/issues/4661
 [#4716]: https://github.com/SpeciesFileGroup/taxonworks/issues/4716
@@ -110,13 +114,6 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Allow creating multiple authors at a time from the New Source authors matcher [#4791]
 - Freeform digitize: In some cases, the SVG editor does not use the full available space. [#4806]
 - Not all selected character state text being returned to a standard key during standard key construction from interactive key
-- [#2141] On the Browse OTU page, display Biological Associations related to an OTU by:
-  - Biological Association -> subject/object is a Collection Object or Field Occurrence -> the Taxon Determination of the Collection Object or Field Occurrence is the OTU in question
-  - Anatomical Part has origin OTU the OTU in question
-- [#4764] On the Browse OTU page, display Asserted Distributions that are related to the OTU through the Asserted Distribution's object being one of the following types:
-  - a Biological Association of the type described in the previous bullet for #2141
-  - a Biological Association of the type described in the previous bullet that's a member of a Biological Associations Graph
-  - a Depiction, Conveyance, or Observation whose object is that OTU
 
 ### Changed
 
@@ -132,7 +129,6 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Refactor Filter annotations task [#4809]
 
 [#345]: https://github.com/SpeciesFileGroup/taxonpages/issues/345
-[#2141]: https://github.com/SpeciesFileGroup/taxonworks/issues/2141
 [#4271]: https://github.com/SpeciesFileGroup/taxonworks/issues/4271
 [#4423]: https://github.com/SpeciesFileGroup/taxonworks/issues/4423
 [#4683]: https://github.com/SpeciesFileGroup/taxonworks/issues/4683
@@ -140,7 +136,6 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 [#4700]: https://github.com/SpeciesFileGroup/taxonworks/issues/4700
 [#4745]: https://github.com/SpeciesFileGroup/taxonworks/issues/4745
 [#4768]: https://github.com/SpeciesFileGroup/taxonworks/issues/4768
-[#4764]: https://github.com/SpeciesFileGroup/taxonworks/issues/4764
 [#4769]: https://github.com/SpeciesFileGroup/taxonworks/issues/4769
 [#4778]: https://github.com/SpeciesFileGroup/taxonworks/issues/4778
 [#4777]: https://github.com/SpeciesFileGroup/taxonworks/issues/4777

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Allow creating multiple authors at a time from the New Source authors matcher [#4791]
 - Freeform digitize: In some cases, the SVG editor does not use the full available space. [#4806]
 - Not all selected character state text being returned to a standard key during standard key construction from interactive key
+- On the Browse OTU page, display Biological Associations related to an OTU by ([#2141]):
+  - Biological Association -> subject/object is a Collection Object or Field Occurrence -> the Taxon Determination of the Collection Object or Field Occurrence is the OTU in question
+  - Anatomical Part has origin OTU the OTU in question
+- On the Browse OTU page, display Asserted Distributions that are related to the OTU through the Asserted Distribution's object being one of the following types ([#4764]):
+  - a Biological Association of the type described in the previous bullet for #2141
+  - a Biological Association of the type described in the previous bullet that's a member of a Biological Associations Graph
+  - a Depiction, Conveyance, or Observation whose object is that OTU
 
 ### Changed
 
@@ -125,6 +132,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Refactor Filter annotations task [#4809]
 
 [#345]: https://github.com/SpeciesFileGroup/taxonpages/issues/345
+[#2141]: https://github.com/SpeciesFileGroup/taxonworks/issues/2141
 [#4271]: https://github.com/SpeciesFileGroup/taxonworks/issues/4271
 [#4423]: https://github.com/SpeciesFileGroup/taxonworks/issues/4423
 [#4683]: https://github.com/SpeciesFileGroup/taxonworks/issues/4683
@@ -132,6 +140,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 [#4700]: https://github.com/SpeciesFileGroup/taxonworks/issues/4700
 [#4745]: https://github.com/SpeciesFileGroup/taxonworks/issues/4745
 [#4768]: https://github.com/SpeciesFileGroup/taxonworks/issues/4768
+[#4764]: https://github.com/SpeciesFileGroup/taxonworks/issues/4764
 [#4769]: https://github.com/SpeciesFileGroup/taxonworks/issues/4769
 [#4778]: https://github.com/SpeciesFileGroup/taxonworks/issues/4778
 [#4777]: https://github.com/SpeciesFileGroup/taxonworks/issues/4777

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,10 +110,10 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Allow creating multiple authors at a time from the New Source authors matcher [#4791]
 - Freeform digitize: In some cases, the SVG editor does not use the full available space. [#4806]
 - Not all selected character state text being returned to a standard key during standard key construction from interactive key
-- On the Browse OTU page, display Biological Associations related to an OTU by ([#2141]):
+- [#2141] On the Browse OTU page, display Biological Associations related to an OTU by:
   - Biological Association -> subject/object is a Collection Object or Field Occurrence -> the Taxon Determination of the Collection Object or Field Occurrence is the OTU in question
   - Anatomical Part has origin OTU the OTU in question
-- On the Browse OTU page, display Asserted Distributions that are related to the OTU through the Asserted Distribution's object being one of the following types ([#4764]):
+- [#4764] On the Browse OTU page, display Asserted Distributions that are related to the OTU through the Asserted Distribution's object being one of the following types:
   - a Biological Association of the type described in the previous bullet for #2141
   - a Biological Association of the type described in the previous bullet that's a member of a Biological Associations Graph
   - a Depiction, Conveyance, or Observation whose object is that OTU

--- a/app/controllers/biological_associations_controller.rb
+++ b/app/controllers/biological_associations_controller.rb
@@ -18,8 +18,38 @@ class BiologicalAssociationsController < ApplicationController
         @biological_associations = Queries::BiologicalAssociation::Filter.new(params)
           .all
           .where(project_id: sessions_current_project_id)
+          .includes(
+            citations: [:source, { citation_topics: :topic }],
+            biological_relationship: :biological_relationship_types
+          )
+          .preload(:biological_association_subject, :biological_association_object)
           .page(params[:page])
           .per(params[:per])
+          .load
+
+        co_fo_subjects = @biological_associations
+          .filter_map { |ba| ba.biological_association_subject if ['CollectionObject', 'FieldOccurrence'].include?(ba.biological_association_subject_type) }
+        ActiveRecord::Associations::Preloader.new(records: co_fo_subjects, associations: [:taxon_determinations, :identifiers]).call unless co_fo_subjects.empty?
+
+        co_fo_objects = @biological_associations
+          .filter_map { |ba| ba.biological_association_object if ['CollectionObject', 'FieldOccurrence'].include?(ba.biological_association_object_type) }
+        ActiveRecord::Associations::Preloader.new(records: co_fo_objects, associations: [:taxon_determinations, :identifiers]).call unless co_fo_objects.empty?
+
+        otu_subjects = @biological_associations
+          .filter_map { |ba| ba.biological_association_subject if ba.biological_association_subject_type == 'Otu' }
+        ActiveRecord::Associations::Preloader.new(records: otu_subjects, associations: [:taxon_name]).call unless otu_subjects.empty?
+
+        otu_objects = @biological_associations
+          .filter_map { |ba| ba.biological_association_object if ba.biological_association_object_type == 'Otu' }
+        ActiveRecord::Associations::Preloader.new(records: otu_objects, associations: [:taxon_name]).call unless otu_objects.empty?
+
+        ap_subjects = @biological_associations
+          .filter_map { |ba| ba.biological_association_subject if ba.biological_association_subject_type == 'AnatomicalPart' }
+        ActiveRecord::Associations::Preloader.new(records: ap_subjects, associations: [:inbound_origin_relationship]).call unless ap_subjects.empty?
+
+        ap_objects = @biological_associations
+          .filter_map { |ba| ba.biological_association_object if ba.biological_association_object_type == 'AnatomicalPart' }
+        ActiveRecord::Associations::Preloader.new(records: ap_objects, associations: [:inbound_origin_relationship]).call unless ap_objects.empty?
       }
     end
   end

--- a/app/helpers/otus_helper.rb
+++ b/app/helpers/otus_helper.rb
@@ -369,7 +369,7 @@ module OtusHelper
       h['features'].push g
     end
 
-    ba_ids = o.all_biological_associations.map(&:id)
+    ba_ids = ::Queries::BiologicalAssociation::Filter.new(otu_query: { otu_id: [o.id] }).all.pluck(:id)
     unless ba_ids.empty?
       ::AssertedDistribution
         .where(

--- a/app/javascript/vue/tasks/otu/browse/components/biologicalAssociations/BiologicalAssociationRelated.vue
+++ b/app/javascript/vue/tasks/otu/browse/components/biologicalAssociations/BiologicalAssociationRelated.vue
@@ -30,7 +30,7 @@
 <script setup>
 import { BiologicalAssociation } from '@/routes/endpoints'
 import { ref, onBeforeMount, watch } from 'vue'
-import { OTU, COLLECTION_OBJECT } from '@/constants/index.js'
+import { OTU, COLLECTION_OBJECT, FIELD_OCCURRENCE, ANATOMICAL_PART } from '@/constants/index.js'
 import VModal from '@/components/ui/Modal.vue'
 import VBtn from '@/components/ui/VBtn/index.vue'
 import getPagination from '@/helpers/getPagination'
@@ -38,7 +38,9 @@ import VSpinner from '@/components/ui/VSpinner.vue'
 
 const param = {
   [OTU]: 'otu_id',
-  [COLLECTION_OBJECT]: 'collection_object_id'
+  [COLLECTION_OBJECT]: 'collection_object_id',
+  [FIELD_OCCURRENCE]: 'field_occurrence_id',
+  [ANATOMICAL_PART]: 'anatomical_part_id'
 }
 
 const props = defineProps({

--- a/app/javascript/vue/tasks/otu/browse/store/actions/loadBiologicalAssociations.js
+++ b/app/javascript/vue/tasks/otu/browse/store/actions/loadBiologicalAssociations.js
@@ -92,9 +92,9 @@ export async function listAdapter(result) {
   })
 }
 
-export default async ({ state, commit, dispatch }, globalId) => {
+export default async ({ state, commit, dispatch }, otuId) => {
   const { body } = await BiologicalAssociation.all({
-    any_global_id: [globalId],
+    otu_query: { otu_id: [otuId] },
     extend
   })
 

--- a/app/javascript/vue/tasks/otu/browse/store/actions/loadBiologicalAssociations.js
+++ b/app/javascript/vue/tasks/otu/browse/store/actions/loadBiologicalAssociations.js
@@ -94,7 +94,7 @@ export async function listAdapter(result) {
 
 export default async ({ state, commit, dispatch }, otuId) => {
   const { body } = await BiologicalAssociation.all({
-    otu_query: { otu_id: [otuId] },
+    otu_query: { otu_id: otuId },
     extend
   })
 

--- a/app/javascript/vue/tasks/otu/browse/store/actions/loadInformation.js
+++ b/app/javascript/vue/tasks/otu/browse/store/actions/loadInformation.js
@@ -13,7 +13,7 @@ export default async ({ dispatch, commit, state }, otus) => {
 
   async function loadOtuInformation(otu) {
     await Promise.all([
-      dispatch(ActionNames.LoadBiologicalAssociations, otu.global_id),
+      dispatch(ActionNames.LoadBiologicalAssociations, otu.id),
       dispatch(ActionNames.LoadDepictions, otu.id),
       dispatch(ActionNames.LoadConveyances, otu.id),
       dispatch(ActionNames.LoadCommonNames, otu.id)

--- a/app/models/asserted_distribution.rb
+++ b/app/models/asserted_distribution.rb
@@ -186,7 +186,8 @@ class AssertedDistribution < ApplicationRecord
     asserted_distribution_object
   end
 
-  # @return [Array of Integer] OTU ids reachable through the AD's polymorphic object.
+  # @return [Array of Integer] OTU ids reachable through the Asserted
+  #   Distribution's polymorphic object.
   #   Handles all supported asserted_distribution_object_type values.
   #   Returns an empty array when no OTUs are reachable through the object.
   #   Raises if the object type is not explicitly handled — see spec vs. DISTRIBUTION_ASSERTABLE_TYPES.
@@ -201,12 +202,12 @@ class AssertedDistribution < ApplicationRecord
       ids << ba.biological_association_object_id if ba.biological_association_object_type == 'Otu'
       ids.uniq
     when 'BiologicalAssociationsGraph'
-      asserted_distribution_object.biological_associations.flat_map do |ba|
-        ids = []
+      ids = []
+      asserted_distribution_object.biological_associations.each do |ba|
         ids << ba.biological_association_subject_id if ba.biological_association_subject_type == 'Otu'
         ids << ba.biological_association_object_id if ba.biological_association_object_type == 'Otu'
-        ids.uniq
-      end.uniq
+      end
+      ids.uniq
     when 'Conveyance'
       c = asserted_distribution_object
       c.conveyance_object_type == 'Otu' ? [c.conveyance_object_id] : []

--- a/app/models/asserted_distribution.rb
+++ b/app/models/asserted_distribution.rb
@@ -196,18 +196,11 @@ class AssertedDistribution < ApplicationRecord
     when 'Otu'
       [asserted_distribution_object_id]
     when 'BiologicalAssociation'
-      ba = asserted_distribution_object
-      ids = []
-      ids << ba.biological_association_subject_id if ba.biological_association_subject_type == 'Otu'
-      ids << ba.biological_association_object_id if ba.biological_association_object_type == 'Otu'
-      ids.uniq
+      asserted_distribution_object.otu_ids
     when 'BiologicalAssociationsGraph'
-      ids = []
-      asserted_distribution_object.biological_associations.each do |ba|
-        ids << ba.biological_association_subject_id if ba.biological_association_subject_type == 'Otu'
-        ids << ba.biological_association_object_id if ba.biological_association_object_type == 'Otu'
-      end
-      ids.uniq
+      asserted_distribution_object.biological_associations
+        .flat_map(&:otu_ids)
+        .uniq
     when 'Conveyance'
       c = asserted_distribution_object
       c.conveyance_object_type == 'Otu' ? [c.conveyance_object_id] : []

--- a/app/models/asserted_distribution.rb
+++ b/app/models/asserted_distribution.rb
@@ -198,9 +198,7 @@ class AssertedDistribution < ApplicationRecord
     when 'BiologicalAssociation'
       asserted_distribution_object.otu_ids
     when 'BiologicalAssociationsGraph'
-      asserted_distribution_object.biological_associations
-        .flat_map(&:otu_ids)
-        .uniq
+      ::BiologicalAssociation.collect_otu_ids(asserted_distribution_object.biological_associations)
     when 'Conveyance'
       c = asserted_distribution_object
       c.conveyance_object_type == 'Otu' ? [c.conveyance_object_id] : []

--- a/app/models/biological_association.rb
+++ b/app/models/biological_association.rb
@@ -141,6 +141,39 @@ class BiologicalAssociation < ApplicationRecord
     ids.uniq
   end
 
+  # @return [Array of Integer]
+  #   OTU ids reachable across a collection of BiologicalAssociations,
+  #   batching queries by type to avoid N+1.
+  def self.collect_otu_ids(biological_associations)
+    bas = biological_associations.to_a
+    ids = []
+
+    [:subject, :object].each do |role|
+      type_attr = "biological_association_#{role}_type"
+      id_attr   = "biological_association_#{role}_id"
+      by_type   = bas.group_by { |ba| ba.send(type_attr) }
+
+      (by_type['Otu'] || []).each { |ba| ids << ba.send(id_attr) }
+
+      %w[CollectionObject FieldOccurrence].each do |type|
+        next unless (typed_bas = by_type[type])
+        typed_ids = typed_bas.map { |ba| ba.send(id_attr) }
+        ids.concat(
+          ::TaxonDetermination
+            .where(taxon_determination_object_type: type, taxon_determination_object_id: typed_ids, position: 1)
+            .pluck(:otu_id)
+        )
+      end
+
+      if (ap_bas = by_type['AnatomicalPart'])
+        ap_ids = ap_bas.map { |ba| ba.send(id_attr) }
+        ids.concat(::AnatomicalPart.where(id: ap_ids).pluck(:cached_otu_id).compact)
+      end
+    end
+
+    ids.uniq
+  end
+
   class << self
 
     def set_batch_cap(request)

--- a/app/models/biological_association.rb
+++ b/app/models/biological_association.rb
@@ -116,6 +116,31 @@ class BiologicalAssociation < ApplicationRecord
     biological_association_object
   end
 
+  # @return [Array of Integer]
+  #   OTU ids reachable through this BiologicalAssociation's subject and object.
+  #   Handles direct Otu subject/object, CollectionObject and FieldOccurrence
+  #   (via position=1 taxon determination), and AnatomicalPart (via cached_otu_id).
+  def otu_ids
+    ids = []
+    [:subject, :object].each do |role|
+      type = send("biological_association_#{role}_type")
+      id   = send("biological_association_#{role}_id")
+      case type
+      when 'Otu'
+        ids << id
+      when 'CollectionObject', 'FieldOccurrence'
+        otu_id = ::TaxonDetermination
+          .where(taxon_determination_object_type: type, taxon_determination_object_id: id, position: 1)
+          .pick(:otu_id)
+        ids << otu_id if otu_id
+      when 'AnatomicalPart'
+        otu_id = ::AnatomicalPart.where(id:).pick(:cached_otu_id)
+        ids << otu_id if otu_id
+      end
+    end
+    ids.uniq
+  end
+
   class << self
 
     def set_batch_cap(request)

--- a/lib/queries/asserted_distribution/filter.rb
+++ b/lib/queries/asserted_distribution/filter.rb
@@ -392,36 +392,19 @@ module Queries
           asserted_distribution_object_id: otu_id
         )
 
-        # ADs on BiologicalAssociations where the OTU is the subject
+        # ADs on BiologicalAssociations related to the OTU — including through
+        # CollectionObject/FieldOccurrence taxon determinations and AnatomicalParts,
+        # by delegating to the BA filter which already covers all those paths.
+        ba_ids = Queries::BiologicalAssociation::Filter.new(otu_query: { otu_id: otu_id }).all.select(:id)
+
         b = ::AssertedDistribution
           .with_biological_associations
-          .where(biological_associations: {
-            biological_association_subject_type: 'Otu',
-            biological_association_subject_id: otu_id
-          })
-
-        # ADs on BiologicalAssociations where the OTU is the object
-        c = ::AssertedDistribution
-          .with_biological_associations
-          .where(biological_associations: {
-            biological_association_object_type: 'Otu',
-            biological_association_object_id: otu_id
-          })
+          .where(biological_associations: { id: ba_ids })
 
         # BiologicalAssociationsGraph IDs that contain a BA involving the OTU
-        otu_ba_ids = ::BiologicalAssociation.where(
-          biological_association_subject_type: 'Otu',
-          biological_association_subject_id: otu_id
-        ).or(
-          ::BiologicalAssociation.where(
-            biological_association_object_type: 'Otu',
-            biological_association_object_id: otu_id
-          )
-        ).select(:id)
-
         bag_ids = ::BiologicalAssociationsGraph
           .joins(:biological_associations_biological_associations_graphs)
-          .where(biological_associations_biological_associations_graphs: { biological_association_id: otu_ba_ids })
+          .where(biological_associations_biological_associations_graphs: { biological_association_id: ba_ids })
           .select(:id)
 
         # ADs on BiologicalAssociationsGraphs that include a BA involving the OTU
@@ -445,7 +428,7 @@ module Queries
           .with_otu_observations
           .where(observations: { observation_object_id: otu_id })
 
-        referenced_klass_union([a, b, c, d, e, f, g])
+        referenced_klass_union([a, b, d, e, f, g])
       end
 
       def biological_association_id_facet

--- a/lib/tasks/maintenance/cached/maps.rake
+++ b/lib/tasks/maintenance/cached/maps.rake
@@ -656,254 +656,63 @@ namespace :tw do
         #   AnatomicalPart cached_otu_id), BiologicalAssociationsGraph (same BA
         #   cases), Conveyance, Depiction, and Observation.
         def ad_to_otu_map_sql
-          <<~SQL.squish
-            SELECT ad.id AS ad_id, ad.asserted_distribution_object_id AS otu_id
-            FROM asserted_distributions ad
-            WHERE ad.asserted_distribution_object_type = 'Otu'
+          # Given a scope with biological_associations joined as `ba_table`,
+          # returns one query per subject/object combination across all BA object types.
+          ba_otu_queries = ->(base, ba_table) do
+            [
+              base.where("#{ba_table}.biological_association_subject_type = 'Otu'")
+                .select("asserted_distributions.id AS ad_id, #{ba_table}.biological_association_subject_id AS otu_id"),
+              base.where("#{ba_table}.biological_association_object_type = 'Otu'")
+                .select("asserted_distributions.id AS ad_id, #{ba_table}.biological_association_object_id AS otu_id"),
+              *%w[CollectionObject FieldOccurrence].flat_map { |type|
+                [
+                  base.where("#{ba_table}.biological_association_subject_type = '#{type}'")
+                    .joins("JOIN taxon_determinations td ON td.taxon_determination_object_id = #{ba_table}.biological_association_subject_id AND td.taxon_determination_object_type = '#{type}' AND td.position = 1")
+                    .select('asserted_distributions.id AS ad_id, td.otu_id AS otu_id'),
+                  base.where("#{ba_table}.biological_association_object_type = '#{type}'")
+                    .joins("JOIN taxon_determinations td ON td.taxon_determination_object_id = #{ba_table}.biological_association_object_id AND td.taxon_determination_object_type = '#{type}' AND td.position = 1")
+                    .select('asserted_distributions.id AS ad_id, td.otu_id AS otu_id'),
+                ]
+              },
+              base.where("#{ba_table}.biological_association_subject_type = 'AnatomicalPart'")
+                .joins("JOIN anatomical_parts ap ON ap.id = #{ba_table}.biological_association_subject_id")
+                .select('asserted_distributions.id AS ad_id, ap.cached_otu_id AS otu_id'),
+              base.where("#{ba_table}.biological_association_object_type = 'AnatomicalPart'")
+                .joins("JOIN anatomical_parts ap ON ap.id = #{ba_table}.biological_association_object_id")
+                .select('asserted_distributions.id AS ad_id, ap.cached_otu_id AS otu_id'),
+            ]
+          end
 
-            UNION
+          direct = AssertedDistribution
+            .where(asserted_distribution_object_type: 'Otu')
+            .select('asserted_distributions.id AS ad_id, asserted_distributions.asserted_distribution_object_id AS otu_id')
 
-            SELECT ad.id AS ad_id, ba.biological_association_subject_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_subject_type = 'Otu'
+          ba_base = AssertedDistribution
+            .with_biological_associations
 
-            UNION
+          bag_base = AssertedDistribution
+            .with_biological_associations_graphs
+            .joins('JOIN biological_associations_biological_associations_graphs babag ON babag.biological_associations_graph_id = biological_associations_graphs.id')
+            .joins('JOIN biological_associations ba ON ba.id = babag.biological_association_id')
 
-            SELECT ad.id AS ad_id, ba.biological_association_object_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_object_type = 'Otu'
+          conveyance = AssertedDistribution
+            .with_otu_conveyances
+            .select('asserted_distributions.id AS ad_id, conveyances.conveyance_object_id AS otu_id')
 
-            UNION
+          depiction = AssertedDistribution
+            .with_otu_depictions
+            .select('asserted_distributions.id AS ad_id, depictions.depiction_object_id AS otu_id')
 
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_subject_type = 'CollectionObject'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_subject_id
-              AND td.taxon_determination_object_type = 'CollectionObject'
-              AND td.position = 1
+          observation = AssertedDistribution
+            .with_otu_observations
+            .select('asserted_distributions.id AS ad_id, observations.observation_object_id AS otu_id')
 
-            UNION
-
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_object_type = 'CollectionObject'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_object_id
-              AND td.taxon_determination_object_type = 'CollectionObject'
-              AND td.position = 1
-
-            UNION
-
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_subject_type = 'FieldOccurrence'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_subject_id
-              AND td.taxon_determination_object_type = 'FieldOccurrence'
-              AND td.position = 1
-
-            UNION
-
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_object_type = 'FieldOccurrence'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_object_id
-              AND td.taxon_determination_object_type = 'FieldOccurrence'
-              AND td.position = 1
-
-            UNION
-
-            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_subject_type = 'AnatomicalPart'
-            JOIN anatomical_parts ap
-              ON ap.id = ba.biological_association_subject_id
-
-            UNION
-
-            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations ba
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
-              AND ad.asserted_distribution_object_id = ba.id
-              AND ba.biological_association_object_type = 'AnatomicalPart'
-            JOIN anatomical_parts ap
-              ON ap.id = ba.biological_association_object_id
-
-            UNION
-
-            SELECT ad.id AS ad_id, ba.biological_association_subject_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_subject_type = 'Otu'
-
-            UNION
-
-            SELECT ad.id AS ad_id, ba.biological_association_object_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_object_type = 'Otu'
-
-            UNION
-
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_subject_type = 'CollectionObject'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_subject_id
-              AND td.taxon_determination_object_type = 'CollectionObject'
-              AND td.position = 1
-
-            UNION
-
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_object_type = 'CollectionObject'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_object_id
-              AND td.taxon_determination_object_type = 'CollectionObject'
-              AND td.position = 1
-
-            UNION
-
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_subject_type = 'FieldOccurrence'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_subject_id
-              AND td.taxon_determination_object_type = 'FieldOccurrence'
-              AND td.position = 1
-
-            UNION
-
-            SELECT ad.id AS ad_id, td.otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_object_type = 'FieldOccurrence'
-            JOIN taxon_determinations td
-              ON td.taxon_determination_object_id = ba.biological_association_object_id
-              AND td.taxon_determination_object_type = 'FieldOccurrence'
-              AND td.position = 1
-
-            UNION
-
-            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_subject_type = 'AnatomicalPart'
-            JOIN anatomical_parts ap
-              ON ap.id = ba.biological_association_subject_id
-
-            UNION
-
-            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN biological_associations_graphs bag
-              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
-              AND ad.asserted_distribution_object_id = bag.id
-            JOIN biological_associations_biological_associations_graphs babag
-              ON babag.biological_associations_graph_id = bag.id
-            JOIN biological_associations ba
-              ON ba.id = babag.biological_association_id
-              AND ba.biological_association_object_type = 'AnatomicalPart'
-            JOIN anatomical_parts ap
-              ON ap.id = ba.biological_association_object_id
-
-            UNION
-
-            SELECT ad.id AS ad_id, c.conveyance_object_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN conveyances c
-              ON ad.asserted_distribution_object_type = 'Conveyance'
-              AND ad.asserted_distribution_object_id = c.id
-              AND c.conveyance_object_type = 'Otu'
-
-            UNION
-
-            SELECT ad.id AS ad_id, d.depiction_object_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN depictions d
-              ON ad.asserted_distribution_object_type = 'Depiction'
-              AND ad.asserted_distribution_object_id = d.id
-              AND d.depiction_object_type = 'Otu'
-
-            UNION
-
-            SELECT ad.id AS ad_id, obs.observation_object_id AS otu_id
-            FROM asserted_distributions ad
-            JOIN observations obs
-              ON ad.asserted_distribution_object_type = 'Observation'
-              AND ad.asserted_distribution_object_id = obs.id
-              AND obs.observation_object_type = 'Otu'
-          SQL
+          ::Queries.union(AssertedDistribution, [
+            direct,
+            *ba_otu_queries.call(ba_base, 'biological_associations'),
+            *ba_otu_queries.call(bag_base, 'ba'),
+            conveyance, depiction, observation
+          ]).to_sql
         end
 
         def process_asserted_distribution_translation(

--- a/lib/tasks/maintenance/cached/maps.rake
+++ b/lib/tasks/maintenance/cached/maps.rake
@@ -659,6 +659,7 @@ namespace :tw do
           # Given a scope with biological_associations joined as `ba_table`,
           # returns one query per subject/object combination across all BA object types.
           ba_otu_queries = ->(base, ba_table) do
+            raise ArgumentError, "ba_table must be 'biological_associations' or 'ba'" unless %w[biological_associations ba].include?(ba_table)
             [
               base.where("#{ba_table}.biological_association_subject_type = 'Otu'")
                 .select("asserted_distributions.id AS ad_id, #{ba_table}.biological_association_subject_id AS otu_id"),

--- a/lib/tasks/maintenance/cached/maps.rake
+++ b/lib/tasks/maintenance/cached/maps.rake
@@ -651,9 +651,10 @@ namespace :tw do
 
         # @return [String] SQL for a subquery mapping asserted_distribution.id
         #   to otu.id for all supported asserted_distribution_object_type values.
-        #   Covers: Otu (direct), BiologicalAssociation (subject/object),
-        #   BiologicalAssociationsGraph (via BA subject/object), Conveyance,
-        #   Depiction, and Observation.
+        #   Covers: Otu (direct), BiologicalAssociation (subject/object directly,
+        #   via CollectionObject/FieldOccurrence taxon determination, or via
+        #   AnatomicalPart cached_otu_id), BiologicalAssociationsGraph (same BA
+        #   cases), Conveyance, Depiction, and Observation.
         def ad_to_otu_map_sql
           <<~SQL.squish
             SELECT ad.id AS ad_id, ad.asserted_distribution_object_id AS otu_id
@@ -680,6 +681,80 @@ namespace :tw do
 
             UNION
 
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations ba
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
+              AND ad.asserted_distribution_object_id = ba.id
+              AND ba.biological_association_subject_type = 'CollectionObject'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_subject_id
+              AND td.taxon_determination_object_type = 'CollectionObject'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations ba
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
+              AND ad.asserted_distribution_object_id = ba.id
+              AND ba.biological_association_object_type = 'CollectionObject'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_object_id
+              AND td.taxon_determination_object_type = 'CollectionObject'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations ba
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
+              AND ad.asserted_distribution_object_id = ba.id
+              AND ba.biological_association_subject_type = 'FieldOccurrence'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_subject_id
+              AND td.taxon_determination_object_type = 'FieldOccurrence'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations ba
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
+              AND ad.asserted_distribution_object_id = ba.id
+              AND ba.biological_association_object_type = 'FieldOccurrence'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_object_id
+              AND td.taxon_determination_object_type = 'FieldOccurrence'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations ba
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
+              AND ad.asserted_distribution_object_id = ba.id
+              AND ba.biological_association_subject_type = 'AnatomicalPart'
+            JOIN anatomical_parts ap
+              ON ap.id = ba.biological_association_subject_id
+
+            UNION
+
+            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations ba
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociation'
+              AND ad.asserted_distribution_object_id = ba.id
+              AND ba.biological_association_object_type = 'AnatomicalPart'
+            JOIN anatomical_parts ap
+              ON ap.id = ba.biological_association_object_id
+
+            UNION
+
             SELECT ad.id AS ad_id, ba.biological_association_subject_id AS otu_id
             FROM asserted_distributions ad
             JOIN biological_associations_graphs bag
@@ -703,6 +778,104 @@ namespace :tw do
             JOIN biological_associations ba
               ON ba.id = babag.biological_association_id
               AND ba.biological_association_object_type = 'Otu'
+
+            UNION
+
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations_graphs bag
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
+              AND ad.asserted_distribution_object_id = bag.id
+            JOIN biological_associations_biological_associations_graphs babag
+              ON babag.biological_associations_graph_id = bag.id
+            JOIN biological_associations ba
+              ON ba.id = babag.biological_association_id
+              AND ba.biological_association_subject_type = 'CollectionObject'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_subject_id
+              AND td.taxon_determination_object_type = 'CollectionObject'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations_graphs bag
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
+              AND ad.asserted_distribution_object_id = bag.id
+            JOIN biological_associations_biological_associations_graphs babag
+              ON babag.biological_associations_graph_id = bag.id
+            JOIN biological_associations ba
+              ON ba.id = babag.biological_association_id
+              AND ba.biological_association_object_type = 'CollectionObject'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_object_id
+              AND td.taxon_determination_object_type = 'CollectionObject'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations_graphs bag
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
+              AND ad.asserted_distribution_object_id = bag.id
+            JOIN biological_associations_biological_associations_graphs babag
+              ON babag.biological_associations_graph_id = bag.id
+            JOIN biological_associations ba
+              ON ba.id = babag.biological_association_id
+              AND ba.biological_association_subject_type = 'FieldOccurrence'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_subject_id
+              AND td.taxon_determination_object_type = 'FieldOccurrence'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, td.otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations_graphs bag
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
+              AND ad.asserted_distribution_object_id = bag.id
+            JOIN biological_associations_biological_associations_graphs babag
+              ON babag.biological_associations_graph_id = bag.id
+            JOIN biological_associations ba
+              ON ba.id = babag.biological_association_id
+              AND ba.biological_association_object_type = 'FieldOccurrence'
+            JOIN taxon_determinations td
+              ON td.taxon_determination_object_id = ba.biological_association_object_id
+              AND td.taxon_determination_object_type = 'FieldOccurrence'
+              AND td.position = 1
+
+            UNION
+
+            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations_graphs bag
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
+              AND ad.asserted_distribution_object_id = bag.id
+            JOIN biological_associations_biological_associations_graphs babag
+              ON babag.biological_associations_graph_id = bag.id
+            JOIN biological_associations ba
+              ON ba.id = babag.biological_association_id
+              AND ba.biological_association_subject_type = 'AnatomicalPart'
+            JOIN anatomical_parts ap
+              ON ap.id = ba.biological_association_subject_id
+
+            UNION
+
+            SELECT ad.id AS ad_id, ap.cached_otu_id AS otu_id
+            FROM asserted_distributions ad
+            JOIN biological_associations_graphs bag
+              ON ad.asserted_distribution_object_type = 'BiologicalAssociationsGraph'
+              AND ad.asserted_distribution_object_id = bag.id
+            JOIN biological_associations_biological_associations_graphs babag
+              ON babag.biological_associations_graph_id = bag.id
+            JOIN biological_associations ba
+              ON ba.id = babag.biological_association_id
+              AND ba.biological_association_object_type = 'AnatomicalPart'
+            JOIN anatomical_parts ap
+              ON ap.id = ba.biological_association_object_id
 
             UNION
 

--- a/spec/helpers/otus_helper_spec.rb
+++ b/spec/helpers/otus_helper_spec.rb
@@ -318,6 +318,26 @@ describe OtusHelper, type: :helper do
           expect(features.count { |f| f['geometry'].nil? }).to eq(1)
         end
 
+        specify 'BiologicalAssociation AD is included when BA subject is a CO determined as the OTU' do
+          br = FactoryBot.create(:valid_biological_relationship)
+          co = FactoryBot.create(:valid_specimen)
+          FactoryBot.create(:taxon_determination, otu: otu3, taxon_determination_object: co)
+          ba = BiologicalAssociation.create!(
+            biological_association_subject: co,
+            biological_association_object:  otu3,
+            biological_relationship: br,
+            project: otu3.project
+          )
+          FactoryBot.create(:valid_biological_association_asserted_distribution,
+            asserted_distribution_object: ba,
+            asserted_distribution_shape: shared_ga2)
+
+          features = run_with_seen(otu, otu3)
+          expect(features.count).to eq(2)
+          expect(features.count { |f| f['geometry'].present? }).to eq(1)
+          expect(features.count { |f| f['geometry'].nil? }).to eq(1)
+        end
+
         specify 'Observation AD on same shape is deduplicated' do
           descriptor = Descriptor::Continuous.create!(name: 'dedup_test_descriptor', project: otu3.project)
           observation = Observation::Continuous.create!(

--- a/spec/lib/queries/asserted_distribution/filter_spec.rb
+++ b/spec/lib/queries/asserted_distribution/filter_spec.rb
@@ -297,6 +297,32 @@ describe Queries::AssertedDistribution::Filter, type: :model, group: [:geo, :col
     expect(q.all).to contain_exactly(ad1, ad_ba)
   end
 
+  specify '#otu_id includes ADs on BiologicalAssociations where BA subject is a CO determined as the OTU' do
+    ad2 # not this one
+    co = FactoryBot.create(:valid_specimen)
+    FactoryBot.create(:valid_taxon_determination, taxon_determination_object: co, otu: o1)
+    ba = FactoryBot.create(:valid_biological_association, biological_association_subject: co)
+    ad_ba = FactoryBot.create(
+      :valid_biological_association_asserted_distribution,
+      asserted_distribution_object: ba
+    )
+    q = query.new({ otu_id: o1.id })
+    expect(q.all).to contain_exactly(ad_ba)
+  end
+
+  specify '#otu_id includes ADs on BiologicalAssociations where BA object is a CO determined as the OTU' do
+    ad2 # not this one
+    co = FactoryBot.create(:valid_specimen)
+    FactoryBot.create(:valid_taxon_determination, taxon_determination_object: co, otu: o1)
+    ba = FactoryBot.create(:valid_biological_association, biological_association_object: co)
+    ad_ba = FactoryBot.create(
+      :valid_biological_association_asserted_distribution,
+      asserted_distribution_object: ba
+    )
+    q = query.new({ otu_id: o1.id })
+    expect(q.all).to contain_exactly(ad_ba)
+  end
+
   specify '#otu_id includes ADs on BiologicalAssociationsGraphs containing a BA where OTU is subject' do
     ad2 # not this one
     ba = FactoryBot.create(:valid_biological_association, biological_association_subject: o1)

--- a/spec/models/asserted_distribution_spec.rb
+++ b/spec/models/asserted_distribution_spec.rb
@@ -566,6 +566,26 @@ describe AssertedDistribution, type: :model, group: [:geo, :shared_geo] do
       ad = FactoryBot.create(:valid_biological_association_asserted_distribution, asserted_distribution_object: ba)
       expect(ad.object_otu_ids).to include(otu.id)
     end
+
+    specify 'BiologicalAssociationsGraph with CO-subject BA returns OTU id via taxon determination' do
+      br = FactoryBot.create(:valid_biological_relationship)
+      otu = FactoryBot.create(:valid_otu)
+      co = FactoryBot.create(:valid_specimen)
+      FactoryBot.create(:taxon_determination, otu:, taxon_determination_object: co)
+      ba = BiologicalAssociation.create!(
+        biological_association_subject: co,
+        biological_association_object: otu,
+        biological_relationship: br,
+        project: otu.project
+      )
+      bag = FactoryBot.create(:valid_biological_associations_graph)
+      FactoryBot.create(:valid_biological_associations_biological_associations_graph,
+        biological_associations_graph: bag,
+        biological_association: ba
+      )
+      ad = FactoryBot.create(:valid_biological_associations_graph_asserted_distribution, asserted_distribution_object: bag)
+      expect(ad.object_otu_ids).to include(otu.id)
+    end
   end
 
   context '#stub_new' do

--- a/spec/models/asserted_distribution_spec.rb
+++ b/spec/models/asserted_distribution_spec.rb
@@ -551,6 +551,21 @@ describe AssertedDistribution, type: :model, group: [:geo, :shared_geo] do
         expect { ad.object_otu_ids }.not_to raise_error, "#{ad.asserted_distribution_object_type} is not handled in #object_otu_ids"
       end
     end
+
+    specify 'BiologicalAssociation with CO subject returns OTU id via taxon determination' do
+      br  = FactoryBot.create(:valid_biological_relationship)
+      otu = FactoryBot.create(:valid_otu)
+      co  = FactoryBot.create(:valid_specimen)
+      FactoryBot.create(:taxon_determination, otu:, taxon_determination_object: co)
+      ba  = BiologicalAssociation.create!(
+        biological_association_subject: co,
+        biological_association_object:  otu,
+        biological_relationship: br,
+        project: otu.project
+      )
+      ad = FactoryBot.create(:valid_biological_association_asserted_distribution, asserted_distribution_object: ba)
+      expect(ad.object_otu_ids).to include(otu.id)
+    end
   end
 
   context '#stub_new' do

--- a/spec/models/biological_association_spec.rb
+++ b/spec/models/biological_association_spec.rb
@@ -196,6 +196,46 @@ describe BiologicalAssociation, type: :model do
     }.to raise_error(TaxonWorks::Error, /project_id.*not set in query_batch_update/)
   end
 
+  context '#otu_ids' do
+    let(:br) { FactoryBot.create(:valid_biological_relationship) }
+
+    def make_ba(subject:, object:)
+      BiologicalAssociation.create!(
+        biological_association_subject: subject,
+        biological_association_object: object,
+        biological_relationship: br,
+        project: otu.project
+      )
+    end
+
+    specify 'direct OTU subject and object' do
+      otu2 = FactoryBot.create(:valid_otu)
+      ba = make_ba(subject: otu, object: otu2)
+      expect(ba.otu_ids).to contain_exactly(otu.id, otu2.id)
+    end
+
+    specify 'CollectionObject subject with taxon determination' do
+      co = FactoryBot.create(:valid_specimen)
+      FactoryBot.create(:taxon_determination, otu:, taxon_determination_object: co)
+      ba = make_ba(subject: co, object: otu)
+      expect(ba.otu_ids).to contain_exactly(otu.id)
+    end
+
+    specify 'FieldOccurrence subject with taxon determination' do
+      fo = FactoryBot.create(:valid_field_occurrence)
+      FactoryBot.create(:taxon_determination, otu:, taxon_determination_object: fo)
+      ba = make_ba(subject: fo, object: otu)
+      expect(ba.otu_ids).to contain_exactly(otu.id)
+    end
+
+    specify 'CollectionObject with no taxon determination returns no otu_id for that role' do
+      co = FactoryBot.create(:valid_specimen)
+      otu2 = FactoryBot.create(:valid_otu)
+      ba = make_ba(subject: co, object: otu2)
+      expect(ba.otu_ids).to contain_exactly(otu2.id)
+    end
+  end
+
   context 'concerns' do
     it_behaves_like 'citations'
     it_behaves_like 'is_data'

--- a/spec/models/biological_association_spec.rb
+++ b/spec/models/biological_association_spec.rb
@@ -234,6 +234,13 @@ describe BiologicalAssociation, type: :model do
       ba = make_ba(subject: co, object: otu2)
       expect(ba.otu_ids).to contain_exactly(otu2.id)
     end
+
+    specify 'AnatomicalPart subject returns otu_id via cached_otu_id' do
+      otu2 = FactoryBot.create(:valid_otu)
+      ap = FactoryBot.create(:valid_anatomical_part, taxon_determination_otu: otu2)
+      ba = make_ba(subject: ap, object: otu)
+      expect(ba.otu_ids).to contain_exactly(otu.id, otu2.id)
+    end
   end
 
   context 'concerns' do


### PR DESCRIPTION
* Now computes BAs for an OTU by finding:
  * otu as subject/object of a BA
  * otu as preferred (first) TD of a CO or FO that's a subject or object of a BA
  * otu as 'origin otu' of an Anatomical Part
* Cached maps now accounts for ADs on all such BAs for an otu
* Fixed n+1 issues for BA display in Browse OTU