### PR TITLE
Add extends=descendants to the TN monograph api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Ctrl+v to paste images and documents in "Drop [image/doc] here"
 - New descriptors: character states' thumbnails [#4796]
 - Project usage count for authors in Match Author task of New Source [#4943]
+- extend[]=descendants option for api/v1/taxon_names/123/monograph endpoint (limited to 2500 results or fewer) [#4860]
 
 ### Changed
 
@@ -41,6 +42,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 
 [#4796]: https://github.com/SpeciesFileGroup/taxonworks/issues/4796
 [#4909]: https://github.com/SpeciesFileGroup/taxonworks/issues/4909
+[#4860]: https://github.com/SpeciesFileGroup/taxonworks/issues/4860
 [#4928]: https://github.com/SpeciesFileGroup/taxonworks/issues/4928
 [#4929]: https://github.com/SpeciesFileGroup/taxonworks/issues/4929
 [#4932]: https://github.com/SpeciesFileGroup/taxonworks/issues/4932

--- a/app/controllers/taxon_names_controller.rb
+++ b/app/controllers/taxon_names_controller.rb
@@ -1,7 +1,7 @@
 class TaxonNamesController < ApplicationController
   include DataControllerConfiguration::ProjectDataControllerConfiguration
 
-  before_action :set_taxon_name, only: [:show, :edit, :update, :destroy, :browse, :original_combination, :catalog, :api_show, :api_summary, :api_catalog, :api_monograph]
+  before_action :set_taxon_name, only: [:show, :edit, :update, :destroy, :browse, :original_combination, :catalog, :api_show, :api_summary, :api_catalog]
   after_action -> { set_pagination_headers(:taxon_names) }, only: [:index, :api_index, :origin_citation], if: :json_request?
 
   # GET /taxon_names

--- a/app/views/taxon_names/api/v1/_monograph_item.json.jbuilder
+++ b/app/views/taxon_names/api/v1/_monograph_item.json.jbuilder
@@ -1,0 +1,60 @@
+json.partial! '/taxon_names/api/v1/attributes', taxon_name: taxon_name
+
+if taxon_name.origin_citation
+  json.original_citation do
+    json.partial! '/citations/api/v1/attributes', citation: taxon_name.origin_citation, extensions: false
+  end
+end
+
+# Duplicates origin_citation ^ when present, that's okay.
+if extend_response_with('base_citations')
+  json.base_citations taxon_name.citations do |c|
+    json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
+  end
+end
+
+json.taxon_name_classifications taxon_name.taxon_name_classifications do |r|
+  json.partial! '/taxon_name_classifications/api/v1/attributes', taxon_name_classification: r, extensions: false
+end
+
+json.object_taxon_name_relationships taxon_name.related_taxon_name_relationships do |r|
+  json.id r.id
+  json.type r.type
+
+  if extend_response_with('relationship_citations')
+    json.citations r.citations do |c|
+      json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
+    end
+  end
+
+  json.subject_taxon_name do
+    json.partial! '/taxon_names/api/v1/base_attributes', taxon_name: r.subject_taxon_name, extensions: false
+
+    if extend_response_with('related_citations')
+      json.citations r.subject_taxon_name.citations do |c|
+        json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
+      end
+    end
+  end
+end
+
+json.subject_taxon_name_relationships taxon_name.taxon_name_relationships do |r|
+  json.id r.id
+  json.type r.type
+
+  if extend_response_with('relationship_citations')
+    json.citations r.citations do |c|
+      json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
+    end
+  end
+
+  json.object_taxon_name do
+    json.partial! '/taxon_names/api/v1/base_attributes', taxon_name: r.object_taxon_name, extensions: false
+
+    if extend_response_with('related_citations')
+      json.citations r.object_taxon_name.citations do |c|
+        json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
+      end
+    end
+  end
+end

--- a/app/views/taxon_names/api/v1/monograph.json.jbuilder
+++ b/app/views/taxon_names/api/v1/monograph.json.jbuilder
@@ -1,66 +1,33 @@
-json.partial! '/taxon_names/api/v1/attributes', taxon_name: @taxon_name
+citation_includes = [{citation_topics: :topic}, :topics, :source]
 
-if @taxon_name.origin_citation
-  json.original_citation do
-    json.partial! '/citations/api/v1/attributes', citation: @taxon_name.origin_citation, extensions: false
-  end
-end
+nested_taxon_name_includes = [:source, {citations: citation_includes}]
 
-# Duplicates origin_citation ^ when present, that's okay.
-if extend_response_with('base_citations')
-  json.base_citations @taxon_name.citations do |c|
-    json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
-  end
-end
+monograph_includes = [
+  :source,
+  {origin_citation: citation_includes},
+  {citations: citation_includes},
+  :taxon_name_classifications,
+  {related_taxon_name_relationships: [
+    {citations: citation_includes},
+    {subject_taxon_name: nested_taxon_name_includes}
+  ]},
+  {taxon_name_relationships: [
+    {citations: citation_includes},
+    {object_taxon_name: nested_taxon_name_includes}
+  ]}
+]
 
-json.taxon_name_classifications TaxonNameClassification.where(taxon_name_id: @taxon_name.id) do |r|
-  json.partial! '/taxon_name_classifications/api/v1/attributes', taxon_name_classification: r, extensions: false
-end
+if extend_response_with('descendants')
+  root = TaxonName.with_project_id(sessions_current_project_id).find(params[:id])
 
-object_relationships = TaxonNameRelationship.where(object_taxon_name_id: @taxon_name.id)
-  .includes(:citations, subject_taxon_name: :citations)
-
-json.object_taxon_name_relationships object_relationships do |r|
-  json.id r.id
-  json.type r.type
-
-  if extend_response_with('relationship_citations')
-    json.citations r.citations do |c|
-      json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
+  if root.descendants.count > 2500
+    json.array! []
+  else
+    json.array!(root.descendants.includes(monograph_includes)) do |taxon_name|
+      json.partial! '/taxon_names/api/v1/monograph_item', taxon_name: taxon_name
     end
   end
-
-  json.subject_taxon_name do
-    json.partial! '/taxon_names/api/v1/base_attributes', taxon_name: r.subject_taxon_name, extensions: false
-
-    if extend_response_with('related_citations')
-      json.citations r.subject_taxon_name.citations do |c|
-        json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
-      end
-    end
-  end
-end
-
-subject_relationships = TaxonNameRelationship.where(subject_taxon_name_id: @taxon_name.id)
-  .includes(:citations, object_taxon_name: :citations)
-
-json.subject_taxon_name_relationships subject_relationships do |r|
-  json.id r.id
-  json.type r.type
-
-  if extend_response_with('relationship_citations')
-    json.citations r.citations do |c|
-      json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
-    end
-  end
-
-  json.object_taxon_name do
-    json.partial! '/taxon_names/api/v1/base_attributes', taxon_name: r.object_taxon_name, extensions: false
-
-    if extend_response_with('related_citations')
-      json.citations r.object_taxon_name.citations do |c|
-        json.partial! '/citations/api/v1/attributes', citation: c, extensions: false
-      end
-    end
-  end
+else
+  taxon_name = TaxonName.with_project_id(sessions_current_project_id).includes(monograph_includes).find(params[:id])
+  json.partial! '/taxon_names/api/v1/monograph_item', taxon_name: taxon_name
 end

--- a/spec/requests/api/v1/rest/taxon_name_spec.rb
+++ b/spec/requests/api/v1/rest/taxon_name_spec.rb
@@ -24,5 +24,46 @@ describe 'Api::V1::TaxonNames', type: :request do
     before { get "/api/v1/taxon_names/#{taxon_name.id}/monograph", headers: headers, params: { project_id: project.id } }
 
     it_behaves_like 'a successful response'
+
+    context 'with extend[]=descendants' do
+      let(:family) do
+        Protonym.create!(name: 'Aidae', rank_class: Ranks.lookup(:iczn, :family), parent: project.root_taxon_name, by: user, project: project)
+      end
+
+      let!(:genus) do
+        Protonym.create!(name: 'Bus', rank_class: Ranks.lookup(:iczn, :genus), parent: family, by: user, project: project)
+      end
+
+      before { get "/api/v1/taxon_names/#{family.id}/monograph", headers: headers, params: { project_id: project.id, extend: ['descendants'] } }
+
+      it_behaves_like 'a successful response'
+
+      it 'returns an array' do
+        expect(JSON.parse(response.body)).to be_an Array
+      end
+
+      it 'includes each descendant' do
+        ids = JSON.parse(response.body).map { |t| t['id'] }
+        expect(ids).to include(genus.id)
+      end
+
+      it 'does not include the root taxon itself' do
+        ids = JSON.parse(response.body).map { |t| t['id'] }
+        expect(ids).not_to include(family.id)
+      end
+
+      context 'when descendant count exceeds 2500' do
+        before do
+          allow_any_instance_of(TaxonName).to receive_message_chain(:descendants, :count).and_return(2501)
+          get "/api/v1/taxon_names/#{family.id}/monograph", headers: headers, params: { project_id: project.id, extend: ['descendants'] }
+        end
+
+        it_behaves_like 'a successful response'
+
+        it 'returns an empty array' do
+          expect(JSON.parse(response.body)).to eq []
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The count guard in the descendants case is intended to protect the db from somebody requesting all that info for the entire taxon tree, e.g., all pre-loaded.

We could maybe switch to paged results if that's needed.