### PR TITLE
Pin rack-proxy below 1.0 to fix broken /packs/* dev assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,10 @@ gem 'rails-jquery-autocomplete', '~> 1.0.3'
 gem 'turbolinks', '~> 5.2.0'
 gem 'jquery-turbolinks', '~> 2.1'
 gem 'shakapacker', '10.3.0'
+# rack-proxy >= 1.0 added an SSRF guard requiring allow_dynamic_backend: true,
+# which shakapacker 10.3.0's DevServerProxy doesn't pass, so every /packs/*
+# request 502s in development. Pin until shakapacker opts in upstream.
+gem 'rack-proxy', '< 1.0'
 
 # BibTeX handling
 gem 'csl', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,8 +504,8 @@ GEM
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
-    rack-proxy (1.0.1)
-      rack (>= 2.0, < 4)
+    rack-proxy (0.8.3)
+      rack
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -907,6 +907,7 @@ DEPENDENCIES
   puma (~> 8.0)
   rack (~> 3.2)
   rack-cors (~> 3.0)
+  rack-proxy (< 1.0)
   rails (~> 8.1.0)
   rails-controller-testing (~> 1.0.2)
   rails-jquery-autocomplete (~> 1.0.3)


### PR DESCRIPTION
cc @LocoDelAssembly @jlpereira 

Symptoms: no styling when loading dev, even with the usual clear-cache, 'rails assets:clobber', restart server and shakapacker. Diagnosis and fix entirely by Claude:

rack-proxy 1.0.0 (pulled in by the recent "bundle update" commit, af65505737) added an SSRF guard: proxied requests with no :backend configured are now refused with a bare 502 unless the middleware passes allow_dynamic_backend: true. shakapacker 10.3.0's DevServerProxy (lib/shakapacker/dev_server_proxy.rb) only passes ssl_verify_none: true, so every /packs/* request in development was being rejected before any network I/O happened - the rspack dev server on :3035 was healthy the whole time, confirmed by curling it directly, but Puma's proxy in front of it refused to forward anything. No amount of clobbering compiled assets, restarting shakapacker, or clearing the browser cache could fix it, since the compiled output was never the problem.

Root cause confirmed via rack-proxy 1.0.1's own bundled docs:
- Migration guide: https://github.com/ncr/rack-proxy/blob/v1.0.1/README.md#upgrading
- Breaking-change/security writeup: https://github.com/ncr/rack-proxy/blob/v1.0.0/CHANGELOG.md
- Repo: https://github.com/ncr/rack-proxy

Pinning to < 1.0 resolves to 0.8.3 and restores the previous dynamic- backend behavior shakapacker relies on. Should be revisited once shakapacker passes allow_dynamic_backend: true upstream.
