### PR TITLE
Handle double origin-citation submit from New Taxon Name #4909

### DIFF
--- a/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorSource.vue
+++ b/app/javascript/vue/tasks/nomenclature/new_taxon_name/components/Author/AuthorSource.vue
@@ -102,7 +102,10 @@ function setSource({ id, pages }) {
   }
 
   store.dispatch(ActionNames.ChangeTaxonSource, payload)
-  store.dispatch(ActionNames.UpdateTaxonName, taxon.value)
+  store.dispatch(ActionNames.UpdateTaxonName, taxon.value).catch((errors) => {
+    const message = errors?.origin_citation?.[0] || 'Origin citation could not be saved.'
+    TW.workbench.alert.create(message, 'error')
+  })
 }
 
 function addPages(citation) {

--- a/app/models/concerns/shared/citations.rb
+++ b/app/models/concerns/shared/citations.rb
@@ -52,9 +52,10 @@ module Shared::Citations
     }
 
     accepts_nested_attributes_for :citations, reject_if: :reject_citations, allow_destroy: true
-    accepts_nested_attributes_for :origin_citation, reject_if: :reject_citations, allow_destroy: true
+    accepts_nested_attributes_for :origin_citation, reject_if: :reject_origin_citation_attributes, allow_destroy: true
 
     validate :origin_citation_source_id, if: -> { !new_record? }
+    validate :no_origin_citation_conflict
 
     # !! use validate: true in associations settings to trigger this as needed
     # Required to trigger validate callbacks, which in turn set user_id related housekeeping
@@ -126,12 +127,34 @@ module Shared::Citations
 
   protected
 
+  # The New Taxon Name task doesn't use a spinner when saves are sent, so it's
+  # known that we can occasionally get duplicate origin citation requests. We
+  # accept that as the price of keeping the task speedy for the user and
+  # silently drop the duplicate here to compensate.
+  def reject_origin_citation_attributes(attributed)
+    if attributed['id'].blank? && origin_citation.present?
+      if origin_citation.source_id.to_s == attributed['source_id'].to_s &&
+         origin_citation.pages.presence == attributed['pages'].presence
+        return true
+      else
+        # This will be caught and reported as an error in validations.
+        @origin_citation_conflict = true
+        return true
+      end
+    end
+    reject_citations(attributed)
+  end
+
   def reject_citations(attributed)
     if (attributed['source_id'].blank? && attributed['source'].blank?)
       return true if new_record?
       return true if attributed['pages'].blank?
     end
     false
+  end
+
+  def no_origin_citation_conflict
+    errors.add(:origin_citation, 'already exists for this object') if @origin_citation_conflict
   end
 
 end

--- a/spec/models/concerns/shared/citations_spec.rb
+++ b/spec/models/concerns/shared/citations_spec.rb
@@ -66,6 +66,51 @@ describe 'Citations', type: :model, group: [:nomenclature, :citations] do
         expect(t.citations.first.is_original?).to be_falsey
       end
 
+      specify 'origin_citation_attributes without an id creates when none exists' do
+        t = TestCitable.create
+        expect {
+          t.update!(origin_citation_attributes: {source_id: source.id, is_original: true})
+        }.to change(Citation, :count).by(1)
+      end
+
+      context 'duplicate origin_citation_attributes (race condition)' do
+        let(:s2) { FactoryBot.create(:valid_source_bibtex, year: 2000) }
+
+        before do
+          class_with_citations.save!
+          class_with_citations.update!(origin_citation_attributes: {source_id: source.id, is_original: true, pages: '1'})
+        end
+
+        specify 'a create without an id when source differs returns a validation error' do
+          result = class_with_citations.update(origin_citation_attributes: {source_id: s2.id, is_original: true})
+          expect(result).to be false
+          expect(class_with_citations.errors[:origin_citation]).to be_present
+        end
+
+        specify 'a create without an id when source differs does not create a new citation' do
+          expect {
+            class_with_citations.update(origin_citation_attributes: {source_id: s2.id, is_original: true})
+          }.not_to change(Citation, :count)
+        end
+
+        specify 'a duplicate create without an id is silently dropped' do
+          expect {
+            class_with_citations.update!(origin_citation_attributes: {source_id: source.id, is_original: true, pages: '1'})
+          }.not_to change(Citation, :count)
+        end
+
+        specify 'the existing origin citation is preserved' do
+          class_with_citations.update!(origin_citation_attributes: {source_id: source.id, is_original: true, pages: '1'})
+          expect(class_with_citations.reload.origin_citation.source_id).to eq(source.id)
+        end
+
+        specify 'an update with an id is not dropped' do
+          id = class_with_citations.origin_citation.id
+          class_with_citations.update!(origin_citation_attributes: {id:, source_id: s2.id, is_original: true})
+          expect(class_with_citations.reload.origin_citation.source_id).to eq(s2.id)
+        end
+      end
+
       context 'with a is_original citation' do
         before do
           citation.is_original = true


### PR DESCRIPTION
STR: double-click on 'Clone last citation' (throttling network in devtools may help locally)
  --> sends two TN updates having nested origin_citation with id: nil
  --> first one saves fine, second one sets citation_object_id=nil on the first one (because the origin_citation association is a has_one) and then saves that
  --> boom: citation_object_id is required on citation.