### PR TITLE
Dropzone paste files with ctrl+v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - `type_taxon_name_relationship` support to the extend[] parameter in `inventory/summary.json`
 - Quick Forms: Pagination to Biological associations slice
 - CSD: Added a button to load the associated CO when the identifier is already in use by another CO
+- Ctrl+v to paste images and documents in "Drop [image/doc] here"
 
 ### Changed
 

--- a/app/javascript/vue/components/dropzone.vue
+++ b/app/javascript/vue/components/dropzone.vue
@@ -16,8 +16,8 @@ import {
   useTemplateRef,
   watch
 } from 'vue'
-
 import { isJSON } from '@/helpers/objects'
+import { useDropzonePasteManager } from '@/composables/useDropzonePasteManager'
 
 const props = defineProps({
   url: {
@@ -59,10 +59,6 @@ const props = defineProps({
     type: Boolean,
     default: true
   },
-  paste: {
-    type: Boolean,
-    default: true
-  },
   useFontAwesome: {
     type: Boolean,
     default: false
@@ -101,6 +97,10 @@ const props = defineProps({
   },
   dropzoneOptions: {
     type: Object
+  },
+  prioritizePaste: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -116,30 +116,23 @@ const emit = defineEmits([
   'vdropzone-queue-complete'
 ])
 
+const { registerPaster, unregisterPaster } = useDropzonePasteManager()
+
 const dropzoneRef = useTemplateRef('dropzoneRef')
 let dropzone = null
-
-const NON_TEXT_INPUT_TYPES = new Set([
-  'button', 'checkbox', 'color', 'file',
-  'hidden', 'image', 'radio', 'range', 'reset', 'submit'
-])
-
-function isTextEditable(el) {
-  if (!el) return false
-  if (el.isContentEditable) return true
-  if (el.tagName === 'TEXTAREA') return true
-  if (el.tagName === 'INPUT') return !NON_TEXT_INPUT_TYPES.has(el.type)
-  return false
-}
+let pasteZone = null
 
 function onPaste(e) {
-  if (isTextEditable(document.activeElement)) return
   const items = e.clipboardData?.items
   if (!items) return
+
   for (const item of items) {
-    if (item.kind === 'file') {
-      dropzone.addFile(item.getAsFile())
-    }
+    if (item.kind !== 'file' || !item.type) continue
+
+    const file = item.getAsFile()
+    if (!file || !(file instanceof File)) continue
+
+    dropzone.addFile(file)
   }
 }
 
@@ -216,11 +209,6 @@ onMounted(() => {
     emit('vdropzone-file-added', file)
   })
 
-  // Each mounted instance with paste=true registers its own document listener, so a
-  // paste event fires all of them. Callers must ensure at most one paste-enabled
-  // dropzone is mounted at a time to avoid the same file being added to multiple instances.
-  if (props.paste) document.addEventListener('paste', onPaste)
-
   dropzone.on('error', function (file, error, xhr) {
     const errorElements = dropzoneRef.value.querySelectorAll(
       '.dz-error-message span'
@@ -233,6 +221,16 @@ onMounted(() => {
       : error
     emit('vdropzone-error', file, error, xhr)
   })
+
+  pasteZone = {
+    handler: (e) => {
+      if (!dropzone) return
+      onPaste(e)
+    },
+    prioritize: props.prioritizePaste
+  }
+
+  registerPaster(pasteZone)
 })
 
 function makeRemoveButton(file) {
@@ -294,7 +292,7 @@ watch(
 )
 
 onBeforeUnmount(() => {
-  if (props.paste) document.removeEventListener('paste', onPaste)
+  unregisterPaster(pasteZone)
   dropzone.destroy()
 })
 </script>

--- a/app/javascript/vue/components/dropzone.vue
+++ b/app/javascript/vue/components/dropzone.vue
@@ -115,6 +115,30 @@ const emit = defineEmits([
 const dropzoneRef = useTemplateRef('dropzoneRef')
 let dropzone = null
 
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button', 'checkbox', 'color', 'file',
+  'hidden', 'image', 'radio', 'range', 'reset', 'submit'
+])
+
+function isTextEditable(el) {
+  if (!el) return false
+  if (el.isContentEditable) return true
+  if (el.tagName === 'TEXTAREA') return true
+  if (el.tagName === 'INPUT') return !NON_TEXT_INPUT_TYPES.has(el.type)
+  return false
+}
+
+function onPaste(e) {
+  if (isTextEditable(document.activeElement)) return
+  const items = e.clipboardData?.items
+  if (!items) return
+  for (const item of items) {
+    if (item.kind === 'file') {
+      dropzone.addFile(item.getAsFile())
+    }
+  }
+}
+
 const defaultConfiguration = computed(() => ({
   maxFilesize: props.maxFileSizeInMB,
   timeout: props.timeout
@@ -187,6 +211,8 @@ onMounted(() => {
 
     emit('vdropzone-file-added', file)
   })
+
+  document.addEventListener('paste', onPaste)
 
   dropzone.on('error', function (file, error, xhr) {
     const errorElements = dropzoneRef.value.querySelectorAll(
@@ -261,6 +287,7 @@ watch(
 )
 
 onBeforeUnmount(() => {
+  document.removeEventListener('paste', onPaste)
   dropzone.destroy()
 })
 </script>

--- a/app/javascript/vue/components/dropzone.vue
+++ b/app/javascript/vue/components/dropzone.vue
@@ -59,6 +59,10 @@ const props = defineProps({
     type: Boolean,
     default: true
   },
+  paste: {
+    type: Boolean,
+    default: true
+  },
   useFontAwesome: {
     type: Boolean,
     default: false
@@ -212,7 +216,10 @@ onMounted(() => {
     emit('vdropzone-file-added', file)
   })
 
-  document.addEventListener('paste', onPaste)
+  // Each mounted instance with paste=true registers its own document listener, so a
+  // paste event fires all of them. Callers must ensure at most one paste-enabled
+  // dropzone is mounted at a time to avoid the same file being added to multiple instances.
+  if (props.paste) document.addEventListener('paste', onPaste)
 
   dropzone.on('error', function (file, error, xhr) {
     const errorElements = dropzoneRef.value.querySelectorAll(
@@ -287,7 +294,7 @@ watch(
 )
 
 onBeforeUnmount(() => {
-  document.removeEventListener('paste', onPaste)
+  if (props.paste) document.removeEventListener('paste', onPaste)
   dropzone.destroy()
 })
 </script>

--- a/app/javascript/vue/components/radials/annotator/components/conveyances/ConveyanceUpload.vue
+++ b/app/javascript/vue/components/radials/annotator/components/conveyances/ConveyanceUpload.vue
@@ -8,6 +8,7 @@
       url="/sounds"
       use-custom-dropzone-options
       :dropzone-options="DROPZONE_CONFIG"
+      prioritize-paste
     />
   </div>
 </template>

--- a/app/javascript/vue/components/radials/annotator/components/depictions/depiction_annotator.vue
+++ b/app/javascript/vue/components/radials/annotator/components/depictions/depiction_annotator.vue
@@ -76,6 +76,7 @@
             url="/depictions"
             :use-custom-dropzone-options="true"
             :dropzone-options="DROPZONE_CONFIG"
+            prioritize-paste
           />
         </template>
         <template #filter>

--- a/app/javascript/vue/components/radials/annotator/components/documentation_annotator.vue
+++ b/app/javascript/vue/components/radials/annotator/components/documentation_annotator.vue
@@ -28,6 +28,7 @@
         :dropzone-options="DROPZONE_CONFIGURATION"
         @vdropzone-sending="sending"
         @vdropzone-success="success"
+        prioritize-paste
       />
     </div>
 

--- a/app/javascript/vue/composables/useDropzonePasteManager.js
+++ b/app/javascript/vue/composables/useDropzonePasteManager.js
@@ -1,0 +1,71 @@
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button', 'checkbox', 'color', 'file',
+  'hidden', 'image', 'radio', 'range', 'reset', 'submit'
+])
+
+function isTextEditable(el) {
+  if (!el) return false
+  if (el.isContentEditable) return true
+  if (el.tagName === 'TEXTAREA') return true
+  if (el.tagName === 'SELECT') return true
+  if (el.tagName === 'INPUT') return !NON_TEXT_INPUT_TYPES.has(el.type)
+  return false
+}
+
+// At module scope, shared by all users of this composable.
+const state = {
+  zones: new Set(), // { handler, prioritize }
+  initialized: false
+}
+
+function resolveActiveZone() {
+  const zones = Array.from(state.zones)
+
+  if (zones.length === 1) return zones[0]
+
+  const prioritized = zones.filter(z => z.prioritize)
+
+  if (prioritized.length === 1) return prioritized[0]
+
+  // none or multiple prioritized → disable
+  return null
+}
+
+function onPaste(e) {
+  if (isTextEditable(document.activeElement)) return
+
+  const active = resolveActiveZone()
+  if (!active) return
+
+  active.handler(e)
+}
+
+function init() {
+  if (state.initialized) return
+  document.addEventListener('paste', onPaste)
+  state.initialized = true
+}
+
+function cleanupIfEmpty() {
+  if (state.zones.size === 0 && state.initialized) {
+    document.removeEventListener('paste', onPaste)
+    state.initialized = false
+  }
+}
+
+export function useDropzonePasteManager() {
+  function registerPaster(zone) {
+    init()
+    state.zones.add(zone)
+  }
+
+  function unregisterPaster(zone) {
+    state.zones.delete(zone)
+    cleanupIfEmpty()
+  }
+
+  return {
+    registerPaster,
+    unregisterPaster
+  }
+}

--- a/app/javascript/vue/tasks/digitize/components/shared/depictions.vue
+++ b/app/javascript/vue/tasks/digitize/components/shared/depictions.vue
@@ -13,6 +13,7 @@
       url="/depictions"
       use-custom-dropzone-options
       :dropzone-options="dropzoneConfig"
+      prioritize-paste
     />
 
     <VPagination

--- a/app/javascript/vue/tasks/images/new_image/components/Panel/PanelCopyrightHolder.vue
+++ b/app/javascript/vue/tasks/images/new_image/components/Panel/PanelCopyrightHolder.vue
@@ -15,6 +15,7 @@
           v-model="rolesAttributes"
           :role-type="ROLE_ATTRIBUTION_COPYRIGHT_HOLDER"
           :organization="view === OPTIONS.Organization"
+          :autofocus="false"
         />
       </div>
       <div class="field label-above">

--- a/app/javascript/vue/tasks/images/new_image/components/PeopleSelector.vue
+++ b/app/javascript/vue/tasks/images/new_image/components/PeopleSelector.vue
@@ -16,6 +16,7 @@
           v-model="rolesAttributes"
           :role-type="roleType"
           :organization="view === OPTIONS.Organization"
+          :autofocus="false"
         />
       </div>
     </template>

--- a/app/javascript/vue/tasks/images/new_image/components/publishedSection.vue
+++ b/app/javascript/vue/tasks/images/new_image/components/publishedSection.vue
@@ -5,7 +5,7 @@
       :options="options"
       v-model="view"
     />
-    <role-picker v-model="roles_attributes" />
+    <role-picker v-model="roles_attributes" :autofocus="false" />
   </div>
 </template>
 

--- a/app/javascript/vue/tasks/observation_matrices/image/components/CellObservation.vue
+++ b/app/javascript/vue/tasks/observation_matrices/image/components/CellObservation.vue
@@ -10,7 +10,6 @@
       ref="dropzoneElement"
       url="/observations"
       use-custom-dropzone-options
-      :paste="false"
       @vdropzone-sending="sending"
       @vdropzone-success="success"
       @vdropzone-error="error"

--- a/app/javascript/vue/tasks/observation_matrices/image/components/CellObservation.vue
+++ b/app/javascript/vue/tasks/observation_matrices/image/components/CellObservation.vue
@@ -10,6 +10,7 @@
       ref="dropzoneElement"
       url="/observations"
       use-custom-dropzone-options
+      :paste="false"
       @vdropzone-sending="sending"
       @vdropzone-success="success"
       @vdropzone-error="error"


### PR DESCRIPTION
Ai code.

Motivation: pasting image into depiction annotator slice or New Image, pasting pdf into documentation annotator slice or New Source.

The paste listener is on `document` (since we don't really have a way to focus our dropzone input without triggering the file dialog (?)) - as long as no "text" input is active on paste, Dropzone will check to see if the paste is a file and add it if so.

!! That means every dropzone on a page catches a paste !!, so we turned off dropzone-paste on the image matrix observations builder (the only case we know of with multiple dropzones on the same page).

Seems to work well on Chrome and for single-file pastes on Firefox (but firefox has a 13 year old bug for multiple pastes :( https://bugzilla.mozilla.org/show_bug.cgi?id=864052).

Dropzone seems to intentionally disable this functionality: 
https://github.com/dropzone/dropzone/blob/f50d1828ab5df79a76be00d1306cc320e39a27f4/src/dropzone.js#L372

(because of the firefox bug??)

@jlpereira (@mjy) any thoughts on this?