### PR TITLE
Match OTUs task minor updates

### DIFF
--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -160,15 +160,15 @@ function applyModifiers(name) {
   return result.trim()
 }
 
-function computeMatchStrings() {
+function computeMatchStrings(matchAll = false) {
   const hasActiveModifier = modifiers.value.some((m) => m.active && m.pattern)
 
   rows.value.forEach((row) => {
     if (row.isEmpty) return
 
-    if (hasActiveModifier && row.selected) {
+    if (hasActiveModifier && (row.selected || matchAll)) {
       row.matchString = applyModifiers(row.scientificName)
-    } else if (!row.selected) {
+    } else if (!row.selected && !matchAll) {
       // Don't change matchString for unselected rows
     } else {
       row.matchString = ''
@@ -177,7 +177,7 @@ function computeMatchStrings() {
 }
 
 async function runMatch({ matchAll = false } = {}) {
-  computeMatchStrings()
+  computeMatchStrings(matchAll)
   syncAllDuplicates()
 
   const checkedRows = rows.value.filter((r) => r.selected && !r.isEmpty)

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -82,12 +82,11 @@ import InputPanel from './components/InputPanel.vue'
 import ResultTable from './components/ResultTable.vue'
 import SummaryBar from './components/SummaryBar.vue'
 import MatchOptionsPanel from './components/MatchOptionsPanel.vue'
+import { MAX_ROWS } from './constants.js'
 
 defineOptions({
   name: 'MatchOtuByTaxonName'
 })
-
-const MAX_ROWS = 1000
 
 const stage = ref('input')
 const isProcessing = ref(false)
@@ -115,7 +114,10 @@ const modifiers = ref([
   { active: false, pattern: '', replacement: '' }
 ])
 
-function handleDataSubmit({ names, csv }) {
+async function handleDataSubmit({ names, csv }) {
+  isProcessing.value = true
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
   csvData.value = csv
 
   rows.value = names.slice(0, MAX_ROWS).map((name, index) => {
@@ -138,9 +140,8 @@ function handleDataSubmit({ names, csv }) {
 
   stage.value = 'results'
 
-  nextTick(() => {
-    runMatch({ matchAll: true })
-  })
+  await nextTick()
+  runMatch({ matchAll: true })
 }
 
 function applyModifiers(name) {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -20,6 +20,7 @@
                 color="primary"
                 medium
                 :disabled="!rows.length"
+                data-help="Re-matches all rows using current settings. To re-match only specific rows, check their checkboxes — each checked row auto-matches immediately using current settings and auto-updates when settings are changed."
                 @click="runMatch({ matchAll: true })"
               >
                 Match

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -27,6 +27,7 @@
               <VBtn
                 circle
                 color="primary"
+                title="Reset task"
                 @click="reset"
               >
                 <VIcon

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -116,6 +116,8 @@ const modifiers = ref([
 
 async function handleDataSubmit({ names, csv }) {
   isProcessing.value = true
+  // Give the browser enough time to paint the spinner before it gets bogged
+  // down in processing.
   await new Promise((resolve) => setTimeout(resolve, 0))
 
   csvData.value = csv
@@ -140,7 +142,6 @@ async function handleDataSubmit({ names, csv }) {
 
   stage.value = 'results'
 
-  await nextTick()
   runMatch({ matchAll: true })
 }
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
@@ -44,17 +44,21 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import VBtn from "@/components/ui/VBtn/index.vue";
+import { useDropzonePasteManager } from "@/composables/useDropzonePasteManager";
 
 const MAX_ROWS = 1000;
 
 const emit = defineEmits(["submit"]);
 
+const { registerPaster, unregisterPaster } = useDropzonePasteManager();
+
 const nameText = ref("");
 const isDragging = ref(false);
 const csvParsedData = ref(null);
 const fileInfo = ref(null);
+let pasteZone = null;
 
 const lines = computed(() => nameText.value.split("\n").map((l) => l.trim()));
 
@@ -69,18 +73,41 @@ function submit() {
     });
 }
 
+function loadFile(file) {
+    const reader = new FileReader();
+    reader.onload = (e) => parseCSV(e.target.result, file.name);
+    reader.readAsText(file);
+}
+
 function handleFileDrop(event) {
     isDragging.value = false;
     const file = event.dataTransfer?.files?.[0];
     if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = (e) => {
-        const text = e.target.result;
-        parseCSV(text, file.name);
-    };
-    reader.readAsText(file);
+    loadFile(file);
 }
+
+function handleFilePaste(event) {
+    const items = event.clipboardData?.items;
+    if (!items) return;
+
+    for (const item of items) {
+        if (item.kind !== "file") continue;
+        const file = item.getAsFile();
+        if (!file) continue;
+        event.preventDefault();
+        loadFile(file);
+        return;
+    }
+}
+
+onMounted(() => {
+    pasteZone = { handler: handleFilePaste, prioritize: false };
+    registerPaster(pasteZone);
+});
+
+onBeforeUnmount(() => {
+    unregisterPaster(pasteZone);
+});
 
 function parseCSV(text, fileName) {
     const lines = text.split(/\r?\n/).filter((l) => l.trim());

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
@@ -3,7 +3,7 @@
     <h3>Provide names</h3>
     <p class="subtle">
       Paste names (one per line) or drag &amp; drop a CSV file with a
-      <code>scientificName</code> column. Maximum 1,000 rows.
+      <code>scientificName</code> column. Maximum 3,000 rows.
     </p>
 
     <div
@@ -19,6 +19,13 @@
         placeholder="Paste names here, one per line, or drag a CSV file..."
         rows="12"
       />
+    </div>
+
+    <div
+      v-if="rawNonEmptyCount > MAX_ROWS"
+      class="truncation-warning margin-small-top"
+    >
+      More than {{ MAX_ROWS.toLocaleString() }} rows provided; only the first {{ MAX_ROWS.toLocaleString() }} will be processed.
     </div>
 
     <div class="flex-row flex-separate margin-small-top">
@@ -50,8 +57,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import VBtn from '@/components/ui/VBtn/index.vue'
 import { useDropzonePasteManager } from '@/composables/useDropzonePasteManager'
-
-const MAX_ROWS = 1000
+import { MAX_ROWS } from '../constants.js'
 
 const emit = defineEmits(['submit'])
 
@@ -65,9 +71,11 @@ let pasteZone = null
 
 const lines = computed(() => nameText.value.split('\n').map((l) => l.trim()))
 
-const nonEmptyCount = computed(() => lines.value.filter(Boolean).length)
+const rawNonEmptyCount = computed(() => lines.value.filter(Boolean).length)
 
-const lineCount = computed(() => lines.value.length)
+const nonEmptyCount = computed(() => Math.min(rawNonEmptyCount.value, MAX_ROWS))
+
+const lineCount = computed(() => nameText.value.trim() ? Math.min(lines.value.length, MAX_ROWS) : 0)
 
 function submit() {
   emit('submit', {
@@ -136,7 +144,8 @@ function parseCSV(text, fileName) {
   const names = []
   const csvRows = []
 
-  dataLines.slice(0, MAX_ROWS).forEach((line) => {
+  // One over MAX_ROWS so nonEmptyCount exceeds MAX_ROWS and the truncation warning fires.
+  dataLines.slice(0, MAX_ROWS + 1).forEach((line) => {
     const fields = parseCsvLine(line, delimiter)
     const name = fields[scientificNameIndex]?.trim()
 
@@ -157,7 +166,7 @@ function parseCSV(text, fileName) {
 
   fileInfo.value = {
     name: fileName,
-    rowCount: names.length
+    rowCount: Math.min(names.length, MAX_ROWS)
   }
 
   nameText.value = names.join('\n')
@@ -217,6 +226,15 @@ function parseCsvLine(line, delimiter) {
 
 .subtle {
   color: #888;
+  font-size: 0.85em;
+}
+
+.truncation-warning {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+  border: 1px solid #faebcc;
+  border-radius: 4px;
+  padding: 6px 10px;
   font-size: 0.85em;
 }
 </style>

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
@@ -1,225 +1,222 @@
 <template>
-    <div class="panel content">
-        <h3>Provide names</h3>
-        <p class="subtle">
-            Paste names (one per line) or drag &amp; drop a CSV file with a
-            <code>scientificName</code> column. Maximum 1,000 rows.
-        </p>
+  <div class="panel content">
+    <h3>Provide names</h3>
+    <p class="subtle">
+      Paste names (one per line) or drag &amp; drop a CSV file with a
+      <code>scientificName</code> column. Maximum 1,000 rows.
+    </p>
 
-        <div
-            class="dropzone-area"
-            :class="{ 'dropzone-active': isDragging }"
-            @dragover.prevent="isDragging = true"
-            @dragleave.prevent="isDragging = false"
-            @drop.prevent="handleFileDrop"
-        >
-            <textarea
-                v-model="nameText"
-                class="full_width"
-                placeholder="Paste names here, one per line, or drag a CSV file..."
-                rows="12"
-            />
-        </div>
-
-        <div class="flex-row flex-separate margin-small-top">
-            <span class="subtle"
-                >{{ nonEmptyCount }} name(s), {{ lineCount }} total row(s)</span
-            >
-            <VBtn
-                color="primary"
-                medium
-                :disabled="!nonEmptyCount"
-                @click="submit"
-            >
-                Process
-            </VBtn>
-        </div>
-
-        <div v-if="fileInfo" class="margin-small-top">
-            <span class="subtle">
-                Loaded from: {{ fileInfo.name }} ({{ fileInfo.rowCount }} rows)
-            </span>
-        </div>
+    <div
+      class="dropzone-area"
+      :class="{ 'dropzone-active': isDragging }"
+      @dragover.prevent="isDragging = true"
+      @dragleave.prevent="isDragging = false"
+      @drop.prevent="handleFileDrop"
+    >
+      <textarea
+        v-model="nameText"
+        class="full_width"
+        placeholder="Paste names here, one per line, or drag a CSV file..."
+        rows="12"
+      />
     </div>
+
+    <div class="flex-row flex-separate margin-small-top">
+      <span class="subtle"
+        >{{ nonEmptyCount }} name(s), {{ lineCount }} total row(s)</span
+      >
+      <VBtn
+        color="primary"
+        medium
+        :disabled="!nonEmptyCount"
+        @click="submit"
+      >
+        Process
+      </VBtn>
+    </div>
+
+    <div
+      v-if="fileInfo"
+      class="margin-small-top"
+    >
+      <span class="subtle">
+        Loaded from: {{ fileInfo.name }} ({{ fileInfo.rowCount }} rows)
+      </span>
+    </div>
+  </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from "vue";
-import VBtn from "@/components/ui/VBtn/index.vue";
-import { useDropzonePasteManager } from "@/composables/useDropzonePasteManager";
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import VBtn from '@/components/ui/VBtn/index.vue'
+import { useDropzonePasteManager } from '@/composables/useDropzonePasteManager'
 
-const MAX_ROWS = 1000;
+const MAX_ROWS = 1000
 
-const emit = defineEmits(["submit"]);
+const emit = defineEmits(['submit'])
 
-const { registerPaster, unregisterPaster } = useDropzonePasteManager();
+const { registerPaster, unregisterPaster } = useDropzonePasteManager()
 
-const nameText = ref("");
-const isDragging = ref(false);
-const csvParsedData = ref(null);
-const fileInfo = ref(null);
-let pasteZone = null;
+const nameText = ref('')
+const isDragging = ref(false)
+const csvParsedData = ref(null)
+const fileInfo = ref(null)
+let pasteZone = null
 
-const lines = computed(() => nameText.value.split("\n").map((l) => l.trim()));
+const lines = computed(() => nameText.value.split('\n').map((l) => l.trim()))
 
-const nonEmptyCount = computed(() => lines.value.filter(Boolean).length);
+const nonEmptyCount = computed(() => lines.value.filter(Boolean).length)
 
-const lineCount = computed(() => lines.value.length);
+const lineCount = computed(() => lines.value.length)
 
 function submit() {
-    emit("submit", {
-        names: lines.value.slice(0, MAX_ROWS),
-        csv: csvParsedData.value,
-    });
+  emit('submit', {
+    names: lines.value.slice(0, MAX_ROWS),
+    csv: csvParsedData.value
+  })
 }
 
 function loadFile(file) {
-    const reader = new FileReader();
-    reader.onload = (e) => parseCSV(e.target.result, file.name);
-    reader.readAsText(file);
+  const reader = new FileReader()
+  reader.onload = (e) => parseCSV(e.target.result, file.name)
+  reader.readAsText(file)
 }
 
 function handleFileDrop(event) {
-    isDragging.value = false;
-    const file = event.dataTransfer?.files?.[0];
-    if (!file) return;
-    loadFile(file);
+  isDragging.value = false
+  const file = event.dataTransfer?.files?.[0]
+  if (!file) return
+  loadFile(file)
 }
 
 function handleFilePaste(event) {
-    const items = event.clipboardData?.items;
-    if (!items) return;
+  const items = event.clipboardData?.items
+  if (!items) return
 
-    for (const item of items) {
-        if (item.kind !== "file") continue;
-        const file = item.getAsFile();
-        if (!file) continue;
-        event.preventDefault();
-        loadFile(file);
-        return;
-    }
+  for (const item of items) {
+    if (item.kind !== 'file') continue
+    const file = item.getAsFile()
+    if (!file) continue
+    event.preventDefault()
+    loadFile(file)
+    return
+  }
 }
 
 onMounted(() => {
-    pasteZone = { handler: handleFilePaste, prioritize: false };
-    registerPaster(pasteZone);
-});
+  pasteZone = { handler: handleFilePaste, prioritize: false }
+  registerPaster(pasteZone)
+})
 
 onBeforeUnmount(() => {
-    unregisterPaster(pasteZone);
-});
+  unregisterPaster(pasteZone)
+})
 
 function parseCSV(text, fileName) {
-    const lines = text.split(/\r?\n/).filter((l) => l.trim());
-    if (lines.length < 2) {
-        TW.workbench.alert.create(
-            "CSV file appears empty or has no data rows.",
-            "error",
-        );
-        return;
+  const lines = text.split(/\r?\n/).filter((l) => l.trim())
+  if (lines.length < 2) {
+    TW.workbench.alert.create('CSV file appears empty or has no data rows.', 'error')
+    return
+  }
+
+  const headerLine = lines[0]
+  const delimiter = headerLine.includes('\t') ? '\t' : ','
+  const headers = parseCsvLine(headerLine, delimiter).map((h) => h.trim())
+
+  const scientificNameIndex = headers.findIndex(
+    (h) => h.toLowerCase() === 'scientificname'
+  )
+
+  if (scientificNameIndex < 0) {
+    TW.workbench.alert.create('CSV must have a "scientificName" column.', 'error')
+    return
+  }
+
+  const dataLines = lines.slice(1)
+  const names = []
+  const csvRows = []
+
+  dataLines.slice(0, MAX_ROWS).forEach((line) => {
+    const fields = parseCsvLine(line, delimiter)
+    const name = fields[scientificNameIndex]?.trim()
+
+    if (name) {
+      names.push(name)
+      const rowData = {}
+      headers.forEach((header, i) => {
+        rowData[header] = fields[i]?.trim() || ''
+      })
+      csvRows.push(rowData)
     }
+  })
 
-    const headerLine = lines[0];
-    const delimiter = headerLine.includes("\t") ? "\t" : ",";
-    const headers = parseCsvLine(headerLine, delimiter).map((h) => h.trim());
+  csvParsedData.value = {
+    headers,
+    rows: csvRows
+  }
 
-    const scientificNameIndex = headers.findIndex(
-        (h) => h.toLowerCase() === "scientificname",
-    );
+  fileInfo.value = {
+    name: fileName,
+    rowCount: names.length
+  }
 
-    if (scientificNameIndex < 0) {
-        TW.workbench.alert.create(
-            'CSV must have a "scientificName" column.',
-            "error",
-        );
-        return;
-    }
-
-    const dataLines = lines.slice(1);
-    const names = [];
-    const csvRows = [];
-
-    dataLines.slice(0, MAX_ROWS).forEach((line) => {
-        const fields = parseCsvLine(line, delimiter);
-        const name = fields[scientificNameIndex]?.trim();
-
-        if (name) {
-            names.push(name);
-            const rowData = {};
-            headers.forEach((header, i) => {
-                rowData[header] = fields[i]?.trim() || "";
-            });
-            csvRows.push(rowData);
-        }
-    });
-
-    csvParsedData.value = {
-        headers,
-        rows: csvRows,
-    };
-
-    fileInfo.value = {
-        name: fileName,
-        rowCount: names.length,
-    };
-
-    nameText.value = names.join("\n");
+  nameText.value = names.join('\n')
 }
 
 function parseCsvLine(line, delimiter) {
-    const fields = [];
-    let current = "";
-    let inQuotes = false;
+  const fields = []
+  let current = ''
+  let inQuotes = false
 
-    for (let i = 0; i < line.length; i++) {
-        const char = line[i];
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]
 
-        if (inQuotes) {
-            if (char === '"') {
-                if (i + 1 < line.length && line[i + 1] === '"') {
-                    current += '"';
-                    i++;
-                } else {
-                    inQuotes = false;
-                }
-            } else {
-                current += char;
-            }
+    if (inQuotes) {
+      if (char === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"'
+          i++
         } else {
-            if (char === '"') {
-                inQuotes = true;
-            } else if (char === delimiter) {
-                fields.push(current);
-                current = "";
-            } else {
-                current += char;
-            }
+          inQuotes = false
         }
+      } else {
+        current += char
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true
+      } else if (char === delimiter) {
+        fields.push(current)
+        current = ''
+      } else {
+        current += char
+      }
     }
+  }
 
-    fields.push(current);
-    return fields;
+  fields.push(current)
+  return fields
 }
 </script>
 
 <style scoped>
 .dropzone-area {
-    border: 2px dashed #ccc;
-    border-radius: 4px;
-    transition: border-color 0.2s;
+  border: 2px dashed #ccc;
+  border-radius: 4px;
+  transition: border-color 0.2s;
 }
 
 .dropzone-active {
-    border-color: #5bc0de;
-    background-color: #f0f9ff;
+  border-color: #5bc0de;
+  background-color: #f0f9ff;
 }
 
 .dropzone-area textarea {
-    border: none;
+  border: none;
 }
 
 .subtle {
-    color: #888;
-    font-size: 0.85em;
+  color: #888;
+  font-size: 0.85em;
 }
 </style>

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
@@ -13,7 +13,7 @@
     <!-- Scope to TaxonName -->
     <div class="flex-col gap-medium">
       <div class="field margin-medium-bottom">
-        <label>Scope to TaxonName</label>
+        <label data-help="Limit matches to names within this taxon's subtree.">Restrict matches to children of</label>
 
         <Autocomplete
           url="/taxon_names/autocomplete"
@@ -46,7 +46,7 @@
 
       <!-- Try without subgenus -->
       <div class="field margin-medium-bottom">
-        <label class="middle">
+        <label class="middle" data-help="When a name fails to match, also tries matching against stored names stripped of their subgenus (e.g. input 'Aus cus' will match a stored name 'Aus (Bus) cus').">
           <input
             type="checkbox"
             :checked="tryWithoutSubgenus"
@@ -97,7 +97,7 @@
 
       <!-- Modifiers -->
       <div class="field">
-        <label>Modifiers</label>
+        <label data-help="Regex find-and-replace rules applied to the match string before searching. Each active row is applied in sequence.">Modifiers</label>
         <div class="modifier-header">
           <span />
           <span class="subtle">Replace this</span>

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -16,7 +16,7 @@
         <th />
         <th data-help="Manually search for and select a TaxonName, overriding the automatic match result. Use this to fix incorrect or ambiguous matches.">Refine</th>
         <th>OTU <ButtonClipboard :text="columnClipboardText('otuLabel')" title="Copy OTU column" /></th>
-        <th>OTU id <ButtonClipboard :text="columnClipboardText('otuId')" title="Copy OTU id column" /></th>
+        <th class="line-nowrap">OTU id <ButtonClipboard :text="columnClipboardText('otuId')" title="Copy OTU id column" /></th>
         <th />
         <th>Set</th>
       </tr>

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -11,10 +11,10 @@
         </th>
         <th />
         <th>scientificName <ButtonClipboard :text="columnClipboardText('scientificName')" title="Copy scientificName column" /></th>
-        <th>Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
+        <th data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
         <th>TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
         <th />
-        <th>Refine</th>
+        <th data-help="Manually search for and select a TaxonName, overriding the automatic match result. Use this to fix incorrect or ambiguous matches.">Refine</th>
         <th>OTU <ButtonClipboard :text="columnClipboardText('otuLabel')" title="Copy OTU column" /></th>
         <th>OTU id <ButtonClipboard :text="columnClipboardText('otuId')" title="Copy OTU id column" /></th>
         <th />

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -10,13 +10,13 @@
           />
         </th>
         <th />
-        <th>scientificName</th>
-        <th>Match</th>
-        <th>TaxonName</th>
+        <th>scientificName <ButtonClipboard :text="columnClipboardText('scientificName')" title="Copy scientificName column" /></th>
+        <th>Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
+        <th>TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
         <th />
         <th>Refine</th>
-        <th>OTU</th>
-        <th>OTU id</th>
+        <th>OTU <ButtonClipboard :text="columnClipboardText('otuLabel')" title="Copy OTU column" /></th>
+        <th>OTU id <ButtonClipboard :text="columnClipboardText('otuId')" title="Copy OTU id column" /></th>
         <th />
         <th>Set</th>
       </tr>
@@ -235,6 +235,7 @@ import VIcon from '@/components/ui/VIcon/index.vue'
 import Autocomplete from '@/components/ui/Autocomplete.vue'
 import RadialAnnotator from '@/components/radials/annotator/annotator.vue'
 import RadialNavigator from '@/components/radials/navigation/radial.vue'
+import ButtonClipboard from '@/components/ui/Button/ButtonClipboard.vue'
 
 const props = defineProps({
   rows: {
@@ -310,6 +311,29 @@ function openContext(row) {
   if (row.csvRow) {
     contextRow.value = row
   }
+}
+
+function columnClipboardText(field) {
+  const values = props.rows.map((row) => {
+    switch (field) {
+      case 'scientificName':
+        return row.scientificName || ''
+      case 'match':
+        return row.matchString || row.scientificName || ''
+      case 'taxonName':
+        return row.taxonName?.cached || ''
+      case 'otuLabel': {
+        const otu = row.otus.find((o) => o.id === row.selectedOtuId)
+        return otu?.object_label || otu?.name || ''
+      }
+      case 'otuId':
+        return row.selectedOtuId != null ? String(row.selectedOtuId) : ''
+      default:
+        return ''
+    }
+  })
+
+  return values.join('\n')
 }
 </script>
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/constants.js
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/constants.js
@@ -1,0 +1,1 @@
+export const MAX_ROWS = 3000

--- a/lib/match/otu/taxon_name.rb
+++ b/lib/match/otu/taxon_name.rb
@@ -26,7 +26,7 @@ module Match
   module Otu
     class TaxonName
 
-      MAX_NAMES = 1000
+      MAX_NAMES = 3000
       MATCHABLE_COLUMNS = [
         :cached, :cached_secondary_homonym, :cached_primary_homonym
       ].freeze

--- a/lib/match/otu/taxon_name.rb
+++ b/lib/match/otu/taxon_name.rb
@@ -27,6 +27,9 @@ module Match
     class TaxonName
 
       MAX_NAMES = 1000
+      MATCHABLE_COLUMNS = [
+        :cached, :cached_secondary_homonym, :cached_primary_homonym
+      ].freeze
 
       attr_reader :names, :project_id, :levenshtein_distance, :taxon_name_id, :resolve_synonyms, :try_without_subgenus
 
@@ -39,7 +42,7 @@ module Match
       def initialize(names:, project_id:, levenshtein_distance: 0, taxon_name_id: nil, resolve_synonyms: false, try_without_subgenus: false)
         @names = names.first(MAX_NAMES)
         @project_id = project_id
-        @levenshtein_distance = levenshtein_distance.to_i
+        @levenshtein_distance = levenshtein_distance.to_i.clamp(0, 8)
         @taxon_name_id = taxon_name_id
         @resolve_synonyms = resolve_synonyms
         @try_without_subgenus = try_without_subgenus
@@ -74,20 +77,19 @@ module Match
         return { taxon_name_id: nil, taxon_name: nil, otus: [], ambiguous: false, matched: false } if taxon_names.empty?
 
         ranked = rank_taxon_names(taxon_names)
-        best = ranked.first
+        matched = ranked.first
+        resolved = matched
 
-        taxon_name_for_otus = best
-
-        if resolve_synonyms && best.cached_valid_taxon_name_id != best.id
-          valid = ::TaxonName.where(project_id: project_id).find_by(id: best.cached_valid_taxon_name_id)
-          taxon_name_for_otus = valid if valid
+        if resolve_synonyms && matched.cached_valid_taxon_name_id != matched.id
+          valid = ::TaxonName.where(project_id: project_id).find_by(id: matched.cached_valid_taxon_name_id)
+          resolved = valid if valid
         end
 
-        otus = ::Otu.where(project_id: project_id, taxon_name_id: taxon_name_for_otus.id).to_a
+        otus = ::Otu.where(project_id: project_id, taxon_name_id: resolved.id).to_a
 
         {
-          taxon_name_id: best.id,
-          taxon_name: best,
+          taxon_name_id: resolved.id,
+          taxon_name: resolved,
           otus: otus,
           ambiguous: ranked.length > 1,
           matched: true
@@ -98,6 +100,8 @@ module Match
       # @param column [Symbol] :cached, :cached_secondary_homonym, or :cached_primary_homonym
       # @return [Array<TaxonName>]
       def find_taxon_names(name, column: :cached)
+        raise ArgumentError, "Invalid column: #{column}" unless MATCHABLE_COLUMNS.include?(column)
+
         if levenshtein_distance > 0
           find_taxon_names_fuzzy(name, column:)
         else
@@ -113,24 +117,19 @@ module Match
         scope.where(column => name).to_a
       end
 
-      MATCHABLE_COLUMNS = [:cached, :cached_secondary_homonym, :cached_primary_homonym].freeze
-
       # @param name [String]
       # @param column [Symbol]
       # @return [Array<TaxonName>]
       def find_taxon_names_fuzzy(name, column: :cached)
-        raise ArgumentError, "Invalid column: #{column}" unless MATCHABLE_COLUMNS.include?(column)
-
         scope = base_scope
         truncated_name = name[0..254]
-        distance = [levenshtein_distance, 8].min
         qualified_column = "taxon_names.#{column}"
 
         scope
           .where(
             "levenshtein(left(#{qualified_column}, 255), ?) <= ?",
             truncated_name,
-            distance
+            levenshtein_distance
           )
           .order(
             Arel.sql(

--- a/spec/lib/match/otu/taxon_name_spec.rb
+++ b/spec/lib/match/otu/taxon_name_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe Match::Otu::TaxonName, type: :model do
+  let(:root)  { FactoryBot.create(:root_taxon_name) }
+  let(:genus) { Protonym.create!(name: 'Aus', rank_class: Ranks.lookup(:iczn, :genus), parent: root) }
+
+  let(:valid_species) do
+    Protonym.create!(name: 'bus', rank_class: Ranks.lookup(:iczn, :species), parent: genus)
+  end
+
+  let(:synonym_species) do
+    Protonym.create!(name: 'cus', rank_class: Ranks.lookup(:iczn, :species), parent: genus)
+  end
+
+  let!(:synonym_relationship) do
+    TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(
+      subject_taxon_name: synonym_species,
+      object_taxon_name: valid_species
+    )
+  end
+
+  let(:project_id) { synonym_species.project_id }
+
+  def match(names:, **opts)
+    Match::Otu::TaxonName.new(names:, project_id:, **opts).call
+  end
+
+  context 'resolve_synonyms' do
+    context 'when the valid name has an OTU and the synonym does not' do
+      let!(:valid_otu) { Otu.create!(taxon_name: valid_species) }
+
+      specify 'returns the valid name and its OTU' do
+        result = match(names: [synonym_species.cached], resolve_synonyms: true).first
+        expect(result[:taxon_name_id]).to eq(valid_species.id)
+        expect(result[:otus].map(&:id)).to contain_exactly(valid_otu.id)
+      end
+    end
+
+    context 'when the synonym has an OTU but the valid name does not' do
+      let!(:synonym_otu) { Otu.create!(taxon_name: synonym_species) }
+
+      specify 'returns the valid name with no OTUs, not the synonym' do
+        result = match(names: [synonym_species.cached], resolve_synonyms: true).first
+        expect(result[:taxon_name_id]).to eq(valid_species.id)
+        expect(result[:otus]).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some small adjustments on the Match OTUs task:
* raised the names limit to 3k from 1k - we discussed raising it to 10k in chat, but at 5k (with the current code) Chrome warned that the browser was unresponsive when building the table.
  * At 3k, building the table takes around 10s, doing the matching takes around 10s
  * Maybe we'll want to switch to a virtual scroll if we really want to support higher limits (@jlpereira)

* Added a 'copy column' button to the columns it makes sense for - in practice I just wanted the `otu_id` column since I already had the scientific name column.
<img width="1265" height="200" alt="image" src="https://github.com/user-attachments/assets/c145c617-c1fe-4ee8-b9f2-8a32b2e1f8ff" />

* Made the regexes apply when the user clicks the 'Match' button
* Added help bubbles to columns/options I didn't really understand and to explain what clicking an individual row does
* Added support for ctrl+v csv pasting in addition to drag-and-drop