### PR TITLE
Updates to the Cite Verbatim Taxon Name Authors task

### DIFF
--- a/app/javascript/vue/routes/endpoints/SoftValidation.js
+++ b/app/javascript/vue/routes/endpoints/SoftValidation.js
@@ -16,11 +16,15 @@ export const SoftValidation = {
       filterParams(params, permitParams)
     ),
 
-  find: (globalId, config) =>
-    AjaxCall(
+  // TODO: axiosConfig (cancelRequest etc.) is passed as AjaxCall's 4th arg, which
+  // axios.get silently ignores — cancellation has never worked for this endpoint.
+  find: (globalId, config = {}) => {
+    const { params: extraParams = {}, ...axiosConfig } = config
+    return AjaxCall(
       'get',
       '/soft_validations/validate',
-      { params: { global_id: globalId } },
-      config
+      { params: { global_id: globalId, ...extraParams } },
+      axiosConfig
     )
+  }
 }

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/app.vue
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/app.vue
@@ -44,6 +44,7 @@
       <AuthorYearTable
         @cite="openSourceModal"
         @preview="openPreviewModal"
+        @page-numbers="openPageNumbersModal"
       />
     </div>
 
@@ -59,6 +60,15 @@
       :year="previewYear"
       @close="closePreviewModal"
     />
+
+    <PageNumbersModal
+      v-if="showPageNumbersModal"
+      :author="pageNumbersRow.verbatim_author"
+      :year="pageNumbersRow.year_of_publication"
+      :taxon-name-ids="pageNumbersRow.citedTaxonNameIds"
+      :source-id="pageNumbersRow.citedSourceId"
+      @close="showPageNumbersModal = false"
+    />
   </div>
 </template>
 
@@ -72,6 +82,7 @@ import VSpinner from '@/components/ui/VSpinner.vue'
 import AuthorYearTable from './components/AuthorYearTable.vue'
 import SourceSelectionModal from './components/SourceSelectionModal.vue'
 import PreviewModal from './components/PreviewModal.vue'
+import PageNumbersModal from './components/PageNumbersModal.vue'
 
 defineOptions({
   name: 'TaxonNameVerbatimWihtoutCitations'
@@ -81,10 +92,12 @@ const store = useStore()
 
 const showSourceModal = ref(false)
 const showPreviewModal = ref(false)
+const showPageNumbersModal = ref(false)
 const previewAuthor = ref(null)
 const previewYear = ref(null)
 const currentAuthor = ref(null)
 const currentYear = ref(null)
+const pageNumbersRow = ref(null)
 
 onMounted(() => {
   const urlParams = URLParamsToJSON(window.location.href)
@@ -140,6 +153,11 @@ function closePreviewModal() {
   previewAuthor.value = null
   previewYear.value = null
   store.resetPreview()
+}
+
+function openPageNumbersModal(row) {
+  pageNumbersRow.value = row
+  showPageNumbersModal.value = true
 }
 
 async function handleSourceSelect(sourceId) {

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/AuthorYearTable.vue
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/AuthorYearTable.vue
@@ -60,6 +60,7 @@
         </td>
         <td>
           <a
+            v-if="!row.isCited"
             :href="filterUrl(row.verbatim_author, row.year_of_publication)"
             target="_blank"
           >
@@ -68,6 +69,7 @@
         </td>
         <td>
           <VBtn
+            v-if="!row.isCited"
             color="primary"
             medium
             @click="
@@ -75,6 +77,14 @@
             "
           >
             Taxon names
+          </VBtn>
+          <VBtn
+            v-else
+            color="primary"
+            medium
+            @click="$emit('page-numbers', row)"
+          >
+            Page numbers
           </VBtn>
         </td>
         <td class="batch-cite-cell">
@@ -139,7 +149,7 @@ const store = useStore()
 const sortColumn = ref('year_of_publication')
 const sortDirection = ref('desc')
 
-defineEmits(['cite', 'preview'])
+defineEmits(['cite', 'preview', 'page-numbers'])
 
 const sortedData = computed(() => {
   const data = [...store.authorYearData]

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/AuthorYearTable.vue
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/AuthorYearTable.vue
@@ -177,8 +177,7 @@ function sortBy(column) {
 
 function filterUrl(author, year) {
   const params = new URLSearchParams({
-    author: author,
-    author_exact: true,
+    verbatim_author: author,
     year: year
   })
   return `${RouteNames.FilterNomenclature}?${params.toString()}`

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/PageNumbersModal.vue
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/PageNumbersModal.vue
@@ -1,0 +1,198 @@
+<template>
+  <VModal
+    @close="$emit('close')"
+    :container-style="{ width: '900px' }"
+  >
+    <template #header>
+      <h3>{{ author }} {{ year }} — page numbers</h3>
+    </template>
+    <template #body>
+      <VSpinner
+        v-if="isLoading"
+        legend="Loading..."
+      />
+      <template v-else>
+        <div
+          v-if="source"
+          class="margin-medium-bottom"
+        >
+          <span v-html="source.cached" />
+          &nbsp;—&nbsp;
+          <a
+            :href="`${RouteNames.NewSource}?source_id=${source.id}`"
+            target="_blank"
+          >
+            View source
+          </a>
+        </div>
+
+        <div v-if="rows.length === 0">
+          <p>No citations found.</p>
+        </div>
+        <table
+          v-else
+          class="full_width"
+        >
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Pages</th>
+              <th />
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="row in rows"
+              :key="row.taxonName.id"
+            >
+              <td>
+                <a
+                  :href="`${RouteNames.BrowseNomenclature}?taxon_name_id=${row.taxonName.id}`"
+                  target="_blank"
+                >
+                  {{
+                    row.taxonName.cached ||
+                    row.taxonName.name ||
+                    `TaxonName #${row.taxonName.id}`
+                  }}
+                </a>
+              </td>
+              <td>
+                <input
+                  v-model="row.pages"
+                  type="text"
+                  class="normal-input inline"
+                  placeholder="pages"
+                />
+              </td>
+              <td>
+                <VBtn
+                  color="submit"
+                  medium
+                  :disabled="row.isSaving"
+                  @click="updatePages(row)"
+                >
+                  {{ row.isSaving ? 'Saving...' : 'Update' }}
+                </VBtn>
+              </td>
+              <td>
+                <SoftValidation
+                  v-if="row.citation && row.hasSaved"
+                  :key="row.validationKey"
+                  :global-id="row.citation.global_id"
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </template>
+    </template>
+  </VModal>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { RouteNames } from '@/routes/routes'
+import { TaxonName, Citation, Source } from '@/routes/endpoints'
+import VModal from '@/components/ui/Modal.vue'
+import VSpinner from '@/components/ui/VSpinner.vue'
+import VBtn from '@/components/ui/VBtn/index.vue'
+import SoftValidation from '@/components/soft_validations/objectValidation.vue'
+
+const props = defineProps({
+  author: {
+    type: String,
+    required: true
+  },
+  year: {
+    type: [Number, String],
+    required: true
+  },
+  taxonNameIds: {
+    type: Array,
+    required: true
+  },
+  sourceId: {
+    type: Number,
+    required: true
+  }
+})
+
+defineEmits(['close'])
+
+const isLoading = ref(false)
+const source = ref(null)
+const rows = ref([])
+
+onMounted(async () => {
+  isLoading.value = true
+  try {
+    const [namesResponse, citationsResponse, sourceResponse] = await Promise.all([
+      TaxonName.where({ taxon_name_id: props.taxonNameIds }),
+      Citation.filter({
+        citation_object_type: 'TaxonName',
+        citation_object_id: props.taxonNameIds,
+        source_id: props.sourceId,
+        is_original: true
+      }),
+      Source.find(props.sourceId)
+    ])
+
+    source.value = sourceResponse.body
+
+    const citationsByTaxonNameId = {}
+    for (const citation of citationsResponse.body) {
+      citationsByTaxonNameId[citation.citation_object_id] = citation
+    }
+
+    rows.value = namesResponse.body.map((taxonName) => ({
+      taxonName,
+      citation: citationsByTaxonNameId[taxonName.id],
+      pages: citationsByTaxonNameId[taxonName.id]?.pages || '',
+      isSaving: false,
+      hasSaved: false,
+      validationKey: 0
+    }))
+  } catch {
+    TW.workbench.alert.create('Error loading citations', 'error')
+  } finally {
+    isLoading.value = false
+  }
+})
+
+async function updatePages(row) {
+  if (!row.citation) return
+  row.isSaving = true
+  try {
+    await Citation.update(row.citation.id, { citation: { pages: row.pages } })
+    row.hasSaved = true
+    row.validationKey++
+    TW.workbench.alert.create('Pages updated', 'notice')
+  } catch {
+    TW.workbench.alert.create('Error updating pages', 'error')
+  } finally {
+    row.isSaving = false
+  }
+}
+</script>
+
+<style scoped>
+table {
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 8px;
+  text-align: left;
+}
+
+th {
+  background-color: var(--table-row-bg-odd);
+}
+
+td {
+  border-bottom: 1px solid var(--border-color);
+}
+</style>

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/PreviewModal.vue
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/PreviewModal.vue
@@ -31,11 +31,16 @@
             :key="taxonName.id"
           >
             <td>
-              {{
-                taxonName.cached ||
-                taxonName.name ||
-                `TaxonName #${taxonName.id}`
-              }}
+              <a
+                :href="`${RouteNames.BrowseNomenclature}?taxon_name_id=${taxonName.id}`"
+                target="_blank"
+              >
+                {{
+                  taxonName.cached ||
+                  taxonName.name ||
+                  `TaxonName #${taxonName.id}`
+                }}
+              </a>
             </td>
             <td>{{ taxonName.verbatim_author || '' }}</td>
             <td>{{ taxonName.year_of_publication || '' }}</td>
@@ -48,6 +53,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { RouteNames } from '@/routes/routes'
 import useStore from '../store/store'
 import VModal from '@/components/ui/Modal.vue'
 import VSpinner from '@/components/ui/VSpinner.vue'

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/SourceSelectionModal.vue
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/components/SourceSelectionModal.vue
@@ -7,6 +7,38 @@
       <h3>Select Source for Citation</h3>
     </template>
     <template #body>
+      <div class="margin-medium-bottom">
+        <SmartSelector
+          model="sources"
+          pin-section="Sources"
+          pin-type="Source"
+          label="cached"
+          :shorten="100"
+          v-model="selectedSource"
+          @selected="onSelected"
+        />
+        <SmartSelectorItem
+          v-if="selectedSource"
+          :item="selectedSource"
+          label="cached"
+          @unset="() => { selectedSource = null }"
+        />
+        <div class="margin-small-top">
+          <VBtn
+            color="create"
+            medium
+            :disabled="!selectedSource"
+            @click="emitSelected"
+          >
+            Cite
+          </VBtn>
+        </div>
+      </div>
+
+      <div class="horizontal-center-content margin-medium-top margin-medium-bottom">
+        <strong>OR</strong>
+      </div>
+
       <VSpinner
         v-if="isLoading"
         legend="Loading recent sources..."
@@ -16,11 +48,11 @@
       </div>
       <table
         v-else
-        class="full_width table-striped"
+        class="full_width table-striped margin-medium-top"
       >
         <thead>
           <tr>
-            <th>Source</th>
+            <th>Recently updated sources</th>
             <th class="w-2" />
           </tr>
         </thead>
@@ -42,7 +74,7 @@
                 medium
                 @click="selectSource(source.id)"
               >
-                Select
+                Cite
               </VBtn>
             </td>
           </tr>
@@ -58,12 +90,15 @@ import useStore from '../store/store'
 import VModal from '@/components/ui/Modal.vue'
 import VBtn from '@/components/ui/VBtn/index.vue'
 import VSpinner from '@/components/ui/VSpinner.vue'
+import SmartSelector from '@/components/ui/SmartSelector.vue'
+import SmartSelectorItem from '@/components/ui/SmartSelectorItem.vue'
 
 const emit = defineEmits(['close', 'select'])
 
 const store = useStore()
 const sources = ref([])
 const isLoading = ref(false)
+const selectedSource = ref(null)
 
 onMounted(async () => {
   isLoading.value = true
@@ -75,6 +110,16 @@ onMounted(async () => {
     isLoading.value = false
   }
 })
+
+function onSelected(source) {
+  selectedSource.value = source
+}
+
+function emitSelected() {
+  if (selectedSource.value) {
+    emit('select', selectedSource.value.id)
+  }
+}
 
 function selectSource(sourceId) {
   emit('select', sourceId)

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/store/store.js
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/store/store.js
@@ -53,7 +53,9 @@ export default defineStore('verbatimAuthorYearSource', {
           isPending: false,
           pendingStage: null,
           progressCurrent: 0,
-          progressTotal: 0
+          progressTotal: 0,
+          citedTaxonNameIds: [],
+          citedSourceId: null
         }))
 
         this.maxCount = response.body.max_count
@@ -152,6 +154,8 @@ export default defineStore('verbatimAuthorYearSource', {
 
         // Mark as complete
         row.isCited = true
+        row.citedTaxonNameIds = ids
+        row.citedSourceId = sourceId
 
         TW.workbench.alert.create(
           'Citations created and taxon names updated',

--- a/app/javascript/vue/tasks/sources/verbatim_author_year_source/store/store.js
+++ b/app/javascript/vue/tasks/sources/verbatim_author_year_source/store/store.js
@@ -77,8 +77,7 @@ export default defineStore('verbatimAuthorYearSource', {
     async loadPreviewTaxonNames(author, year) {
       try {
         const response = await TaxonName.where({
-          author: author,
-          author_exact: true,
+          verbatim_author: author,
           year: year,
           citations: false
         })
@@ -106,8 +105,7 @@ export default defineStore('verbatimAuthorYearSource', {
       try {
         // Get TaxonName IDs
         const taxonNamesResponse = await TaxonName.where({
-          author: author,
-          author_exact: true,
+          verbatim_author: author,
           year: year,
           citations: false
         })

--- a/lib/queries/taxon_name/filter.rb
+++ b/lib/queries/taxon_name/filter.rb
@@ -49,6 +49,7 @@ module Queries
         :type_metadata,
         :validify,
         :validity,
+        :verbatim_author,
         :verbatim_name,
         :year,
         :year_end,
@@ -172,6 +173,10 @@ module Queries
       # name is returned
       # !! This param is not like the others. !!
       attr_accessor :validify
+
+      # @param verbatim_author [String]
+      #   Exact match against verbatim_author.
+      attr_accessor :verbatim_author
 
       # @oparams verbatim_name  ['true', True, nil]
       # @return Boolean
@@ -402,6 +407,7 @@ module Queries
         @type_metadata = boolean_param(params, :type_metadata)
         @validify = boolean_param(params, :validify)
         @validity = boolean_param(params, :validity)
+        @verbatim_author = params[:verbatim_author]
         @verbatim_name = boolean_param(params, :verbatim_name)
 
         @year = params[:year]
@@ -869,6 +875,11 @@ module Queries
         end
       end
 
+      def verbatim_author_facet
+        return nil if verbatim_author.blank?
+        table[:verbatim_author].eq(verbatim_author)
+      end
+
       def verbatim_name_facet
         return nil if verbatim_name.nil?
         if verbatim_name
@@ -1013,6 +1024,7 @@ module Queries
           taxon_name_type_facet,
           validity_facet,
           availability_facet,
+          verbatim_author_facet,
           verbatim_name_facet,
           with_nomenclature_code,
           with_nomenclature_group,

--- a/spec/lib/queries/taxon_name/filter_spec.rb
+++ b/spec/lib/queries/taxon_name/filter_spec.rb
@@ -657,6 +657,38 @@ describe Queries::TaxonName::Filter, type: :model, group: [:nomenclature] do
     expect(query.all.map(&:id)).to contain_exactly()
   end
 
+  specify '#verbatim_author matches exact stored value without parens' do
+    query.verbatim_author = 'Fitch & Say'
+    expect(query.all.map(&:id)).to contain_exactly(species.id)
+  end
+
+  specify '#verbatim_author does not match when parens differ' do
+    query.verbatim_author = '(Fitch & Say)'
+    expect(query.all.map(&:id)).to contain_exactly()
+  end
+
+  context '#verbatim_author with parens' do
+    let!(:parenthesized) {
+      Protonym.create!(
+        name: 'obscura',
+        rank_class: Ranks.lookup(:iczn, 'species'),
+        parent: genus,
+        verbatim_author: '(Fitch & Say)',
+        year_of_publication: 1800,
+      )
+    }
+
+    specify 'matches exact value with parens' do
+      query.verbatim_author = '(Fitch & Say)'
+      expect(query.all.map(&:id)).to contain_exactly(parenthesized.id)
+    end
+
+    specify 'does not match bare author when stored value has parens' do
+      query.verbatim_author = 'Fitch & Say'
+      expect(query.all.map(&:id)).to contain_exactly(species.id)
+    end
+  end
+
   specify '#year' do
     query.year = 1800
     expect(query.all).to contain_exactly(species)


### PR DESCRIPTION
These were discussed at last week's Community Consult.

The main changes:
* add a Source selector to the modal currently showing the 10 most recent Sources when you click on the Cite button (so that you can choose a source that was entered long ago but never processed until now)
* once a row's names have been cited, the 'Filter Names' link and 'TaxonNames' button no longer work (because the names no longer have verbatim); now those go away and the 'TaxonNames' button turns into a 'Page numbers' button that you can click to add the page to each Citation that was created by the Cite button click:
<img width="960" height="511" alt="image" src="https://github.com/user-attachments/assets/90a754eb-2656-48e1-9b08-3d7b21e3ff83" />

