### PR TITLE
When creating a bibtex source, if the bibtex serial issn matches a db serial, use it #4701

### DIFF
--- a/app/models/source/bibtex.rb
+++ b/app/models/source/bibtex.rb
@@ -689,11 +689,10 @@ class Source::Bibtex < Source
       s = Serial.where(name: journal).first
       i = Identifier::Global::Issn.where(identifier: value, identifier_object_type: 'Serial').first
 
-      # Found an Existing Serial identically named with an assigned Identical ISSN
-      if !s.nil? && (s == i&.identifier_object)
-        self[:serial_id] = s.id
-      elsif i && s.nil? # Found a Serial with an Identifier, but not identically named, assign it anyway
+      if i # ISSN match takes priority
         self[:serial_id] = i.identifier_object_id
+      elsif s # Fall back to name-only match
+        self[:serial_id] = s.id
       end
     end
   end

--- a/spec/models/source/bibtex_spec.rb
+++ b/spec/models/source/bibtex_spec.rb
@@ -180,6 +180,25 @@ describe Source::Bibtex, type: :model, group: :sources do
     expect(src.serial_id).to eq(s.id)
   end
 
+  specify '.new_from_bibtex with ISSN and name matching different Serials links to ISSN-matched Serial' do
+    issn = '1540-7063'
+    citation_string = %q{@Article{Someone2021,
+        author = {Someone},
+        title = {A paper},
+        journal = {Integrative and Comparative Biology},
+        year = {2021},
+        issn = {1540-7063},
+        }}
+
+    name_serial = FactoryBot.create(:valid_serial, name: 'Integrative and Comparative Biology')
+    issn_serial = FactoryBot.create(:valid_serial, name: 'Integrative & Comparative Biology',
+      identifiers_attributes: [{ type: 'Identifier::Global::Issn', identifier: issn }])
+
+    src = Source::Bibtex.new_from_bibtex_text(citation_string)
+    src.save!
+    expect(src.serial_id).to eq(issn_serial.id)
+  end
+
   specify '.new_from_bibtex without create project source' do
     citation_string =  %q{@Article{Park2021a,
         author = {Kyu-Tek Park AND J. B. Heppner},


### PR DESCRIPTION
Do so even if the serial title doesn't match - issn is a GUID, and there are many subtle title differences in TW serial titles entered by humans.

The scenario that used to cause mysterious batch import source errors was:
```
 1. Incoming BibTeX has journal title "X" and ISSN "123"
 2. DB has a Serial named "X" (name match, `s`) — but with no ISSN, or a different ISSN
 3. DB has a different Serial with ISSN "123" (identifier `i`) — but a different name

The old code required both conditions — s exists AND s == i.identifier_object — to set serial_id on the new source. With those two different serials in the DB, that equality check fails, serial_id stays blank, and the fallback tries to build a new Serial "X" with ISSN "123"... which already belongs to the other serial and so raises an error.
```

Now we assign the serial from 3 because its UUID issn matches the incoming serial's UUID issn (even though it doesn't match on serial title).