### PR TITLE
Set TN#cached_misspelling correctly after destruction of TNR::misspelling

### DIFF
--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -480,7 +480,7 @@ class TaxonNameRelationship < ApplicationRecord
 
         if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)
           t.update_columns(
-            cached_misspelling: true,
+            cached_misspelling: destroyed? ? nil : t.get_cached_misspelling,
             cached_author_year: t.get_author_and_year,
             cached_nomenclature_date: t.nomenclature_date,
             cached_original_combination: t.get_original_combination,

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -480,7 +480,7 @@ class TaxonNameRelationship < ApplicationRecord
 
         if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)
           t.update_columns(
-            cached_misspelling: destroyed? ? nil : t.get_cached_misspelling,
+            cached_misspelling: t.get_cached_misspelling,
             cached_author_year: t.get_author_and_year,
             cached_nomenclature_date: t.nomenclature_date,
             cached_original_combination: t.get_original_combination,

--- a/spec/models/taxon_name_relationship_spec.rb
+++ b/spec/models/taxon_name_relationship_spec.rb
@@ -320,6 +320,16 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
         expect(s1.cached_html).to eq('<i>Aus aus</i> [sic]')
       end
 
+      specify 'destroy misspelling relationship clears cached_misspelling' do
+        r3 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s2,
+                               type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')
+        s1.reload
+        expect(s1.cached_misspelling).to be_truthy
+        r3.destroy!
+        s1.reload
+        expect(s1.cached_misspelling).to be_falsey
+      end
+
       specify 'fixing synonym linked to another synonym' do
         r3 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s2,
                                type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')

--- a/spec/models/taxon_name_relationship_spec.rb
+++ b/spec/models/taxon_name_relationship_spec.rb
@@ -320,6 +320,19 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
         expect(s1.cached_html).to eq('<i>Aus aus</i> [sic]')
       end
 
+      specify 'destroy one of multiple misspelling relationships retains cached_misspelling' do
+        s3 = FactoryBot.create(:relationship_species, name: 'cus', parent: g1)
+        r3 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s2,
+                               type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')
+        r4 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s3,
+                               type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')
+        s1.reload
+        expect(s1.cached_misspelling).to be_truthy
+        r3.destroy!
+        s1.reload
+        expect(s1.cached_misspelling).to be_truthy
+      end
+
       specify 'destroy misspelling relationship clears cached_misspelling' do
         r3 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s2,
                                type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')


### PR DESCRIPTION
You never see the bug from New Taxon Name because it always resaves the TN after a TNR delete.

@proceps / @mjy is this okay?