### PR TITLE
Match Taxon Names to OTU ids task updates

### DIFF
--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -347,6 +347,15 @@ function syncAllDuplicates() {
 }
 
 function clearAllMatches() {
+  scopeTaxonName.value = null
+  levenshteinDistance.value = 0
+  tryWithoutSubgenus.value = false
+  resolveSynonyms.value = false
+  modifiers.value = [
+    { active: false, pattern: '^(\\S*\\s+\\S*).*', replacement: '$1' },
+    { active: false, pattern: '', replacement: '' }
+  ]
+
   rows.value.forEach((row) => {
     row.taxonName = null
     row.taxonNameId = null
@@ -357,6 +366,8 @@ function clearAllMatches() {
     row.regexMatchString = ''
     row.userMatchString = ''
   })
+
+  handleOptionsChange()
 }
 
 function scrollToRow(index) {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -17,15 +17,6 @@
           <div class="panel content">
             <div class="flex-row flex-separate middle">
               <VBtn
-                color="primary"
-                medium
-                :disabled="!rows.length"
-                data-help="Re-matches all rows using current settings. To re-match only specific rows, check their checkboxes — each checked row auto-matches immediately using current settings and auto-updates when settings are changed."
-                @click="runMatch({ matchAll: true })"
-              >
-                Match
-              </VBtn>
-              <VBtn
                 circle
                 color="primary"
                 title="Reset task"
@@ -46,7 +37,7 @@
             v-model:resolve-synonyms="resolveSynonyms"
             v-model:modifiers="modifiers"
             @clear-all="clearAllMatches"
-            @update-options="runMatch"
+            @update-options="handleOptionsChange"
           />
         </div>
 
@@ -63,7 +54,7 @@
               @update-row="handleRowUpdate"
               @create-otu="handleCreateOtu"
               @scroll-to-row="scrollToRow"
-              @update-selection="() => runMatch()"
+              @match-row="handleMatchRow"
             />
           </div>
         </div>
@@ -127,7 +118,8 @@ async function handleDataSubmit({ names, csv }) {
     return {
       index,
       scientificName: isEmpty ? '' : name,
-      matchString: '',
+      regexMatchString: '',
+      userMatchString: '',
       taxonName: null,
       taxonNameId: null,
       otus: [],
@@ -142,7 +134,7 @@ async function handleDataSubmit({ names, csv }) {
 
   stage.value = 'results'
 
-  runMatch({ matchAll: true })
+  handleOptionsChange()
 }
 
 function applyModifiers(name) {
@@ -162,36 +154,38 @@ function applyModifiers(name) {
   return result.trim()
 }
 
-function computeMatchStrings(matchAll = false) {
+function scopedRows() {
+  const checked = rows.value.filter((r) => r.selected && !r.isEmpty)
+  return checked.length ? checked : rows.value.filter((r) => !r.isEmpty)
+}
+
+function applyModifiersToRows(targetRows) {
   const hasActiveModifier = modifiers.value.some((m) => m.active && m.pattern)
-
-  rows.value.forEach((row) => {
-    if (row.isEmpty) return
-
-    if (hasActiveModifier && (row.selected || matchAll)) {
-      row.matchString = applyModifiers(row.scientificName)
-    } else if (!row.selected && !matchAll) {
-      // Don't change matchString for unselected rows
-    } else {
-      row.matchString = ''
-    }
+  targetRows.forEach((row) => {
+    row.regexMatchString = hasActiveModifier ? applyModifiers(row.scientificName) : ''
   })
 }
 
-async function runMatch({ matchAll = false } = {}) {
-  computeMatchStrings(matchAll)
-  syncAllDuplicates()
+async function handleOptionsChange() {
+  const target = scopedRows()
+  applyModifiersToRows(target)
+  await matchRows(target)
+}
 
-  const checkedRows = rows.value.filter((r) => r.selected && !r.isEmpty)
-  const selectedRows = matchAll
-    ? rows.value.filter((r) => !r.isEmpty)
-    : checkedRows
-  if (!selectedRows.length) return
+async function handleMatchRow({ index }) {
+  const row = rows.value[index]
+  if (!row || row.isEmpty) return
+  await matchRows([row])
+}
+
+async function matchRows(targetRows) {
+  syncAllDuplicates()
+  if (!targetRows.length) return
 
   const nameMap = new Map()
 
-  selectedRows.forEach((row) => {
-    const effectiveName = row.matchString || row.scientificName
+  targetRows.forEach((row) => {
+    const effectiveName = row.userMatchString || row.regexMatchString || row.scientificName
     if (!nameMap.has(effectiveName)) {
       nameMap.set(effectiveName, [])
     }
@@ -253,8 +247,8 @@ function handleRowUpdate({ index, field, value }) {
     }
 
     syncDuplicateRows(row)
-  } else if (field === 'matchString') {
-    row.matchString = value
+  } else if (field === 'userMatchString') {
+    row.userMatchString = value
   } else if (field === 'selected') {
     row.selected = value
   } else if (field === 'selectedOtuId') {
@@ -307,14 +301,17 @@ async function handleCreateOtu({ index }) {
   }
 }
 
+function effectiveName(row) {
+  return row.userMatchString || row.regexMatchString || row.scientificName
+}
+
 function syncDuplicateRows(sourceRow) {
-  const sourceName = sourceRow.matchString || sourceRow.scientificName
+  const sourceName = effectiveName(sourceRow)
 
   rows.value.forEach((row) => {
     if (row.index === sourceRow.index) return
 
-    const rowName = row.matchString || row.scientificName
-    if (rowName === sourceName) {
+    if (effectiveName(row) === sourceName) {
       row.taxonName = sourceRow.taxonName
       row.taxonNameId = sourceRow.taxonNameId
       row.otus = sourceRow.otus
@@ -333,7 +330,7 @@ function syncAllDuplicates() {
   rows.value.forEach((row) => {
     if (row.isEmpty) return
 
-    const name = row.matchString || row.scientificName
+    const name = effectiveName(row)
     if (!seen.has(name)) {
       seen.set(name, row)
     } else {
@@ -357,7 +354,8 @@ function clearAllMatches() {
     row.selectedOtuId = null
     row.ambiguous = false
     row.matched = false
-    row.matchString = ''
+    row.regexMatchString = ''
+    row.userMatchString = ''
   })
 }
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -245,23 +245,21 @@ function handleRowUpdate({ index, field, value }) {
   if (!row) return
 
   if (field === 'taxonName') {
-    applyMatchResult(row, {
-      taxonName: null,
-      taxonNameId: value?.id || null,
-      otus: [],
-      selectedOtuId: null,
-      ambiguous: false,
-      matched: !!value
-    })
-
     if (value) {
       // The autocomplete result doesn't include cached_html (only label/label_html,
       // meant for the dropdown itself), so re-fetch the full record for display.
-      loadTaxonName(value.id, row)
-      loadOtusForTaxonName(value.id, row)
+      refreshTaxonNameSelection(value.id, row)
+    } else {
+      applyMatchResult(row, {
+        taxonName: null,
+        taxonNameId: null,
+        otus: [],
+        selectedOtuId: null,
+        ambiguous: false,
+        matched: false
+      })
+      syncDuplicateRows(row)
     }
-
-    syncDuplicateRows(row)
   } else if (field === 'userMatchString') {
     row.userMatchString = value
   } else if (field === 'selected') {
@@ -272,32 +270,54 @@ function handleRowUpdate({ index, field, value }) {
   }
 }
 
-async function loadTaxonName(taxonNameId, row) {
+// Fetches the full TaxonName record (for cached_html, not present on the
+// autocomplete result) and its OTUs together, then applies both to the row
+// in one step and syncs duplicates once — the row's prior match stays on
+// screen, under the full-screen spinner, until the refetch settles, instead
+// of flashing blank/partial state while it loads or on failure.
+async function refreshTaxonNameSelection(taxonNameId, row) {
+  isProcessing.value = true
+
   try {
-    const { body } = await TaxonName.find(taxonNameId)
-    row.taxonName = body
+    const [taxonName, otus] = await Promise.all([
+      fetchTaxonName(taxonNameId),
+      fetchOtusForTaxonName(taxonNameId)
+    ])
+
+    applyMatchResult(row, {
+      taxonName,
+      taxonNameId,
+      otus,
+      selectedOtuId: otus.length ? otus[0].id : null,
+      ambiguous: false,
+      matched: true
+    })
+
     syncDuplicateRows(row)
   } catch (e) {
-    console.error('Failed to load TaxonName:', e)
+    TW.workbench.alert.create(
+      'Error loading TaxonName/OTU details. See console for details.',
+      'error'
+    )
+    console.error(e)
+  } finally {
+    isProcessing.value = false
   }
 }
 
-async function loadOtusForTaxonName(taxonNameId, row) {
-  try {
-    const { body } = await TaxonName.otus(taxonNameId)
-    row.otus = sortOtus(body.map((o) => ({
-      id: o.id,
-      name: o.name,
-      taxon_name_id: o.taxon_name_id,
-      object_label: o.object_label
-    })))
-    if (row.otus.length) {
-      row.selectedOtuId = row.otus[0].id
-    }
-    syncDuplicateRows(row)
-  } catch (e) {
-    console.error('Failed to load OTUs:', e)
-  }
+async function fetchTaxonName(taxonNameId) {
+  const { body } = await TaxonName.find(taxonNameId)
+  return body
+}
+
+async function fetchOtusForTaxonName(taxonNameId) {
+  const { body } = await TaxonName.otus(taxonNameId)
+  return sortOtus(body.map((o) => ({
+    id: o.id,
+    name: o.name,
+    taxon_name_id: o.taxon_name_id,
+    object_label: o.object_label
+  })))
 }
 
 async function handleCreateOtu({ index }) {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -75,12 +75,13 @@ import SummaryBar from './components/SummaryBar.vue'
 import MatchOptionsPanel from './components/MatchOptionsPanel.vue'
 import { MAX_ROWS, defaultModifiers } from './constants.js'
 import effectiveName from './utils/effectiveName.js'
+import sortOtus from './utils/sortOtus.js'
 
 defineOptions({
   name: 'MatchOtuByTaxonName'
 })
 
-const stage = ref('input')
+const stage = ref('input') // 'input' or 'results'
 const isProcessing = ref(false)
 const rows = ref([])
 const csvData = ref(null)
@@ -99,10 +100,12 @@ onMounted(() => {
   const taxonNameId = urlParams.get('taxon_name_id')
 
   if (taxonNameId) {
-    TaxonName.find(taxonNameId).then(({ body }) => {
-      scopeTaxonName.value = body
-      initialScopeTaxonName.value = body
-    })
+    TaxonName.find(taxonNameId)
+      .then(({ body }) => {
+        scopeTaxonName.value = body
+        initialScopeTaxonName.value = body
+      })
+      .catch(() => {})
   }
 })
 
@@ -212,12 +215,14 @@ async function matchRows(targetRows) {
       const matchedRows = nameMap.get(result.scientific_name)
       if (!matchedRows) return
 
+      const otus = sortOtus(result.otus || [])
+
       matchedRows.forEach((row) => {
         applyMatchResult(row, {
           taxonName: result.taxon_name,
           taxonNameId: result.taxon_name_id,
-          otus: result.otus || [],
-          selectedOtuId: result.otus?.length ? result.otus[0].id : null,
+          otus,
+          selectedOtuId: otus.length ? otus[0].id : null,
           ambiguous: result.ambiguous,
           matched: result.matched
         })
@@ -267,12 +272,12 @@ function handleRowUpdate({ index, field, value }) {
 async function loadOtusForTaxonName(taxonNameId, row) {
   try {
     const { body } = await TaxonName.otus(taxonNameId)
-    row.otus = body.map((o) => ({
+    row.otus = sortOtus(body.map((o) => ({
       id: o.id,
       name: o.name,
       taxon_name_id: o.taxon_name_id,
       object_label: o.object_label
-    }))
+    })))
     if (row.otus.length) {
       row.selectedOtuId = row.otus[0].id
     }

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -210,12 +210,14 @@ async function matchRows(targetRows) {
       if (!matchedRows) return
 
       matchedRows.forEach((row) => {
-        row.taxonName = result.taxon_name
-        row.taxonNameId = result.taxon_name_id
-        row.otus = result.otus || []
-        row.selectedOtuId = result.otus?.length ? result.otus[0].id : null
-        row.ambiguous = result.ambiguous
-        row.matched = result.matched
+        applyMatchResult(row, {
+          taxonName: result.taxon_name,
+          taxonNameId: result.taxon_name_id,
+          otus: result.otus || [],
+          selectedOtuId: result.otus?.length ? result.otus[0].id : null,
+          ambiguous: result.ambiguous,
+          matched: result.matched
+        })
       })
     })
   } catch (e) {
@@ -235,12 +237,14 @@ function handleRowUpdate({ index, field, value }) {
   if (!row) return
 
   if (field === 'taxonName') {
-    row.taxonName = value
-    row.taxonNameId = value?.id || null
-    row.otus = []
-    row.selectedOtuId = null
-    row.ambiguous = false
-    row.matched = !!value
+    applyMatchResult(row, {
+      taxonName: value,
+      taxonNameId: value?.id || null,
+      otus: [],
+      selectedOtuId: null,
+      ambiguous: false,
+      matched: !!value
+    })
 
     if (value) {
       loadOtusForTaxonName(value.id, row)
@@ -305,6 +309,15 @@ function effectiveName(row) {
   return row.userMatchString || row.regexMatchString || row.scientificName
 }
 
+function applyMatchResult(row, source) {
+  row.taxonName = source.taxonName
+  row.taxonNameId = source.taxonNameId
+  row.otus = source.otus
+  row.selectedOtuId = source.selectedOtuId
+  row.ambiguous = source.ambiguous
+  row.matched = source.matched
+}
+
 function syncDuplicateRows(sourceRow) {
   const sourceName = effectiveName(sourceRow)
 
@@ -312,12 +325,7 @@ function syncDuplicateRows(sourceRow) {
     if (row.index === sourceRow.index) return
 
     if (effectiveName(row) === sourceName) {
-      row.taxonName = sourceRow.taxonName
-      row.taxonNameId = sourceRow.taxonNameId
-      row.otus = sourceRow.otus
-      row.selectedOtuId = sourceRow.selectedOtuId
-      row.ambiguous = sourceRow.ambiguous
-      row.matched = sourceRow.matched
+      applyMatchResult(row, sourceRow)
     }
   })
 }
@@ -335,12 +343,7 @@ function syncAllDuplicates() {
       seen.set(name, row)
     } else {
       const source = seen.get(name)
-      row.taxonName = source.taxonName
-      row.taxonNameId = source.taxonNameId
-      row.otus = source.otus
-      row.selectedOtuId = source.selectedOtuId
-      row.ambiguous = source.ambiguous
-      row.matched = source.matched
+      applyMatchResult(row, source)
       row.selected = false
     }
   })
@@ -365,6 +368,7 @@ function clearAllMatches() {
     row.matched = false
     row.regexMatchString = ''
     row.userMatchString = ''
+    row.selected = false
   })
 
   handleOptionsChange()

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -90,6 +90,10 @@ const levenshteinDistance = ref(0)
 const tryWithoutSubgenus = ref(false)
 const resolveSynonyms = ref(false)
 
+// The scope the task was actually launched with (via ?taxon_name_id=), so
+// Restart/Reset can return to it instead of always clearing to no scope.
+const initialScopeTaxonName = ref(null)
+
 onMounted(() => {
   const urlParams = new URLSearchParams(window.location.search)
   const taxonNameId = urlParams.get('taxon_name_id')
@@ -97,6 +101,7 @@ onMounted(() => {
   if (taxonNameId) {
     TaxonName.find(taxonNameId).then(({ body }) => {
       scopeTaxonName.value = body
+      initialScopeTaxonName.value = body
     })
   }
 })
@@ -344,7 +349,7 @@ function syncAllDuplicates() {
 }
 
 function resetMatchOptions() {
-  scopeTaxonName.value = null
+  scopeTaxonName.value = initialScopeTaxonName.value
   levenshteinDistance.value = 0
   tryWithoutSubgenus.value = false
   resolveSynonyms.value = false

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -246,7 +246,7 @@ function handleRowUpdate({ index, field, value }) {
 
   if (field === 'taxonName') {
     applyMatchResult(row, {
-      taxonName: value,
+      taxonName: null,
       taxonNameId: value?.id || null,
       otus: [],
       selectedOtuId: null,
@@ -255,6 +255,9 @@ function handleRowUpdate({ index, field, value }) {
     })
 
     if (value) {
+      // The autocomplete result doesn't include cached_html (only label/label_html,
+      // meant for the dropdown itself), so re-fetch the full record for display.
+      loadTaxonName(value.id, row)
       loadOtusForTaxonName(value.id, row)
     }
 
@@ -266,6 +269,16 @@ function handleRowUpdate({ index, field, value }) {
   } else if (field === 'selectedOtuId') {
     row.selectedOtuId = value
     syncDuplicateRows(row)
+  }
+}
+
+async function loadTaxonName(taxonNameId, row) {
+  try {
+    const { body } = await TaxonName.find(taxonNameId)
+    row.taxonName = body
+    syncDuplicateRows(row)
+  } catch (e) {
+    console.error('Failed to load TaxonName:', e)
   }
 }
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -73,7 +73,7 @@ import InputPanel from './components/InputPanel.vue'
 import ResultTable from './components/ResultTable.vue'
 import SummaryBar from './components/SummaryBar.vue'
 import MatchOptionsPanel from './components/MatchOptionsPanel.vue'
-import { MAX_ROWS } from './constants.js'
+import { MAX_ROWS, defaultModifiers } from './constants.js'
 
 defineOptions({
   name: 'MatchOtuByTaxonName'
@@ -100,10 +100,7 @@ onMounted(() => {
   }
 })
 
-const modifiers = ref([
-  { active: false, pattern: '^(\\S*\\s+\\S*).*', replacement: '$1' },
-  { active: false, pattern: '', replacement: '' }
-])
+const modifiers = ref(defaultModifiers())
 
 async function handleDataSubmit({ names, csv }) {
   isProcessing.value = true
@@ -349,15 +346,16 @@ function syncAllDuplicates() {
   })
 }
 
-function clearAllMatches() {
+function resetMatchOptions() {
   scopeTaxonName.value = null
   levenshteinDistance.value = 0
   tryWithoutSubgenus.value = false
   resolveSynonyms.value = false
-  modifiers.value = [
-    { active: false, pattern: '^(\\S*\\s+\\S*).*', replacement: '$1' },
-    { active: false, pattern: '', replacement: '' }
-  ]
+  modifiers.value = defaultModifiers()
+}
+
+function clearAllMatches() {
+  resetMatchOptions()
 
   rows.value.forEach((row) => {
     row.taxonName = null
@@ -387,14 +385,7 @@ function reset() {
   stage.value = 'input'
   rows.value = []
   csvData.value = null
-  scopeTaxonName.value = null
-  levenshteinDistance.value = 0
-  tryWithoutSubgenus.value = false
-  resolveSynonyms.value = false
-  modifiers.value = [
-    { active: false, pattern: '^(\\S*\\s+\\S*).*', replacement: '$1' },
-    { active: false, pattern: '', replacement: '' }
-  ]
+  resetMatchOptions()
 }
 </script>
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -74,6 +74,7 @@ import ResultTable from './components/ResultTable.vue'
 import SummaryBar from './components/SummaryBar.vue'
 import MatchOptionsPanel from './components/MatchOptionsPanel.vue'
 import { MAX_ROWS, defaultModifiers } from './constants.js'
+import effectiveName from './utils/effectiveName.js'
 
 defineOptions({
   name: 'MatchOtuByTaxonName'
@@ -182,11 +183,11 @@ async function matchRows(targetRows) {
   const nameMap = new Map()
 
   targetRows.forEach((row) => {
-    const effectiveName = row.userMatchString || row.regexMatchString || row.scientificName
-    if (!nameMap.has(effectiveName)) {
-      nameMap.set(effectiveName, [])
+    const name = effectiveName(row)
+    if (!nameMap.has(name)) {
+      nameMap.set(name, [])
     }
-    nameMap.get(effectiveName).push(row)
+    nameMap.get(name).push(row)
   })
 
   const uniqueNames = [...nameMap.keys()]
@@ -300,10 +301,6 @@ async function handleCreateOtu({ index }) {
     TW.workbench.alert.create('Failed to create OTU.', 'error')
     console.error(e)
   }
-}
-
-function effectiveName(row) {
-  return row.userMatchString || row.regexMatchString || row.scientificName
 }
 
 function applyMatchResult(row, source) {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -31,6 +31,7 @@
           </div>
 
           <MatchOptionsPanel
+            class="sticky-panel"
             v-model:scope-taxon-name="scopeTaxonName"
             v-model:levenshtein-distance="levenshteinDistance"
             v-model:try-without-subgenus="tryWithoutSubgenus"
@@ -430,6 +431,19 @@ function reset() {
 </script>
 
 <style scoped>
+/* Stretched (rather than the row's default flex-start) so this column's own
+   box spans the full height of the results table next to it — giving
+   .sticky-panel room to stick throughout the scroll instead of scrolling
+   away as soon as this short column's natural content height passes. */
+.left-column {
+  align-self: stretch;
+}
+
+.sticky-panel {
+  position: sticky;
+  top: 0;
+}
+
 /* Table cells paint their own (striped) background over the row's, so the
    animation has to run on each td — animating the tr itself is invisible. */
 :deep(.highlight-row td) {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/app.vue
@@ -397,7 +397,9 @@ function reset() {
 </script>
 
 <style scoped>
-:deep(.highlight-row) {
+/* Table cells paint their own (striped) background over the row's, so the
+   animation has to run on each td — animating the tr itself is invisible. */
+:deep(.highlight-row td) {
   animation: highlight-fade 2s ease-out;
 }
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
@@ -19,7 +19,7 @@
         class="full_width"
         placeholder="Paste names here, one per line, or drag a CSV file..."
         rows="12"
-        @paste="handleTextareaPaste"
+        @paste="handlePaste"
       />
     </div>
 
@@ -100,9 +100,16 @@ function handleFileDrop(event) {
   loadFile(file)
 }
 
-function handleFilePaste(event) {
-  const items = event.clipboardData?.items
+function handlePaste(event) {
+  const clipboardData = event.clipboardData
+  const items = clipboardData?.items
   if (!items?.length) return // clipboard is empty, nothing to do
+
+  // Spreadsheet copies (e.g. Google Sheets) often also put an image
+  // snapshot of the selection on the clipboard as a file item. Prefer the
+  // plain text, when present, over any file item.
+  const hasText = clipboardData.getData('text')?.trim()
+  if (hasText) return // gets handled natively
 
   for (const item of items) {
     if (item.kind !== 'file') continue
@@ -114,18 +121,8 @@ function handleFilePaste(event) {
   }
 }
 
-function handleTextareaPaste(event) {
-  const clipboardData = event.clipboardData
-  if (!clipboardData?.items?.length) return // clipboard is empty, nothing to do
-
-  const hasText = clipboardData.getData('text')?.trim()
-  if (hasText) return // gets handled natively
-
-  handleFilePaste(event)
-}
-
 onMounted(() => {
-  pasteZone = { handler: handleFilePaste, prioritize: false }
+  pasteZone = { handler: handlePaste, prioritize: false }
   registerPaster(pasteZone)
   textareaRef.value?.focus()
 })

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
@@ -14,10 +14,12 @@
       @drop.prevent="handleFileDrop"
     >
       <textarea
+        ref="textareaRef"
         v-model="nameText"
         class="full_width"
         placeholder="Paste names here, one per line, or drag a CSV file..."
         rows="12"
+        @paste="handleTextareaPaste"
       />
     </div>
 
@@ -54,7 +56,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
 import VBtn from '@/components/ui/VBtn/index.vue'
 import { useDropzonePasteManager } from '@/composables/useDropzonePasteManager'
 import { MAX_ROWS } from '../constants.js'
@@ -67,6 +69,7 @@ const nameText = ref('')
 const isDragging = ref(false)
 const csvParsedData = ref(null)
 const fileInfo = ref(null)
+const textareaRef = useTemplateRef('textareaRef')
 let pasteZone = null
 
 const lines = computed(() => nameText.value.split('\n').map((l) => l.trim()))
@@ -99,7 +102,7 @@ function handleFileDrop(event) {
 
 function handleFilePaste(event) {
   const items = event.clipboardData?.items
-  if (!items) return
+  if (!items?.length) return // clipboard is empty, nothing to do
 
   for (const item of items) {
     if (item.kind !== 'file') continue
@@ -111,9 +114,20 @@ function handleFilePaste(event) {
   }
 }
 
+function handleTextareaPaste(event) {
+  const clipboardData = event.clipboardData
+  if (!clipboardData?.items?.length) return // clipboard is empty, nothing to do
+
+  const hasText = clipboardData.getData('text')?.trim()
+  if (hasText) return // gets handled natively
+
+  handleFilePaste(event)
+}
+
 onMounted(() => {
   pasteZone = { handler: handleFilePaste, prioritize: false }
   registerPaster(pasteZone)
+  textareaRef.value?.focus()
 })
 
 onBeforeUnmount(() => {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/InputPanel.vue
@@ -107,7 +107,7 @@ function handleFilePaste(event) {
   for (const item of items) {
     if (item.kind !== 'file') continue
     const file = item.getAsFile()
-    if (!file) continue
+    if (!file?.size) continue // skip empty/phantom file entries some browsers report on an empty clipboard
     event.preventDefault()
     loadFile(file)
     return

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
@@ -4,9 +4,10 @@
       <h3>Match options</h3>
       <VBtn
         color="primary"
+        title="Reset all options and match strings to defaults and re-run matching"
         @click="emit('clear-all')"
       >
-        Clear all matches
+        Restart
       </VBtn>
     </div>
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
@@ -14,7 +14,7 @@
     <!-- Scope to TaxonName -->
     <div class="flex-col gap-medium">
       <div class="field margin-medium-bottom">
-        <label data-help="Limit matches to names within this taxon's subtree.">Restrict matches to children of</label>
+        <label>Restrict matches to children of</label>
 
         <Autocomplete
           url="/taxon_names/autocomplete"

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/MatchOptionsPanel.vue
@@ -5,7 +5,7 @@
       <VBtn
         color="primary"
         title="Reset all options and match strings to defaults and re-run matching"
-        @click="emit('clear-all')"
+        @click="handleClearAll"
       >
         Restart
       </VBtn>
@@ -211,6 +211,11 @@ function debouncedUpdate() {
   debounceTimer = setTimeout(() => {
     emit('update-options')
   }, 500)
+}
+
+function handleClearAll() {
+  clearTimeout(debounceTimer)
+  emit('clear-all')
 }
 
 function handleScopeSelect(item) {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -232,6 +232,7 @@ import Autocomplete from '@/components/ui/Autocomplete.vue'
 import RadialAnnotator from '@/components/radials/annotator/annotator.vue'
 import RadialNavigator from '@/components/radials/navigation/radial.vue'
 import ButtonClipboard from '@/components/ui/Button/ButtonClipboard.vue'
+import effectiveName from '../utils/effectiveName.js'
 
 const props = defineProps({
   rows: {
@@ -280,10 +281,6 @@ function browseTaxonNameUrl(id) {
   return `${RouteNames.BrowseNomenclature}?taxon_name_id=${id}`
 }
 
-function effectiveName(row) {
-  return row.userMatchString || row.regexMatchString || row.scientificName
-}
-
 function firstUniqueIndex(row) {
   const name = effectiveName(row)
   return props.rows.findIndex((r) => effectiveName(r) === name)
@@ -314,7 +311,7 @@ function columnClipboardText(field) {
       case 'scientificName':
         return row.scientificName || ''
       case 'match':
-        return row.userMatchString || row.regexMatchString || row.scientificName || ''
+        return effectiveName(row)
       case 'taxonName':
         return row.taxonName?.cached || ''
       case 'otuLabel': {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -10,12 +10,12 @@
           />
         </th>
         <th />
-        <th>scientificName <ButtonClipboard :text="columnClipboardText('scientificName')" title="Copy scientificName column" /></th>
-        <th data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
-        <th>TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
+        <th class="line-nowrap">scientificName <ButtonClipboard :text="columnClipboardText('scientificName')" title="Copy scientificName column" /></th>
+        <th class="line-nowrap" data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
+        <th class="line-nowrap">TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
         <th />
         <th data-help="Manually search for and select a TaxonName, overriding the automatic match result. Use this to fix incorrect or ambiguous matches.">Refine</th>
-        <th>OTU <ButtonClipboard :text="columnClipboardText('otuLabel')" title="Copy OTU column" /></th>
+        <th class="line-nowrap">OTU <ButtonClipboard :text="columnClipboardText('otuLabel')" title="Copy OTU column" /></th>
         <th class="line-nowrap">OTU id <ButtonClipboard :text="columnClipboardText('otuId')" title="Copy OTU id column" /></th>
         <th />
         <th>Set</th>

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -281,9 +281,22 @@ function browseTaxonNameUrl(id) {
   return `${RouteNames.BrowseNomenclature}?taxon_name_id=${id}`
 }
 
+// Maps effectiveName -> the index of its first occurrence in props.rows.
+// Built once in O(n) instead of re-scanning all rows (O(n) per call) from
+// every isDuplicate/isActionable/activeRowIndex call site in the template.
+const firstIndexByEffectiveName = computed(() => {
+  const map = new Map()
+  props.rows.forEach((row) => {
+    const name = effectiveName(row)
+    if (!map.has(name)) {
+      map.set(name, row.index)
+    }
+  })
+  return map
+})
+
 function firstUniqueIndex(row) {
-  const name = effectiveName(row)
-  return props.rows.findIndex((r) => effectiveName(r) === name)
+  return firstIndexByEffectiveName.value.get(effectiveName(row))
 }
 
 function isDuplicate(row) {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -11,7 +11,7 @@
         </th>
         <th />
         <th class="line-nowrap">scientificName <ButtonClipboard :text="columnClipboardText('scientificName')" title="Copy scientificName column" /></th>
-        <th class="line-nowrap" data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
+        <th class="line-nowrap" data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is. Highlighted in blue when you have typed a custom value. Regex modifiers (left panel) write to this field automatically.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
         <th class="line-nowrap">TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
         <th />
         <th data-help="Manually search for and select a TaxonName, overriding the automatic match result. Use this to fix incorrect or ambiguous matches.">Refine</th>

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -11,7 +11,7 @@
         </th>
         <th />
         <th class="line-nowrap">scientificName <ButtonClipboard :text="columnClipboardText('scientificName')" title="Copy scientificName column" /></th>
-        <th class="line-nowrap" data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is. Highlighted in blue when you have typed a custom value. Regex modifiers (left panel) write to this field automatically.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
+        <th class="line-nowrap" data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is. A manually-entered value shows a small dot. Regex modifiers (left panel) write to this field automatically.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
         <th class="line-nowrap">TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
         <th />
         <th data-help="Manually search for and select a TaxonName, overriding the automatic match result. Use this to fix incorrect or ambiguous matches.">Refine</th>
@@ -74,20 +74,29 @@
 
         <!-- match -->
         <td>
-          <input
-            v-if="isActionable(row)"
-            type="text"
-            :class="['normal-input', 'match-input', { 'match-input-user': !!row.userMatchString }]"
-            :value="row.userMatchString || row.regexMatchString"
-            placeholder="(uses scientificName)"
-            @change="
-              (e) => {
-                emit('update-row', { index: row.index, field: 'userMatchString', value: e.target.value })
-                emit('match-row', { index: row.index })
-              }
-            "
-          />
-          <span v-else>{{ row.userMatchString || row.regexMatchString }}</span>
+          <div class="horizontal-left-content gap-xsmall">
+            <span class="match-icon-slot">
+              <span
+                v-if="row.userMatchString"
+                class="user-match-dot"
+                title="Manually entered — overrides the automatic scientificName-based match."
+              />
+            </span>
+            <input
+              v-if="isActionable(row)"
+              type="text"
+              class="normal-input match-input"
+              :value="row.userMatchString || row.regexMatchString"
+              placeholder="(uses scientificName)"
+              @change="
+                (e) => {
+                  emit('update-row', { index: row.index, field: 'userMatchString', value: e.target.value })
+                  emit('match-row', { index: row.index })
+                }
+              "
+            />
+            <span v-else>{{ row.userMatchString || row.regexMatchString }}</span>
+          </div>
         </td>
 
         <!-- TaxonName -->
@@ -164,8 +173,9 @@
             v-if="row.selectedOtuId"
             :href="browseOtuUrl(row.selectedOtuId)"
             target="_blank"
-            >{{ row.selectedOtuId }}</a
           >
+            {{ row.selectedOtuId }}
+          </a>
         </td>
 
         <!-- create OTU -->
@@ -370,8 +380,19 @@ thead th {
   width: 200px;
 }
 
-.match-input-user {
-  background-color: #e8f4fd;
+.match-icon-slot {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: var(--size-xSmall);
+}
+
+.user-match-dot {
+  display: inline-block;
+  width: var(--size-xxSmall);
+  height: var(--size-xxSmall);
+  border-radius: 50%;
+  background-color: var(--badge-blue-color);
 }
 
 .cell-ambiguous {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -2,7 +2,7 @@
   <table class="table-striped full_width">
     <thead>
       <tr>
-        <th>
+        <th data-help="Check rows to restrict option changes and regex application to only those rows. When none are checked, all rows are affected.">
           <input
             type="checkbox"
             :checked="allSelected"
@@ -45,9 +45,6 @@
                   field: 'selected',
                   value: e.target.checked
                 })
-                if (e.target.checked) {
-                  emit('update-selection')
-                }
               }
             "
           />
@@ -80,18 +77,17 @@
           <input
             v-if="isActionable(row)"
             type="text"
-            class="normal-input match-input"
-            :value="row.matchString"
+            :class="['normal-input', 'match-input', { 'match-input-user': !!row.userMatchString }]"
+            :value="row.userMatchString || row.regexMatchString"
             placeholder="(uses scientificName)"
             @change="
-              emit('update-row', {
-                index: row.index,
-                field: 'matchString',
-                value: $event.target.value
-              })
+              (e) => {
+                emit('update-row', { index: row.index, field: 'userMatchString', value: e.target.value })
+                emit('match-row', { index: row.index })
+              }
             "
           />
-          <span v-else>{{ row.matchString }}</span>
+          <span v-else>{{ row.userMatchString || row.regexMatchString }}</span>
         </td>
 
         <!-- TaxonName -->
@@ -253,7 +249,7 @@ const emit = defineEmits([
   'update-row',
   'create-otu',
   'scroll-to-row',
-  'update-selection'
+  'match-row'
 ])
 
 const contextRow = ref(null)
@@ -278,7 +274,6 @@ function toggleSelectAll(checked) {
       })
     }
   })
-  emit('update-selection', checked)
 }
 
 function browseTaxonNameUrl(id) {
@@ -286,7 +281,7 @@ function browseTaxonNameUrl(id) {
 }
 
 function effectiveName(row) {
-  return row.matchString || row.scientificName
+  return row.userMatchString || row.regexMatchString || row.scientificName
 }
 
 function firstUniqueIndex(row) {
@@ -319,7 +314,7 @@ function columnClipboardText(field) {
       case 'scientificName':
         return row.scientificName || ''
       case 'match':
-        return row.matchString || row.scientificName || ''
+        return row.userMatchString || row.regexMatchString || row.scientificName || ''
       case 'taxonName':
         return row.taxonName?.cached || ''
       case 'otuLabel': {
@@ -340,6 +335,10 @@ function columnClipboardText(field) {
 <style scoped>
 .match-input {
   width: 200px;
+}
+
+.match-input-user {
+  background-color: #e8f4fd;
 }
 
 .cell-ambiguous {

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -12,7 +12,7 @@
         <th />
         <th class="line-nowrap">scientificName <ButtonClipboard :text="columnClipboardText('scientificName')" title="Copy scientificName column" /></th>
         <th class="line-nowrap" data-help="Override the string used for matching. Leave blank to match using the scientificName value as-is. A manually-entered value shows a small dot. Regex modifiers (left panel) write to this field automatically.">Match <ButtonClipboard :text="columnClipboardText('match')" title="Copy match column" /></th>
-        <th class="line-nowrap">TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
+        <th class="line-nowrap" data-help="A yellow cell indicates that there was more than one matching Taxon Name to choose from, so you may want to confirm the name selected - if the wrong name was selected you can select the correct one in the Refine column.">TaxonName <ButtonClipboard :text="columnClipboardText('taxonName')" title="Copy TaxonName column" /></th>
         <th />
         <th data-help="Manually search for and select a TaxonName, overriding the automatic match result. Use this to fix incorrect or ambiguous matches.">Refine</th>
         <th class="line-nowrap">OTU <ButtonClipboard :text="columnClipboardText('otuLabel')" title="Copy OTU column" /></th>
@@ -389,20 +389,28 @@ thead th {
   background-color: var(--badge-blue-color);
 }
 
+/* !important needed: .table-striped's tr:nth-of-type(even/odd) td rule has
+   higher specificity (2 classes/pseudo + 2 elements) than a single class here. */
 .cell-ambiguous {
-  background-color: #fcf8e3;
+  background-color: #fcf8e3 !important;
 }
 
 .row-disabled {
   opacity: 0.6;
 }
 
-.row-no-match {
+/* .table-striped sets a background directly on every td, and border-collapse
+   leaves tr no visible area of its own to paint into — so a tr-level
+   background-color (even with !important) is invisible; it must target td. */
+.row-no-match td {
   background-color: #fdf2f2 !important;
 }
 
-.row-empty {
+.row-empty td {
   background-color: #f5f5f5 !important;
+}
+
+.row-empty {
   opacity: 0.5;
 }
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -159,7 +159,14 @@
         </td>
 
         <!-- OTU id -->
-        <td>{{ row.selectedOtuId || '' }}</td>
+        <td>
+          <a
+            v-if="row.selectedOtuId"
+            :href="browseOtuUrl(row.selectedOtuId)"
+            target="_blank"
+            >{{ row.selectedOtuId }}</a
+          >
+        </td>
 
         <!-- create OTU -->
         <td>
@@ -279,6 +286,10 @@ function toggleSelectAll(checked) {
 
 function browseTaxonNameUrl(id) {
   return `${RouteNames.BrowseNomenclature}?taxon_name_id=${id}`
+}
+
+function browseOtuUrl(id) {
+  return `${RouteNames.BrowseOtu}?otu_id=${id}`
 }
 
 // Maps effectiveName -> the index of its first occurrence in props.rows.

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -135,7 +135,7 @@
         <td>
           <template v-if="row.otus.length">
             <div
-              v-for="otu in row.otus"
+              v-for="otu in sortedOtus(row)"
               :key="otu.id"
               class="horizontal-left-content gap-xsmall"
             >
@@ -290,6 +290,12 @@ function browseTaxonNameUrl(id) {
 
 function browseOtuUrl(id) {
   return `${RouteNames.BrowseOtu}?otu_id=${id}`
+}
+
+// Unnamed OTUs (relying on the taxon name for their label) are listed before
+// named ones, so an ambiguous match's more generic OTUs surface first.
+function sortedOtus(row) {
+  return [...row.otus].sort((a, b) => (a.name ? 1 : 0) - (b.name ? 1 : 0))
 }
 
 // Maps effectiveName -> the index of its first occurrence in props.rows.

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -73,7 +73,7 @@
         </td>
 
         <!-- match -->
-        <td>
+        <td class="match-cell">
           <div class="horizontal-left-content gap-xsmall">
             <span class="match-icon-slot">
               <span
@@ -83,7 +83,7 @@
               />
             </span>
             <input
-              v-if="isActionable(row)"
+              v-if="!row.isEmpty"
               type="text"
               class="normal-input match-input"
               :value="row.userMatchString || row.regexMatchString"
@@ -395,7 +395,9 @@ thead th {
   background-color: #fcf8e3 !important;
 }
 
-.row-disabled {
+/* Dim everything but the Match cell — opacity compounds through descendants,
+   so dimming the tr itself would dim the still-editable Match input too. */
+.row-disabled > td:not(.match-cell) {
   opacity: 0.6;
 }
 

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -144,7 +144,7 @@
         <td>
           <template v-if="row.otus.length">
             <div
-              v-for="otu in sortedOtus(row)"
+              v-for="otu in row.otus"
               :key="otu.id"
               class="horizontal-left-content gap-xsmall"
             >
@@ -300,12 +300,6 @@ function browseTaxonNameUrl(id) {
 
 function browseOtuUrl(id) {
   return `${RouteNames.BrowseOtu}?otu_id=${id}`
-}
-
-// Unnamed OTUs (relying on the taxon name for their label) are listed before
-// named ones, so an ambiguous match's more generic OTUs surface first.
-function sortedOtus(row) {
-  return [...row.otus].sort((a, b) => (a.name ? 1 : 0) - (b.name ? 1 : 0))
 }
 
 // Maps effectiveName -> the index of its first occurrence in props.rows.

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -360,6 +360,12 @@ function columnClipboardText(field) {
 </script>
 
 <style scoped>
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
 .match-input {
   width: 200px;
 }

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/ResultTable.vue
@@ -73,7 +73,7 @@
         </td>
 
         <!-- match -->
-        <td class="match-cell">
+        <td class="cell-interactive">
           <div class="horizontal-left-content gap-xsmall">
             <span class="match-icon-slot">
               <span
@@ -242,7 +242,8 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { RouteNames } from '@/routes/routes'
+import { OTU, TAXON_NAME } from '@/constants'
+import { makeBrowseUrl } from '@/helpers'
 import VBtn from '@/components/ui/VBtn/index.vue'
 import VIcon from '@/components/ui/VIcon/index.vue'
 import Autocomplete from '@/components/ui/Autocomplete.vue'
@@ -295,11 +296,11 @@ function toggleSelectAll(checked) {
 }
 
 function browseTaxonNameUrl(id) {
-  return `${RouteNames.BrowseNomenclature}?taxon_name_id=${id}`
+  return makeBrowseUrl({ id, type: TAXON_NAME })
 }
 
 function browseOtuUrl(id) {
-  return `${RouteNames.BrowseOtu}?otu_id=${id}`
+  return makeBrowseUrl({ id, type: OTU })
 }
 
 // Maps effectiveName -> the index of its first occurrence in props.rows.
@@ -395,10 +396,17 @@ thead th {
   background-color: #fcf8e3 !important;
 }
 
-/* Dim everything but the Match cell — opacity compounds through descendants,
-   so dimming the tr itself would dim the still-editable Match input too. */
-.row-disabled > td:not(.match-cell) {
+/* Dim duplicate rows — opacity compounds through descendants, so dimming the
+   tr itself would dim still-interactive cells (e.g. the Match input) too.
+   Cells that must stay legible/interactive opt in via .cell-interactive
+   instead of being named here, so adding one doesn't require editing this
+   rule. */
+.row-disabled td {
   opacity: 0.6;
+}
+
+.row-disabled .cell-interactive {
+  opacity: 1;
 }
 
 /* .table-striped sets a background directly on every td, and border-collapse

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/SummaryBar.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/SummaryBar.vue
@@ -40,6 +40,7 @@
 <script setup>
 import { computed } from 'vue'
 import ButtonClipboard from '@/components/ui/Button/ButtonClipboard.vue'
+import effectiveName from '../utils/effectiveName.js'
 
 const CLIPBOARD_HEADERS = ['scientificName', 'match', 'otuId']
 
@@ -91,7 +92,7 @@ const clipboardText = computed(() =>
     CLIPBOARD_HEADERS.join('\t'),
     ...props.rows.map((row) => {
       const name = row.scientificName || ''
-      const match = row.userMatchString || row.regexMatchString || row.scientificName || ''
+      const match = effectiveName(row)
       const otuId = row.selectedOtuId != null ? String(row.selectedOtuId) : ''
       return `${name}\t${match}\t${otuId}`
     })

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/components/SummaryBar.vue
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/components/SummaryBar.vue
@@ -91,7 +91,7 @@ const clipboardText = computed(() =>
     CLIPBOARD_HEADERS.join('\t'),
     ...props.rows.map((row) => {
       const name = row.scientificName || ''
-      const match = row.matchString || row.scientificName || ''
+      const match = row.userMatchString || row.regexMatchString || row.scientificName || ''
       const otuId = row.selectedOtuId != null ? String(row.selectedOtuId) : ''
       return `${name}\t${match}\t${otuId}`
     })

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/constants.js
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/constants.js
@@ -1,1 +1,9 @@
 export const MAX_ROWS = 3000
+
+// A fresh array/objects each call, so callers never share mutable state.
+export function defaultModifiers() {
+  return [
+    { active: false, pattern: '^(\\S*\\s+\\S*).*', replacement: '$1' },
+    { active: false, pattern: '', replacement: '' }
+  ]
+}

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/utils/effectiveName.js
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/utils/effectiveName.js
@@ -1,0 +1,5 @@
+// The name actually used for matching/grouping a row: a manual override
+// takes precedence over a regex-modifier result, which takes precedence
+// over the row's raw scientificName.
+export default (row) =>
+  row.userMatchString || row.regexMatchString || row.scientificName

--- a/app/javascript/vue/tasks/otus/match_by_taxon_name/utils/sortOtus.js
+++ b/app/javascript/vue/tasks/otus/match_by_taxon_name/utils/sortOtus.js
@@ -1,0 +1,5 @@
+// Unnamed OTUs (relying on the taxon name for their label) sort before named
+// ones, so an ambiguous match's more generic OTUs surface first. Used for both
+// display order and picking the default selectedOtuId, so the two stay consistent.
+export default (otus) =>
+  [...otus].sort((a, b) => (a.name ? 1 : 0) - (b.name ? 1 : 0))

--- a/lib/match/otu/taxon_name.rb
+++ b/lib/match/otu/taxon_name.rb
@@ -91,9 +91,19 @@ module Match
           taxon_name_id: resolved.id,
           taxon_name: resolved,
           otus: otus,
-          ambiguous: ranked.length > 1,
+          ambiguous: genuinely_ambiguous?(ranked),
           matched: true
         }
+      end
+
+      # Multiple candidate rows aren't ambiguous if they all resolve to the
+      # same valid taxon (e.g. a Combination alongside its own Protonym) —
+      # ranking always picks correctly there. Only flag it when candidates
+      # point to genuinely different valid taxa (e.g. true homonyms).
+      # @param ranked [Array<TaxonName>]
+      # @return [Boolean]
+      def genuinely_ambiguous?(ranked)
+        ranked.map(&:cached_valid_taxon_name_id).uniq.length > 1
       end
 
       # @param name [String]

--- a/spec/lib/match/otu/taxon_name_spec.rb
+++ b/spec/lib/match/otu/taxon_name_spec.rb
@@ -46,4 +46,32 @@ describe Match::Otu::TaxonName, type: :model do
       end
     end
   end
+
+  context 'ambiguous' do
+    context 'when multiple candidates share a cached name but resolve to the same valid taxon (e.g. a Combination alongside its own Protonym)' do
+      let!(:combination_like) do
+        Protonym.create!(name: 'dus', rank_class: Ranks.lookup(:iczn, :species), parent: genus).tap do |tn|
+          tn.update_columns(cached: valid_species.cached, cached_valid_taxon_name_id: valid_species.id)
+        end
+      end
+
+      specify 'is not flagged ambiguous' do
+        result = match(names: [valid_species.cached]).first
+        expect(result[:ambiguous]).to eq(false)
+      end
+    end
+
+    context 'when multiple candidates share a cached name but resolve to different valid taxa (true homonyms)' do
+      let!(:homonym) do
+        Protonym.create!(name: 'eus', rank_class: Ranks.lookup(:iczn, :species), parent: genus).tap do |tn|
+          tn.update_columns(cached: valid_species.cached)
+        end
+      end
+
+      specify 'is flagged ambiguous' do
+        result = match(names: [valid_species.cached]).first
+        expect(result[:ambiguous]).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This looks like a lot, but many commits are basic/small things. As always I'm happy to get suggested changes.
* fixed an issue Matt ran into during CC where the Match column was being cleared. I think I broke that worse with my last commits on this task, apologies for that. There was always an issue where we didn't keep track of whether the Match column had been entered by the user or had been filled by regexes. We now keep track and use a small blue dot to indicate user-entered (noted in help bubble):
<img width="263" height="185" alt="image" src="https://github.com/user-attachments/assets/d01a493e-09b7-43fd-bd77-6d8d7c0662cf" />

User-entered overrules regex-created (i.e. applying a regex to that row does not overwrite what the user entered as their desired match term).
* Returned colors to rows indicating their state: red/pink (as above) means no match found, yellow on the match column indicates an ambiguous match, which really shows up now on higher Levenshtein distances. (These styles were already setup in the code, but the table styling was drawing over them so they were never visible.)
  * adjusted the meaning of ambiguous: a match is now ambiguous only if there was more than one `cached_valid_taxon_name_id` from the set of names matched - when there's a single `cached_valid_taxon_name_id` for all matches then we rely on our internal ranking to choose the "correct" one and don't refer to it as ambiguous. (Previously a Protonym and its subsequent combination Combination were causing the disambiguation warning on every non-original valid name.) Again help bubble notes the meaning of the color.
<img width="2731" height="78" alt="image" src="https://github.com/user-attachments/assets/6a68b8d5-7536-4d83-a925-6ed525851612" />

* Removed the 'Clear matches' button
  * every option change updates the matches
  * entering a Match string and blurring that input updates the matches
  * selecting a Refine name updates the matches
  * there's now a 'Restart' button to reset everything *on the given list of names* (and still a reset button to provide a new list of names)
* When there are multiple OTUs for a matched name, auto-select one without a name attribute (requested by Maria Belén)
* When 'resolve synonyms' is checked, copy  columns now copies the *valid* names (requested by Michele)
* Optimized the dup-row matching, 3k names now takes ~10 rather than ~30 seconds
* Various other minor fixups
