### PR TITLE
Try to make unintended creates in Name Matcher less likely

### DIFF
--- a/app/javascript/vue/tasks/sources/new_source/components/bibtex/AuthorMatchModal.vue
+++ b/app/javascript/vue/tasks/sources/new_source/components/bibtex/AuthorMatchModal.vue
@@ -22,7 +22,7 @@
           <tr>
             <th>Author String</th>
             <th>Matches</th>
-            <th>Select(ed)</th>
+            <th>Create a new person</th>
           </tr>
         </thead>
         <tbody>
@@ -138,7 +138,7 @@
                 <VBtn
                   color="create"
                   medium
-                  :disabled="!row.newPersonForm.last_name"
+                  :disabled="!row.newPersonForm.last_name || !!row.selectedPersonId"
                   @click="createPerson(row)"
                 >
                   Create

--- a/app/javascript/vue/tasks/sources/new_source/components/bibtex/AuthorMatchModal.vue
+++ b/app/javascript/vue/tasks/sources/new_source/components/bibtex/AuthorMatchModal.vue
@@ -21,7 +21,7 @@
         <thead>
           <tr>
             <th>Author String</th>
-            <th>Matches</th>
+            <th>Selected match</th>
             <th>Create a new person</th>
           </tr>
         </thead>
@@ -45,9 +45,20 @@
                 <span class="no-matches">No matches found</span>
               </div>
               <div
-                v-else-if="!row.alreadyExists"
+                v-else-if="!row.alreadyExists && !row.createdPerson"
                 class="matches-list"
               >
+                <div class="match-option">
+                  <label>
+                    <input
+                      type="radio"
+                      :name="`author-match-${index}`"
+                      :value="null"
+                      v-model="row.selectedPersonId"
+                    />
+                    <span>none</span>
+                  </label>
+                </div>
                 <div
                   v-for="person in row.matches"
                   :key="person.id"


### PR DESCRIPTION
Theories:
* people radio-select a name but nothing happens immediately, so they click Create on the same name from the third column
* people see `Select(ed)` in the third column title and think 'this is how I select a name'

Not sure either of these are really the case...

@jlpereira what do you think? This does mean (as written) that once you radio select in a row, you can't change your mind and Create instead (you'd have to quit the modal and reopen).