### PR TITLE
Combination touchups

### DIFF
--- a/app/models/combination.rb
+++ b/app/models/combination.rb
@@ -722,9 +722,8 @@ class Combination < TaxonName
       begin
         TaxonName.transaction do
           # update_column(:parent_id, check.parent_id) ## do not use this, it breaks the taxon_name_hierarchies
-          parent_id = check.parent_id
-          self.save
-          return true
+          self.parent_id = check.parent_id
+          return true if self.save
         end
       rescue
       end

--- a/app/models/taxon_name_classification/latinized/gender.rb
+++ b/app/models/taxon_name_classification/latinized/gender.rb
@@ -43,12 +43,15 @@ class TaxonNameClassification::Latinized::Gender < TaxonNameClassification::Lati
     end
 
     TaxonNameRelationship::Combination.where(subject_taxon_name: t).collect{|i| i.object_taxon_name}.uniq.each do |t1|
-      t1.update_column(:verbatim_name, t1.cached) if t1.verbatim_name.nil?
-      n = t1.get_full_name
-      t1.update_columns(
-        cached: n,
-        cached_html: t1.get_full_name_html(n)
-      )
+      next if t1.verbatim_name.present? # already pinned to an explicit citation, leave it alone
+
+      fresh_name = t1.get_full_name # verbatim_name is blank here, so this recomputes under the new gender
+      next if fresh_name == t1.cached # gender change didn't alter the spelling, nothing to preserve
+
+      # The ending changed - freeze the pre-change spelling as the historical
+      # citation.
+      # cached/cached_html are already correct for this verbatim_name.
+      t1.update_column(:verbatim_name, t1.cached)
     end
   end
 

--- a/spec/models/combination_spec.rb
+++ b/spec/models/combination_spec.rb
@@ -378,6 +378,27 @@ describe Combination, type: :model, group: :nomenclature do
       combination.soft_validate(only_sets: :incomplete_combination)
       expect(combination.soft_validations.messages_on(:base).count).to eq(2)
     end
+
+    context 'sv_fix_combination_parent_update' do
+      specify 'corrects a parent_id that no longer matches the genus protonym' do
+        basic_combination.save!
+        basic_combination.update_column(:parent_id, subgenus.id)
+
+        basic_combination.soft_validate(only_sets: :combination_linked_to_valid_name, include_flagged: true)
+        basic_combination.fix_soft_validations
+
+        expect(basic_combination.reload.parent_id).to eq(genus.parent_id)
+      end
+
+      specify 'returns false and leaves parent_id unchanged when the save fails' do
+        basic_combination.save!
+        basic_combination.update_column(:parent_id, subgenus.id)
+        allow(basic_combination).to receive(:save).and_return(false)
+
+        expect(basic_combination.send(:sv_fix_combination_parent_update)).to be_falsey
+        expect(basic_combination.reload.parent_id).to eq(subgenus.id)
+      end
+    end
   end
 
     specify '#cached combination' do

--- a/spec/models/taxon_name_classification/latinized/gender_spec.rb
+++ b/spec/models/taxon_name_classification/latinized/gender_spec.rb
@@ -41,4 +41,63 @@ describe TaxonNameClassification::Latinized::Gender, type: :model, group: [:nome
     expect(classification.errors[:taxon_name]).to include('Gender is only applicable to genus names')
   end
 
+  context 'subsequent combinations' do
+    let(:genus) { FactoryBot.create(:iczn_genus) }
+
+    let(:species) {
+      Protonym.create!(
+        name: 'alta',
+        masculine_name: 'altus',
+        feminine_name: 'alta',
+        parent: genus,
+        rank_class: Ranks.lookup(:iczn, :species)
+      )
+    }
+
+    let(:combination) { Combination.create!(genus: genus, species: species) }
+
+    specify 'freezes verbatim_name to the pre-change spelling when the gender change alters the ending' do
+      masculine = TaxonNameClassification::Latinized::Gender::Masculine.create!(taxon_name: genus)
+      expect(combination.reload.cached).to include('altus')
+
+      masculine.destroy
+      TaxonNameClassification::Latinized::Gender::Feminine.create!(taxon_name: genus)
+      combination.reload
+
+      expect(combination.verbatim_name).to include('altus')
+      expect(combination.cached).to include('altus') # left as the pre-change (now pinned) spelling
+    end
+
+    specify 'does not set verbatim_name when the gender change does not alter the ending' do
+      invariant_species = Protonym.create!(
+        name: 'nigra',
+        masculine_name: 'nigra',
+        feminine_name: 'nigra',
+        parent: genus,
+        rank_class: Ranks.lookup(:iczn, :species)
+      )
+      invariant_combination = Combination.create!(genus: genus, species: invariant_species)
+
+      masculine = TaxonNameClassification::Latinized::Gender::Masculine.create!(taxon_name: genus)
+      expect(invariant_combination.reload.verbatim_name).to be_nil
+
+      masculine.destroy
+      TaxonNameClassification::Latinized::Gender::Feminine.create!(taxon_name: genus)
+      invariant_combination.reload
+
+      expect(invariant_combination.verbatim_name).to be_nil
+      expect(invariant_combination.cached).to include('nigra')
+    end
+
+    specify 'leaves an already-explicit verbatim_name untouched' do
+      explicit_combination = Combination.create!(genus: genus, species: species, verbatim_name: 'Verbatimus explicitus')
+
+      TaxonNameClassification::Latinized::Gender::Masculine.create!(taxon_name: genus)
+      explicit_combination.reload
+
+      expect(explicit_combination.verbatim_name).to eq('Verbatimus explicitus')
+      expect(explicit_combination.cached).to eq('Verbatimus explicitus')
+    end
+  end
+
 end


### PR DESCRIPTION
@mjy/@proceps I think the first commmit is a straightforward fix, but please take a look at the second commit:

While investigating issues related to the SV fix I got onto this code that's come up in CCs several times that auto-adds a verbatim name to Combinations whenever a gender on the combination's genus is added and the Combination doesn't already have a verbatim name. 

The change here is that we now only add the verbatim name when the gender change actually changes an ending - the thinking being that
* we don't want to be using verbatim names more than needed, and
* it's not generally clear to users why this verbatim name shows up in the first place, so let's limit when we add it.

Am I missing anything?