### PR TITLE
4819 isbn parse error

### DIFF
--- a/app/models/identifier/global/isbn.rb
+++ b/app/models/identifier/global/isbn.rb
@@ -10,10 +10,16 @@
 #   Registration group element – this identifies the particular country, geographical region, or language area
 #     participating in the ISBN system. This element may be between 1 and 5 digits in length.
 #   Registrant element - this identifies the particular publisher or imprint. This may be up to 7 digits in length.
-#   Publication element – this identifies the particular edition and format of a specific title. This may be up to 6
-#     digits in length
+#   Publication element – this identifies the particular edition and format of a specific title. This may be up to 7
+#     digits in length.
 #   Check digit – this is always the final single digit that mathematically validates the rest of the number.
 #     It is calculated using a Modulus 10 system with alternate weights of 1 and 3.
+#
+# The 7-digit maximum for registrant and publication elements is confirmed by the official ISBN range data.
+# The range file format is documented at https://www.isbn-international.org/range_file_generation, which
+# specifies that registrant element ranges are "padded to maximum 7 digits". The range data itself
+# (https://www.isbn-international.org/export_rangemessage.xml) contains Length values up to 7 for
+# registrant elements, e.g. within the 978-2 (French) group (checked 2026-04-25).
 #
 # All of this means that it is difficult to validate an ISBN.
 #
@@ -40,10 +46,13 @@ class Identifier::Global::Isbn < Identifier::Global
       isbn.strip!
       # '978-0-596-52068-7' or '978 0 596 52068 7'
       # if there are spaces or hyphens, check to see that they are in the right places
-      /^(\d{3}[ -]{0,1}){0,1}\d{1,5}[ -]{0,1}\d{1,5}[ -]{0,1}\d{1,5}[ -]{0,1}(?<last>.)$/ =~ isbn
+      /^(\d{3}[ -]{0,1}){0,1}\d{1,5}[ -]{0,1}\d{1,7}[ -]{0,1}\d{1,7}[ -]{0,1}(?<last>.)$/ =~ isbn
 
       isbn.gsub!(' ', '')
       isbn.gsub!('-', '')
+      # Registrant/publication elements can exceed the regex limits for some valid ISBNs;
+      # always derive last from the stripped isbn as the authoritative check digit.
+      last = isbn[-1]
       # if there are *any* non-digits left, it is improperly formed
       # NB! 'X' is a valid digit in this case
       /[^\dX]/ =~ isbn

--- a/app/models/identifier/global/isbn.rb
+++ b/app/models/identifier/global/isbn.rb
@@ -45,13 +45,14 @@ class Identifier::Global::Isbn < Identifier::Global
       # ' 978-0-596-52068-7'
       isbn.strip!
       # '978-0-596-52068-7' or '978 0 596 52068 7'
-      # if there are spaces or hyphens, check to see that they are in the right places
-      /^(\d{3}[ -]{0,1}){0,1}\d{1,5}[ -]{0,1}\d{1,7}[ -]{0,1}\d{1,7}[ -]{0,1}(?<last>.)$/ =~ isbn
+      # for hyphenated/spaced input, reject if element lengths exceed spec bounds
+      if isbn.match?(/[ -]/) && /^(\d{3}[ -]{0,1}){0,1}\d{1,5}[ -]{0,1}\d{1,7}[ -]{0,1}\d{1,7}[ -]{0,1}.$/ !~ isbn
+        errors.add(:identifier, "'#{identifier}' is an improperly formed ISBN.")
+        return
+      end
 
       isbn.gsub!(' ', '')
       isbn.gsub!('-', '')
-      # Registrant/publication elements can exceed the regex limits for some valid ISBNs;
-      # always derive last from the stripped isbn as the authoritative check digit.
       last = isbn[-1]
       # if there are *any* non-digits left, it is improperly formed
       # NB! 'X' is a valid digit in this case

--- a/spec/models/identifier/global/isbn_spec.rb
+++ b/spec/models/identifier/global/isbn_spec.rb
@@ -104,6 +104,32 @@ describe Identifier::Global::Isbn, type: :model, group: :identifiers do
         id.identifier = '0-2015-3082-1'
         expect(id.valid?).to be_truthy
       end
+
+      # ISBN-10 with 6-digit registrant element (valid per ISBN spec; up to 7 digits allowed).
+      # Regression for https://github.com/SpeciesFileGroup/taxonworks/issues/4819.
+      specify '2-903052-10-7' do
+        id.identifier = '2-903052-10-7'
+        expect(id.valid?).to be_truthy
+      end
+
+      # ISBN-10 with 7-digit registrant element (upper boundary of the spec)
+      specify '0-1234567-8-9' do
+        id.identifier = '0-1234567-8-9'
+        expect(id.valid?).to be_truthy
+      end
+
+      # ISBN-13 with 7-digit registrant element
+      specify '978-0-1234567-8-6' do
+        id.identifier = '978-0-1234567-8-6'
+        expect(id.valid?).to be_truthy
+      end
+
+      # Bad check digit on an ISBN with a long registrant element
+      specify '2-903052-10-8 has bad check digit' do
+        id.identifier = '2-903052-10-8'
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("'2-903052-10-8' has bad check digit.")
+      end
     end
   end
 end

--- a/spec/models/identifier/global/isbn_spec.rb
+++ b/spec/models/identifier/global/isbn_spec.rb
@@ -124,6 +124,20 @@ describe Identifier::Global::Isbn, type: :model, group: :identifiers do
         expect(id.valid?).to be_truthy
       end
 
+      # 8-digit registrant element exceeds the 7-digit spec maximum
+      specify '0-12345678-1-2 has 8-digit registrant element' do
+        id.identifier = '0-12345678-1-2'
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("'0-12345678-1-2' is an improperly formed ISBN.")
+      end
+
+      # 8-digit publication element exceeds the 7-digit spec maximum
+      specify '0-1-12345678-2 has 8-digit publication element' do
+        id.identifier = '0-1-12345678-2'
+        expect(id.valid?).to be_falsey
+        expect(id.errors.messages[:identifier][0]).to eq("'0-1-12345678-2' is an improperly formed ISBN.")
+      end
+
       # Bad check digit on an ISBN with a long registrant element
       specify '2-903052-10-8 has bad check digit' do
         id.identifier = '2-903052-10-8'


### PR DESCRIPTION
* Update length maxima for registrant and publication (likely were lower or not functionally in use the last this code was changed over a decade ago)
* if the isbn includes spaces and/or dashes, verify that it actually matches the expected RE
* verified that all of the ISBNs that Josh posted that used to fail now pass (I checked two of them by hand for correct check digit, Josh also ran them all through a website checker)