### PR TITLE
3178 sqed automate breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - New Source can fail to update a serial when the serial being updated to has no issn [#4921]
 - In New Source, an issn value never overrides the serial selected by the user
 - Filter CO: Biological associations facet doesn't work with the `without` option [#4926]
+ Sqed images are automatically processed when created [#3178]
 
 [#4921]: https://github.com/SpeciesFileGroup/taxonworks/issues/4921
 [#2325]: https://github.com/SpeciesFileGroup/taxonworks/issues/2325
+[#3178]: https://github.com/SpeciesFileGroup/taxonworks/issues/3178
 [#4926]: https://github.com/SpeciesFileGroup/taxonworks/issues/4926
 
 ## [0.62.0] - 2026-05-08

--- a/app/controllers/tasks/accessions/breakdown/sqed_depiction_controller.rb
+++ b/app/controllers/tasks/accessions/breakdown/sqed_depiction_controller.rb
@@ -81,8 +81,6 @@ class Tasks::Accessions::Breakdown::SqedDepictionController < ApplicationControl
   def set_sqed_depiction
     @sqed_depiction = SqedDepiction.where(project_id: sessions_current_project_id).find(params[:id])
     @sqed_depiction.update_column(:in_progress, Time.now)
-    # TODO: Run jobs in background with admin task.
-    # @sqed_depiction.preprocess
   end
 
 end

--- a/app/jobs/sqed_depiction_preprocess_job.rb
+++ b/app/jobs/sqed_depiction_preprocess_job.rb
@@ -1,0 +1,8 @@
+class SqedDepictionPreprocessJob < ApplicationJob
+  queue_as :sqed_preprocess
+
+  def perform(sqed_depiction_id:)
+    sqed_depiction = SqedDepiction.find_by(id: sqed_depiction_id)
+    sqed_depiction&.preprocess(false)
+  end
+end

--- a/app/models/sqed_depiction.rb
+++ b/app/models/sqed_depiction.rb
@@ -64,6 +64,7 @@ class SqedDepiction < ApplicationRecord
   end
 
   after_save :recalculate, if: -> { rebuild }
+  after_create_commit :enqueue_preprocess
 
   def self.is_containable?
     false
@@ -75,6 +76,10 @@ class SqedDepiction < ApplicationRecord
 
   def recalculate
     preprocess(true)
+  end
+
+  def enqueue_preprocess
+    SqedDepictionPreprocessJob.perform_later(sqed_depiction_id: id)
   end
 
   def extraction_metadata

--- a/config/interface/object_radials.yml
+++ b/config/interface/object_radials.yml
@@ -164,6 +164,7 @@ Image:
     - filter_images_task
     - unify_objects_task
     - browse_images_task
+    - sqed_depiction_breakdown_todo_map_task
   config:
     recent: false
   new: new_image_task

--- a/exe/delayed_job
+++ b/exe/delayed_job
@@ -2,4 +2,4 @@
 set -e
 
 cd /app
-exec chpst -u app env QUEUE=project_download,cached_map,dwca_export,coldp_export,basic_nomenclature_export,dwc_occurrence_index,dwca_build_index,import_dataset_import,import_dataset_stage,cache,query_batch_update,import_nexus,import_gazetteers,inaturalist_import /usr/bin/bundle exec rails jobs:work
+exec chpst -u app env QUEUE=project_download,cached_map,dwca_export,coldp_export,basic_nomenclature_export,dwc_occurrence_index,dwca_build_index,import_dataset_import,import_dataset_stage,cache,query_batch_update,import_nexus,import_gazetteers,inaturalist_import,sqed_preprocess /usr/bin/bundle exec rails jobs:work

--- a/spec/jobs/sqed_depiction_preprocess_job_spec.rb
+++ b/spec/jobs/sqed_depiction_preprocess_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe SqedDepictionPreprocessJob, type: :model do
+
+  context 'job configuration' do
+    specify 'queues in sqed_preprocess queue' do
+      expect {
+        SqedDepictionPreprocessJob.perform_later(sqed_depiction_id: 1)
+      }.to have_enqueued_job(SqedDepictionPreprocessJob)
+        .with(sqed_depiction_id: 1)
+        .on_queue('sqed_preprocess')
+    end
+  end
+
+  context 'perform' do
+    let(:sqed_depiction) { FactoryBot.create(:valid_sqed_depiction) }
+
+    specify 'calls preprocess(false) on the identified record' do
+      expect_any_instance_of(SqedDepiction).to receive(:preprocess).with(false)
+      SqedDepictionPreprocessJob.perform_now(sqed_depiction_id: sqed_depiction.id)
+    end
+
+    specify 'does nothing when the record is not found' do
+      expect {
+        SqedDepictionPreprocessJob.perform_now(sqed_depiction_id: 0)
+      }.not_to raise_error
+    end
+  end
+
+  context 'after_create_commit' do
+    specify 'enqueues a job when a SqedDepiction is created' do
+      expect {
+        FactoryBot.create(:valid_sqed_depiction)
+      }.to have_enqueued_job(SqedDepictionPreprocessJob)
+    end
+  end
+
+end


### PR DESCRIPTION
Works for me (creates the breakdown as soon as the sqed depiction is created from New Image, and it's available as soon as I load the sqed todo task from Filter Staged Images), but I'm no expert on this flow.