### PR TITLE
5013 autocomplete mark

### DIFF
--- a/app/assets/stylesheets/vendor/jquery/autocomplete.scss
+++ b/app/assets/stylesheets/vendor/jquery/autocomplete.scss
@@ -60,11 +60,6 @@
     font-size: 10px;
     font-weight: 300;
   }
-  mark {
-    font-weight: 300;
-    color: $color-primary-4;
-    background: none;
-  }
 }
 
 .ui-helper-hidden-accessible {

--- a/app/assets/stylesheets/views/shared_data/show.scss
+++ b/app/assets/stylesheets/views/shared_data/show.scss
@@ -78,7 +78,10 @@
 
 mark {
   font-weight: 700;
-  background-color: transparent;
+  color: var(--color-on-attention);
+  background-color: var(--color-attention);
+  padding: 0 0.2em;
+  border-radius: 0.15em;
   a {
     font-weight: 700;
   }

--- a/app/assets/stylesheets/views/shared_data/show.scss
+++ b/app/assets/stylesheets/views/shared_data/show.scss
@@ -80,11 +80,22 @@ mark {
   font-weight: 700;
   color: var(--color-on-attention);
   background-color: var(--color-attention);
-  padding: 0 0.2em;
+  padding: 0 0.08em;
   border-radius: 0.15em;
   a {
     font-weight: 700;
   }
+}
+
+// Italic text leans right into whatever follows it, and whatever comes before
+// leans into it; give marked text a little breathing room here so neither side
+// gets cut off.
+i mark,
+em mark,
+cite mark {
+  margin-left: 0.14em;
+  padding-right: 0.14em;
+  padding-left: 0;
 }
 
 .housekeeping {

--- a/app/helpers/anatomical_parts_helper.rb
+++ b/app/helpers/anatomical_parts_helper.rb
@@ -20,8 +20,8 @@ module AnatomicalPartsHelper
     content_tag(:span, safe_join([anatomical_part.cached, ': ', origin_content || '']))
   end
 
-  def anatomical_part_autocomplete_tag(anatomical_part)
-    anatomical_part_tag(anatomical_part)
+  def anatomical_part_autocomplete_tag(anatomical_part, term = nil)
+    mark_tag(anatomical_part_tag(anatomical_part), term)
   end
 
   def label_for_anatomical_part(anatomical_part, depth: 0)

--- a/app/helpers/asserted_distributions_helper.rb
+++ b/app/helpers/asserted_distributions_helper.rb
@@ -12,6 +12,10 @@ module AssertedDistributionsHelper
     ].join('&nbsp;').html_safe
   end
 
+  def asserted_distribution_autocomplete_tag(asserted_distribution, term = nil)
+    mark_tag(asserted_distribution_tag(asserted_distribution), term)
+  end
+
   def label_for_asserted_distribution(asserted_distribution)
     return nil if asserted_distribution.nil?
     [

--- a/app/helpers/biological_associations_graphs_helper.rb
+++ b/app/helpers/biological_associations_graphs_helper.rb
@@ -6,10 +6,10 @@ module BiologicalAssociationsGraphsHelper
     biological_associations_graph.name ||'Nameless graph. id: ' + biological_associations_graph.to_param
   end
 
-  def biological_associations_graph_autocomplete_tag(biological_association_graph)
+  def biological_associations_graph_autocomplete_tag(biological_association_graph, term = nil)
     return nil if biological_association_graph.nil?
 
-    biological_association_graph_tag(biological_association_graph)
+    mark_tag(biological_associations_graph_tag(biological_association_graph), term)
   end
 
   def label_for_biological_associations_graph(biological_associations_graph)

--- a/app/helpers/biological_associations_helper.rb
+++ b/app/helpers/biological_associations_helper.rb
@@ -20,10 +20,10 @@ module BiologicalAssociationsHelper
     label_for(biological_association.biological_association_object)
   end
 
-  def biological_association_autocomplete_tag(biological_association)
+  def biological_association_autocomplete_tag(biological_association, term = nil)
     return nil if biological_association.nil?
 
-    biological_association_tag(biological_association)
+    mark_tag(biological_association_tag(biological_association), term)
   end
 
   def biological_associations_search_form

--- a/app/helpers/biological_relationships_helper.rb
+++ b/app/helpers/biological_relationships_helper.rb
@@ -5,6 +5,10 @@ module BiologicalRelationshipsHelper
     [biological_relationship.name, biological_relationship.inverted_name].compact.join(' / ')
   end
 
+  def biological_relationship_autocomplete_tag(biological_relationship, term = nil)
+    mark_tag(biological_relationship_tag(biological_relationship), term)
+  end
+
   def label_for_biological_relationship(biological_relationship)
     return nil if biological_relationship.nil?
     biological_relationship.name

--- a/app/helpers/collecting_events_helper.rb
+++ b/app/helpers/collecting_events_helper.rb
@@ -16,9 +16,9 @@ module CollectingEventsHelper
     collecting_event.cached
   end
 
-  def collecting_event_autocomplete_tag(collecting_event, join_string = '<br>')
+  def collecting_event_autocomplete_tag(collecting_event, join_string = '<br>', term: nil)
     return nil if collecting_event.nil?
-    [ collecting_event_identifiers_tag(collecting_event),
+    s = [ collecting_event_identifiers_tag(collecting_event),
       collecting_event_geographic_names_tag(collecting_event),
       collecting_event_verbatim_locality_tag(collecting_event),
       collecting_event_dates_tag(collecting_event),
@@ -27,7 +27,8 @@ module CollectingEventsHelper
       # collecting_event_coordinates_tag(collecting_event), # this is very slow
       collecting_event_method_habitat_tag(collecting_event),
       collecting_event_uses_tag(collecting_event)
-    ].compact.join(join_string).html_safe
+    ].compact.join(join_string)
+    mark_tag(s, term)
   end
 
   def collecting_event_uses_tag(collecting_event)

--- a/app/helpers/collection_objects_helper.rb
+++ b/app/helpers/collection_objects_helper.rb
@@ -47,13 +47,13 @@ module CollectionObjectsHelper
       collection_object.id.to_s
   end
 
-  def collection_object_autocomplete_tag(collection_object)
+  def collection_object_autocomplete_tag(collection_object, term = nil)
     return nil if collection_object.nil?
     [
       collection_object_loan_tag(collection_object),
       collection_object_deaccession_tag(collection_object),
-      collection_object_identifier_tag(collection_object),
-      collection_object_taxon_determination_tag(collection_object)
+      collection_object_identifier_tag(collection_object, term),
+      collection_object_taxon_determination_tag(collection_object, term)
     ].join(' ').html_safe
   end
 
@@ -81,9 +81,10 @@ module CollectionObjectsHelper
     link_to('Verify', verify_accessions_task_path(by: priority.metamorphosize.class.name.tableize.singularize.to_sym, id: priority.to_param))
   end
 
-  def collection_object_identifier_tag(collection_object)
+  def collection_object_identifier_tag(collection_object, term = nil)
     return nil if collection_object.nil?
     t, i = collection_object_visualized_identifier(collection_object)
+    i = mark_tag(i, term)
 
     return content_tag(:span, i, class: [
       :feedback,
@@ -139,9 +140,10 @@ module CollectionObjectsHelper
     nil
   end
 
-  def collection_object_taxon_determination_tag(collection_object)
+  def collection_object_taxon_determination_tag(collection_object, term = nil)
     return nil if collection_object.nil?
     i = taxon_determination_tag(collection_object.taxon_determinations.order(:position).first)
+    i = mark_tag(i, term)
     return content_tag(:span, i, class: [:feedback, 'feedback-thin', 'feedback-secondary']) if i
     nil
   end

--- a/app/helpers/containers_helper.rb
+++ b/app/helpers/containers_helper.rb
@@ -38,8 +38,8 @@ module ContainersHelper
     container.name || container.print_label || label_for_identifier(container.identifiers.first) || container.id.to_s
   end
 
-  def container_autocomplete_tag(container)
-    container_tag(container)
+  def container_autocomplete_tag(container, term = nil)
+    mark_tag(container_tag(container), term)
   end
 
   def container_parent_tag(container)

--- a/app/helpers/controlled_vocabulary_terms_helper.rb
+++ b/app/helpers/controlled_vocabulary_terms_helper.rb
@@ -16,11 +16,12 @@ module ControlledVocabularyTermsHelper
     controlled_vocabulary_term.name
   end
 
-  def controlled_vocabulary_term_autocomplete_tag(controlled_vocabulary_term)
-    [ controlled_vocabulary_term_tag(controlled_vocabulary_term),
+  def controlled_vocabulary_term_autocomplete_tag(controlled_vocabulary_term, term = nil)
+    s = [ controlled_vocabulary_term_tag(controlled_vocabulary_term),
       content_tag(:span, controlled_vocabulary_term.type, class: [:feedback, 'feedback-secondary', 'feedback-thin']),
       content_tag(:span, pluralize( controlled_vocabulary_term_use(controlled_vocabulary_term), 'use'), class: [:feedback, 'feedback-info', 'feedback-thin'])
     ].compact.join(' ')
+    mark_tag(s, term)
   end
 
   def controlled_vocabulary_term_use(controlled_vocabulary_term)

--- a/app/helpers/conveyances_helper.rb
+++ b/app/helpers/conveyances_helper.rb
@@ -6,8 +6,8 @@ module ConveyancesHelper
     [ sound_tag(conveyance.sound), 'on', object_tag(conveyance.conveyance_object)  ].compact.join('&nbsp;').html_safe
   end
 
-  def conveyance_autocomplete_tag(conveyance)
-    conveyance_tag(conveyance)
+  def conveyance_autocomplete_tag(conveyance, term = nil)
+    mark_tag(conveyance_tag(conveyance), term)
   end
 
   def label_for_conveyance(conveyance)

--- a/app/helpers/data_attributes_helper.rb
+++ b/app/helpers/data_attributes_helper.rb
@@ -11,15 +11,16 @@ module DataAttributesHelper
     content_tag(:span, s.html_safe, class: [:annotation__data_attribute])
   end
 
-  def data_attribute_autocomplete_tag(data_attribute)
+  def data_attribute_autocomplete_tag(data_attribute, term = nil)
     return nil if data_attribute.nil?
-    [
+    s = [
       [ content_tag(:span, data_attribute.predicate_name, class: [:feedback, 'feedback-thin', 'feedback-primary']),
         content_tag(:span, data_attribute.value, class: [:feedback, 'feedback-thin', 'feedback-primary']),
         content_tag(:span, data_attribute.type, class: [:feedback, 'feedback-thin', 'feedback-secondary']),
-        content_tag(:span, data_attribute.attribute_subject_type, class: [:feedback, 'feedback-thin', 'feedback-light'])].join('&nbsp;').html_safe,
+        content_tag(:span, data_attribute.attribute_subject_type, class: [:feedback, 'feedback-thin', 'feedback-light'])].join('&nbsp;'),
     content_tag(:div, object_tag(data_attribute.annotated_object.metamorphosize))
-    ].join.html_safe
+    ].join
+    mark_tag(s, term)
   end
 
   # TODO deprecate

--- a/app/helpers/depictions_helper.rb
+++ b/app/helpers/depictions_helper.rb
@@ -15,8 +15,8 @@ module DepictionsHelper
     end
   end
 
-  def depiction_autocomplete_tag(depiction)
-    depiction_tag(depiction)
+  def depiction_autocomplete_tag(depiction, term = nil)
+    mark_tag(depiction_tag(depiction), term)
   end
 
   # Only text, no HTML

--- a/app/helpers/descriptors_helper.rb
+++ b/app/helpers/descriptors_helper.rb
@@ -22,11 +22,7 @@ module DescriptorsHelper
   def descriptors_autocomplete_tag(descriptor, term = nil)
     return nil if descriptor.nil?
 
-    if term
-      s = descriptor.name.gsub(/#{Regexp.escape(term)}/i, "<mark>#{term}</mark>")
-    else
-      s = descriptor.name
-    end
+    s = mark_tag(descriptor.name, term, html_safe: false)
 
     s += ' ' + content_tag(:span, descriptor.type.split('::').last, class: [:feedback, 'feedback-secondary', 'feedback-thin'])
 

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -5,6 +5,10 @@ module DocumentsHelper
     document.document_file_file_name
   end
 
+  def document_autocomplete_tag(document, term = nil)
+    mark_tag(document_tag(document), term)
+  end
+
   def document_link(document)
     return nil if document.nil?
     link_to(document_tag(document).html_safe, document)

--- a/app/helpers/extracts_helper.rb
+++ b/app/helpers/extracts_helper.rb
@@ -37,11 +37,12 @@ module ExtractsHelper
     ].compact.join('; ')
   end
 
-  def extract_autocomplete_tag(extract)
+  def extract_autocomplete_tag(extract, term = nil)
     return nil if extract.nil?
-    [simple_identifier_list_tag(extract),
+    s = [simple_identifier_list_tag(extract),
      extract_origin_tags(extract),
-    ].join(' ').html_safe
+    ].join(' ')
+    mark_tag(s, term)
   end
 
   # @return [String, nil\

--- a/app/helpers/field_occurrences_helper.rb
+++ b/app/helpers/field_occurrences_helper.rb
@@ -37,11 +37,9 @@ module FieldOccurrencesHelper
     ].compact.join('; ')
   end
 
-  def field_occurrence_autocomplete_tag(field_occurrence)
+  def field_occurrence_autocomplete_tag(field_occurrence, term = nil)
     return nil if field_occurrence.nil?
-    [
-      field_occurrence_tag(field_occurrence)
-    ].join(' ').html_safe
+    mark_tag(field_occurrence_tag(field_occurrence), term)
   end
 
   def field_occurrences_search_form

--- a/app/helpers/gazetteers_helper.rb
+++ b/app/helpers/gazetteers_helper.rb
@@ -21,8 +21,8 @@ module GazetteersHelper
     end
   end
 
-  def gazetteer_autocomplete_tag(gazetteer)
-    gazetteer_tag(gazetteer)
+  def gazetteer_autocomplete_tag(gazetteer, term = nil)
+    mark_tag(gazetteer_tag(gazetteer), term)
   end
 
   def gazetteers_search_form

--- a/app/helpers/geographic_areas_helper.rb
+++ b/app/helpers/geographic_areas_helper.rb
@@ -12,11 +12,7 @@ module GeographicAreasHelper
 
   def geographic_area_autocomplete_tag(geographic_area, term, mark = true)
     return nil if geographic_area.nil?
-    if term && mark
-      s = geographic_area.name.gsub(/#{Regexp.escape(term)}/i, "<mark>#{term}</mark>") + ' '
-    else
-      s = geographic_area.name + ' '
-    end
+    s = (mark ? mark_tag(geographic_area.name, term, html_safe: false) : geographic_area.name) + ' '
 
     s = [geographic_area&.parent&.parent&.name, geographic_area&.parent&.name, s].compact.join(': ').gsub('Earth: ', '')
 

--- a/app/helpers/identifiers_helper.rb
+++ b/app/helpers/identifiers_helper.rb
@@ -39,15 +39,16 @@ module IdentifiersHelper
   end
 
   # @return [String, nil]
-  def identifier_autocomplete_tag(identifier)
+  def identifier_autocomplete_tag(identifier, term = nil)
     return nil if identifier.nil?
-    content_tag(:span, class: :annotation__identifier) do
+    s = content_tag(:span, class: :annotation__identifier) do
       [
         object_tag(identifier.annotated_object.metamorphosize),
         content_tag(:span, identifier.identifier_object_type, class: [:feedback, 'feedback-thin', 'feedback-primary']),
         content_tag(:span, identifier.type, class: [:feedback, 'feedback-thin', 'feedback-secondary']),
       ].join('&nbsp;').html_safe
     end
+    mark_tag(s, term)
   end
 
   # @return [String, nil]

--- a/app/helpers/leads_helper.rb
+++ b/app/helpers/leads_helper.rb
@@ -24,8 +24,8 @@ module LeadsHelper
     link_to(lead_tag(lead), lead)
   end
 
-  def lead_autocomplete_tag(lead)
-    lead_tag(lead)
+  def lead_autocomplete_tag(lead, term = nil)
+    mark_tag(lead_tag(lead), term)
   end
 
   def label_for_lead(lead)

--- a/app/helpers/loans_helper.rb
+++ b/app/helpers/loans_helper.rb
@@ -21,16 +21,17 @@ module LoansHelper
     (recipients.presence || 'No recipients defined!')
   end
 
-  def loan_autocomplete_tag(loan)
+  def loan_autocomplete_tag(loan, term = nil)
     return nil if loan.nil?
-    [
+    s = [
       content_tag(:span, (identifier_tag(loan_identifier(loan)) || loan.id), class: [:feedback, 'feedback-thin', 'feedback-primary']),
       loan.loan_recipients.collect{|a| a.name}.join(', '),
       loan.recipient_email,
       loan.date_sent,
       loan.recipient_address,
       loan_status_tag(loan)
-    ].delete_if{|b| b.blank? }.join(' - ').gsub(/\n/, '; ').html_safe
+    ].delete_if{|b| b.blank? }.join(' - ').gsub(/\n/, '; ')
+    mark_tag(s, term)
   end
 
   def loan_identifier(loan)

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -5,7 +5,7 @@ module NamespacesHelper
     namespace.short_name + ': ' + namespace.name
   end
 
-  def namespace_autocomplete_tag(namespace)
+  def namespace_autocomplete_tag(namespace, term = nil)
     return nil if namespace.nil?
     r = []
 
@@ -21,7 +21,7 @@ module NamespacesHelper
       r.push content_tag(:span, namespace.institution, class: [:feedback, 'feedback-thin', 'feedback-secondary'] )
     end
 
-    r.join('<br/>').html_safe
+    mark_tag(r.join('<br/>'), term)
   end
 
   def namespace_link(namespace)

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -13,8 +13,8 @@ module ObservationsHelper
     "#{a}: #{b} on #{c}".html_safe
   end
 
-  def observation_autocomplete_tag(observation)
-    observation_tag(observation)
+  def observation_autocomplete_tag(observation, term = nil)
+    mark_tag(observation_tag(observation), term)
   end
 
   def label_for_observation(observation)

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -5,4 +5,8 @@ module OrganizationsHelper
     organization.name
   end
 
+  def organization_autocomplete_tag(organization, term = nil)
+    mark_tag(organization_tag(organization), term)
+  end
+
 end

--- a/app/helpers/otus_helper.rb
+++ b/app/helpers/otus_helper.rb
@@ -52,6 +52,11 @@ module OtusHelper
     content_tag(:span, a.compact.join(' ').html_safe, class: :otu_tag)
   end
 
+  def otu_autocomplete_tag(otu, term = nil)
+    return nil if otu.nil?
+    mark_tag(otu_tag(otu), term)
+  end
+
   def label_for_otu(otu)
     return nil if otu.nil?
     [ label_for_taxon_name(otu.taxon_name),

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -19,13 +19,14 @@ module PeopleHelper
     link_to(person_tag(person), person.metamorphosize)
   end
 
-  def person_autocomplete_tag(person)
+  def person_autocomplete_tag(person, term = nil)
     return nil if person.nil?
-    [ person_tag(person),
+    s = [ person_tag(person),
       person_timeframe_tag(person),
       person_used_tag(person),
       person_project_membership_tag(person)
     ].compact.join(' ')
+    mark_tag(s, term)
   end
 
   def person_timeframe_tag(person)

--- a/app/helpers/preparation_types_helper.rb
+++ b/app/helpers/preparation_types_helper.rb
@@ -10,8 +10,8 @@ module PreparationTypesHelper
     preparation_type.name
   end
 
-  def preparation_type_autocomplete_tag(preparation_type)
-    preparation_type_tag(preparation_type)
+  def preparation_type_autocomplete_tag(preparation_type, term = nil)
+    mark_tag(preparation_type_tag(preparation_type), term)
   end
 
   def preparation_type_link(preparation_type)

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -17,14 +17,15 @@ module RepositoriesHelper
     link_to(repository_tag(repository).html_safe, repository)
   end
 
-  def repository_autocomplete_tag(repository)
-    [
+  def repository_autocomplete_tag(repository, term = nil)
+    s = [
       tag.span(repository.acronym, class: [:feedback, 'feedback-thin', 'feedback-secondary']),
       repository.name,
       repository.url.present? ? tag.span(repository.url, class: [:feedback, 'feedback-thin']) : nil,
       (repository.is_index_herbariorum ? tag.span('Herbarium', class: [:feedback, 'feedback-info', 'feedback-thin']) : nil),
       repository_usage_tag(repository)
-    ].compact.join(' ').html_safe
+    ].compact.join(' ')
+    mark_tag(s, term)
   end
 
   # use_count/in_project_use_count come from autocomplete pre-calculation, when present

--- a/app/helpers/serials_helper.rb
+++ b/app/helpers/serials_helper.rb
@@ -5,9 +5,9 @@ module SerialsHelper
     serial.name
   end
 
-  def serial_autocomplete_tag(serial, term = '')
+  def serial_autocomplete_tag(serial, term = nil)
     return nil if serial.nil?
-    [ serial.name.gsub(/#{Regexp.escape(term)}/, "<mark>#{term}</mark>"), 
+    [ mark_tag(serial.name, term),
       content_tag(:span, "Project uses: #{Serial.joins(sources: [:project_sources]).where('project_sources.project_id = ? and serials.id = ?', sessions_current_project_id, serial.id).count}", class: [:feedback, 'feedback-primary', 'feedback-thin']),
       content_tag(:span, "All uses: #{serial.sources.count}", class: [:feedback, 'feedback-secondary', 'feedback-thin'])
 

--- a/app/helpers/sounds_helper.rb
+++ b/app/helpers/sounds_helper.rb
@@ -16,6 +16,11 @@ module SoundsHelper
     render('/sounds/quick_search_form')
   end
 
+  def sound_autocomplete_tag(sound, term = nil)
+    return nil if sound.nil?
+    mark_tag(sound_tag(sound), term)
+  end
+
   def sound_link(sound)
     return nil if sound.nil?
     link_to(sound_tag(sound), sound.metamorphosize).html_safe

--- a/app/helpers/sources_helper.rb
+++ b/app/helpers/sources_helper.rb
@@ -16,11 +16,7 @@ module SourcesHelper
   def sources_autocomplete_tag(source, term)
     return nil if source.nil?
 
-    if term
-      s = regex_mark_tag(source.cached, term) + ' '
-    else
-      s = source.cached + ' '
-    end
+    s = mark_tag(source.cached, term, html_safe: false) + ' '
 
     # In project is the project_if if present in this project see lib/queries/source/autocomplete
     if source.respond_to?(:in_project) && !source.in_project.nil?

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -32,8 +32,9 @@ module UsersHelper
     content_tag(:div, user_initials(user), class: classes, title: title)
   end
 
-  def user_autocomplete_tag(user)
-    user.name + ' ' + content_tag(:span, user.email, class: [:feedback, 'feedback-thin', 'feedback-primary']).html_safe
+  def user_autocomplete_tag(user, term = nil)
+    s = user.name + ' ' + content_tag(:span, user.email, class: [:feedback, 'feedback-thin', 'feedback-primary'])
+    mark_tag(s, term)
   end
 
   def user_email_tag(user)

--- a/app/helpers/workbench/display_helper.rb
+++ b/app/helpers/workbench/display_helper.rb
@@ -80,15 +80,4 @@ module Workbench::DisplayHelper
     object.class.base_class.name.tableize.to_s
   end
 
-  # @return [String, nil]
-  #   use `mark` tags to highlight the position of the term in the text
-  def regex_mark_tag(text, term)
-    return text if term.nil?
-    if t = text[/#{Regexp.escape(term)}/i]  # probably some look-ahead (behind) magic could be used here
-      text.gsub(/#{Regexp.escape(term)}/i, "<mark>#{t}</mark>")
-    else
-      text
-    end
-  end
-
 end

--- a/app/helpers/workbench/html_helper.rb
+++ b/app/helpers/workbench/html_helper.rb
@@ -6,14 +6,24 @@ module Workbench::HtmlHelper
   # TODO: see also highlight()
   # @return [String, nil]
   #   markup a string, skipping matches inside HTML tags (e.g. attribute values)
-  def mark_tag(string, term)
+  # @param html_safe [Boolean]
+  #   pass false when the caller keeps building the result with plain
+  #   String#+/+=  and applies .html_safe itself at the end - otherwise
+  #   an already-safe return value here causes later unsafe appends to
+  #   get HTML-escaped by ActiveSupport::SafeBuffer#+
+  def mark_tag(string, term, html_safe: true)
     return nil if string.nil?
-    return string if term.blank?
-    t = Regexp.escape(term)
 
-    string.split(/(<[^>]*>)/).map { |piece|
-      piece.start_with?('<') ? piece : piece.gsub(/(#{t})/i) { content_tag(:mark, $1) }
-    }.join.html_safe
+    s = if term.blank?
+      string
+    else
+      t = Regexp.escape(term)
+      string.split(/(<[^>]*>)/).map { |piece|
+        piece.start_with?('<') ? piece : piece.gsub(/(#{t})/i) { content_tag(:mark, $1) }
+      }.join
+    end
+
+    html_safe ? s.html_safe : String.new(s)
   end
 
 end

--- a/app/helpers/workbench/html_helper.rb
+++ b/app/helpers/workbench/html_helper.rb
@@ -1,4 +1,4 @@
-# Basic, non model dependent helpers that inject HTML, 
+# Basic, non model dependent helpers that inject HTML,
 # these should all depend on Rails helpers, if they don't
 # they should go into Utilities
 module Workbench::HtmlHelper
@@ -19,7 +19,13 @@ module Workbench::HtmlHelper
     else
       t = Regexp.escape(term)
       string.split(/(<[^>]*>)/).map { |piece|
-        piece.start_with?('<') ? piece : piece.gsub(/(#{t})/i) { content_tag(:mark, $1) }
+        next piece if piece.start_with?('<')
+
+        # We split on the html entities content_tag could produce (though at
+        # time of writing these could also come from user input).
+        piece.split(/(&(?:amp|lt|gt|quot|\#39);)/).map { |chunk|
+          chunk.start_with?('&') ? chunk : chunk.gsub(/(#{t})/i) { content_tag(:mark, $1) }
+        }.join
       }.join
     end
 

--- a/app/helpers/workbench/html_helper.rb
+++ b/app/helpers/workbench/html_helper.rb
@@ -5,14 +5,15 @@ module Workbench::HtmlHelper
 
   # TODO: see also highlight()
   # @return [String, nil]
-  #   markup a string
+  #   markup a string, skipping matches inside HTML tags (e.g. attribute values)
   def mark_tag(string, term)
     return nil if string.nil?
-    return string if term.nil?
+    return string if term.blank?
     t = Regexp.escape(term)
 
-    # (?!>) Don't substitute if the next character is a closing paren
-    string.gsub(/(#{t})(?!>)/i, content_tag(:mark, '\1')).html_safe
+    string.split(/(<[^>]*>)/).map { |piece|
+      piece.start_with?('<') ? piece : piece.gsub(/(#{t})/i) { content_tag(:mark, $1) }
+    }.join.html_safe
   end
 
 end

--- a/app/views/anatomical_parts/autocomplete.json.jbuilder
+++ b/app/views/anatomical_parts/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @anatomical_parts do |ap|
   json.gid ap.to_global_id.to_s
   json.id ap.id
   json.label label_for_anatomical_part(ap)
-  json.label_html anatomical_part_autocomplete_tag(ap)
+  json.label_html anatomical_part_autocomplete_tag(ap, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/asserted_distributions/autocomplete.json.jbuilder
+++ b/app/views/asserted_distributions/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @asserted_distributions do |a|
   v = asserted_distribution_tag(a)
   json.id a.id
   json.label v
-  json.label_html v 
+  json.label_html asserted_distribution_autocomplete_tag(a, params[:term])
 
   json.response_values do 
     if params[:method]

--- a/app/views/biological_associations/autocomplete.json.jbuilder
+++ b/app/views/biological_associations/autocomplete.json.jbuilder
@@ -3,7 +3,7 @@ json.array! @biological_associations do |b|
   json.gid b.to_global_id.to_s
 
   json.label label_for_biological_association(b)
-  json.label_html biological_association_autocomplete_tag(b)
+  json.label_html biological_association_autocomplete_tag(b, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/biological_associations_graphs/autocomplete.json.jbuilder
+++ b/app/views/biological_associations_graphs/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @biological_associations_graphs.each do |t|
   json.id t.id
   json.label biological_associations_graph_tag(t)
-  json.label_html biological_associations_graph_tag(t) 
+  json.label_html biological_associations_graph_autocomplete_tag(t, params[:term])
   json.gid t.to_global_id.to_s
 
   json.response_values do 

--- a/app/views/biological_relationships/autocomplete.json.jbuilder
+++ b/app/views/biological_relationships/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @biological_relationships do |t|
   json.id t.id
   json.label biological_relationship_tag(t)
-  json.label_html biological_relationship_tag(t)
+  json.label_html biological_relationship_autocomplete_tag(t, params[:term])
 
   json.response_values do 
     if params[:method]

--- a/app/views/collecting_events/autocomplete.json.jbuilder
+++ b/app/views/collecting_events/autocomplete.json.jbuilder
@@ -3,7 +3,7 @@ json.array! @collecting_events do |s|
   json.id s.id
   json.label v
 
-  json.label_html collecting_event_autocomplete_tag(s)
+  json.label_html collecting_event_autocomplete_tag(s, term: params[:term])
 
   json.response_values do 
     if params[:method]

--- a/app/views/collection_objects/autocomplete.json.jbuilder
+++ b/app/views/collection_objects/autocomplete.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @collection_objects do |s|
-  v = collection_object_autocomplete_tag(s)
+  v = collection_object_autocomplete_tag(s, params[:term])
   json.id s.id
   json.label label_for_collection_object(s)
   json.gid s.to_global_id.to_s

--- a/app/views/containers/autocomplete.json.jbuilder
+++ b/app/views/containers/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @containers do |c|
   json.id c.id
   json.label label_for_container(c)
   json.gid c.to_global_id.to_s
-  json.label_html container_autocomplete_tag(c) 
+  json.label_html container_autocomplete_tag(c, params[:term])
 
   json.response_values do 
     if params[:method]

--- a/app/views/controlled_vocabulary_terms/autocomplete.json.jbuilder
+++ b/app/views/controlled_vocabulary_terms/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @controlled_vocabulary_terms do |c|
   json.extract! c, :id
   json.label c.name
-  json.label_html controlled_vocabulary_term_autocomplete_tag(c)
+  json.label_html controlled_vocabulary_term_autocomplete_tag(c, params[:term])
 
   json.response_values do
     json.set! params[:method], c.id

--- a/app/views/conveyances/autocomplete.json.jbuilder
+++ b/app/views/conveyances/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @conveyances do |c|
   json.gid c.to_global_id.to_s
   json.id c.id
   json.label label_for_conveyance(c)
-  json.label_html conveyance_autocomplete_tag(c)
+  json.label_html conveyance_autocomplete_tag(c, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/data_attributes/autocomplete.json.jbuilder
+++ b/app/views/data_attributes/autocomplete.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @data_attributes do |i|
-  v = data_attribute_autocomplete_tag(i)
+  v = data_attribute_autocomplete_tag(i, params[:term])
   
   json.id i.id
 

--- a/app/views/depictions/autocomplete.json.jbuilder
+++ b/app/views/depictions/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @depictions do |d|
   json.gid d.to_global_id.to_s
   json.id d.id
   json.label label_for_depiction(d)
-  json.label_html depiction_autocomplete_tag(d)
+  json.label_html depiction_autocomplete_tag(d, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/documents/autocomplete.json.jbuilder
+++ b/app/views/documents/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @documents do |s|
   v = document_tag(s)
   json.id s.id
   json.label v
-  json.label_html v 
+  json.label_html document_autocomplete_tag(s, params[:term])
 
   json.response_values do 
     if params[:method]

--- a/app/views/extracts/autocomplete.json.jbuilder
+++ b/app/views/extracts/autocomplete.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @extracts do |s|
-  v = extract_autocomplete_tag(s)
+  v = extract_autocomplete_tag(s, params[:term])
   json.id s.id
   json.label  label_for_extract(s)
   json.gid s.to_global_id.to_s

--- a/app/views/field_occurrences/autocomplete.json.jbuilder
+++ b/app/views/field_occurrences/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @field_occurrences do |p|
   json.id p.id
   json.label label_for_field_occurrence(p)
-  json.label_html field_occurrence_autocomplete_tag(p)
+  json.label_html field_occurrence_autocomplete_tag(p, params[:term])
 
   json.object_id p.id
 

--- a/app/views/gazetteers/autocomplete.json.jbuilder
+++ b/app/views/gazetteers/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @gazetteers do |g|
   json.gid g.to_global_id.to_s
   json.id g.id
   json.label label_for_gazetteer(g)
-  json.label_html gazetteer_autocomplete_tag(g)
+  json.label_html gazetteer_autocomplete_tag(g, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/identifiers/autocomplete.json.jbuilder
+++ b/app/views/identifiers/autocomplete.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @identifiers do |i|
-  v = identifier_autocomplete_tag(i)
+  v = identifier_autocomplete_tag(i, params[:term])
   json.id i.id
   json.label i.cached
   json.label_html v

--- a/app/views/leads/autocomplete.json.jbuilder
+++ b/app/views/leads/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @leads do |l|
   json.gid l.to_global_id.to_s
   json.id l.id
   json.label label_for_lead(l)
-  json.label_html lead_autocomplete_tag(l)
+  json.label_html lead_autocomplete_tag(l, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/loans/autocomplete.json.jbuilder
+++ b/app/views/loans/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @loans do |l|
   json.gid l.to_global_id.to_s
   json.id l.id
   json.label label_for_loan(l)
-  json.label_html loan_autocomplete_tag(l)
+  json.label_html loan_autocomplete_tag(l, params[:term])
 
   json.response_values do 
     if params[:method]

--- a/app/views/namespaces/autocomplete.json.jbuilder
+++ b/app/views/namespaces/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @namespaces do |n|
   json.id n.id
   json.label n.name
-  json.label_html namespace_autocomplete_tag(n)
+  json.label_html namespace_autocomplete_tag(n, params[:term])
   json.short_name n.short_name
 
   json.response_values do 

--- a/app/views/observation_matrices/autocomplete.json.jbuilder
+++ b/app/views/observation_matrices/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @observation_matrices do |m|
   json.id m.id
   json.label m.name
   json.gid m.to_global_id.to_s 
-  json.label_html m.name
+  json.label_html mark_tag(m.name, params[:term])
 
   json.response_values do 
     if params[:method]

--- a/app/views/observations/autocomplete.json.jbuilder
+++ b/app/views/observations/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @observations do |o|
   json.gid o.to_global_id.to_s
   json.id o.id
   json.label label_for_observation(o)
-  json.label_html observation_autocomplete_tag(o)
+  json.label_html observation_autocomplete_tag(o, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/organizations/autocomplete.json.jbuilder
+++ b/app/views/organizations/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @organizations do |t|
   json.id t.id
   json.label t.name 
-  json.label_html organization_tag(t)
+  json.label_html organization_autocomplete_tag(t, params[:term])
   json.gid t.to_global_id.to_s
 
   json.response_values do 

--- a/app/views/otus/autocomplete.json.jbuilder
+++ b/app/views/otus/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @otus do |t|
   json.id t.id
   json.label otu_autocomplete_selected_tag(t)
-  json.label_html otu_tag(t)
+  json.label_html otu_autocomplete_tag(t, params[:term])
   json.gid t.to_global_id.to_s
 
   json.response_values do 

--- a/app/views/people/autocomplete.json.jbuilder
+++ b/app/views/people/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @people do |p|
   json.id p.id
   json.label person_tag(p)
-  json.label_html person_autocomplete_tag(p)
+  json.label_html person_autocomplete_tag(p, params[:term])
 
   json.object_id p.id # backwards compatability for lookup_person
 

--- a/app/views/preparation_types/autocomplete.json.jbuilder
+++ b/app/views/preparation_types/autocomplete.json.jbuilder
@@ -2,7 +2,7 @@ json.array! @preparation_types do |p|
   json.gid p.to_global_id.to_s
   json.id p.id
   json.label label_for_preparation_type(p)
-  json.label_html preparation_type_autocomplete_tag(p)
+  json.label_html preparation_type_autocomplete_tag(p, params[:term])
 
   json.response_values do
     if params[:method]

--- a/app/views/repositories/autocomplete.json.jbuilder
+++ b/app/views/repositories/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @repositories do |t|
   json.id t.id
   json.label t.name
-  json.label_html repository_autocomplete_tag(t)
+  json.label_html repository_autocomplete_tag(t, params[:term])
   json.gid t.to_global_id.to_s
 
   json.response_values do 

--- a/app/views/sounds/autocomplete.json.jbuilder
+++ b/app/views/sounds/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @sounds do |t|
   json.id t.id
   json.label t.name
-  json.label_html sound_tag(t)
+  json.label_html sound_autocomplete_tag(t, params[:term])
   json.gid t.to_global_id.to_s
 
   json.response_values do 

--- a/app/views/users/autocomplete.json.jbuilder
+++ b/app/views/users/autocomplete.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @users do |t|
   json.id t.id
   json.label t.name
-  json.label_html user_autocomplete_tag(t)
+  json.label_html user_autocomplete_tag(t, params[:term])
   json.gid t.to_global_id.to_s
 
   json.response_values do

--- a/spec/helpers/workbench/html_helper_spec.rb
+++ b/spec/helpers/workbench/html_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe Workbench::HtmlHelper, type: :helper do
+
+  specify '#mark_tag wraps a matching term in <mark>' do
+    expect(helper.mark_tag('plain text term here', 'term')).to eq('plain text <mark>term</mark> here')
+  end
+
+  specify '#mark_tag is case insensitive' do
+    expect(helper.mark_tag('Plain Text', 'text')).to eq('Plain <mark>Text</mark>')
+  end
+
+  specify '#mark_tag wraps all occurrences of the term' do
+    expect(helper.mark_tag('term term', 'term')).to eq('<mark>term</mark> <mark>term</mark>')
+  end
+
+  specify '#mark_tag escapes regex special characters in the term' do
+    expect(helper.mark_tag('a (b) c', '(b)')).to eq('a <mark>(b)</mark> c')
+  end
+
+  specify '#mark_tag does not mark text inside HTML tag attributes' do
+    expect(helper.mark_tag('<span title="Catalog Number">ABC123</span>', 'Catalog'))
+      .to eq('<span title="Catalog Number">ABC123</span>')
+  end
+
+  specify '#mark_tag marks matching visible text alongside untouched markup' do
+    expect(helper.mark_tag('<span title="Catalog Number">ABC123</span>', 'ABC'))
+      .to eq('<span title="Catalog Number"><mark>ABC</mark>123</span>')
+  end
+
+  specify '#mark_tag returns nil when the string is nil' do
+    expect(helper.mark_tag(nil, 'term')).to be_nil
+  end
+
+  specify '#mark_tag returns the string unchanged when the term is nil' do
+    expect(helper.mark_tag('abc', nil)).to eq('abc')
+  end
+
+  specify '#mark_tag returns the string unchanged when the term is blank' do
+    expect(helper.mark_tag('abc', '')).to eq('abc')
+  end
+
+  specify '#mark_tag returns an html_safe string' do
+    expect(helper.mark_tag('term', 'term')).to be_html_safe
+  end
+
+end

--- a/spec/helpers/workbench/html_helper_spec.rb
+++ b/spec/helpers/workbench/html_helper_spec.rb
@@ -44,4 +44,21 @@ describe Workbench::HtmlHelper, type: :helper do
     expect(helper.mark_tag('term', 'term')).to be_html_safe
   end
 
+  specify '#mark_tag returns a non-html_safe string when html_safe: false' do
+    expect(helper.mark_tag('term', 'term', html_safe: false)).to_not be_html_safe
+  end
+
+  specify '#mark_tag with html_safe: false still marks the term' do
+    expect(helper.mark_tag('plain text term here', 'term', html_safe: false))
+      .to eq('plain text <mark>term</mark> here')
+  end
+
+  specify '#mark_tag with html_safe: false does not leak safety from a caller that keeps concatenating' do
+    # Guards against ActiveSupport::SafeBuffer#+ escaping later unsafe appends
+    # when the accumulator was seeded with an already-safe mark_tag result.
+    s = helper.mark_tag('term', 'term', html_safe: false)
+    s += ' ' + helper.content_tag(:span, 'x')
+    expect(s).to eq('<mark>term</mark> <span>x</span>')
+  end
+
 end

--- a/spec/helpers/workbench/html_helper_spec.rb
+++ b/spec/helpers/workbench/html_helper_spec.rb
@@ -28,6 +28,14 @@ describe Workbench::HtmlHelper, type: :helper do
       .to eq('<span title="Catalog Number"><mark>ABC</mark>123</span>')
   end
 
+  specify '#mark_tag does not mark text inside an HTML entity' do
+    expect(helper.mark_tag('AT&amp;T', 'amp')).to eq('AT&amp;T')
+  end
+
+  specify '#mark_tag still marks visible text adjacent to an HTML entity' do
+    expect(helper.mark_tag('Smith &amp; term', 'term')).to eq('Smith &amp; <mark>term</mark>')
+  end
+
   specify '#mark_tag returns nil when the string is nil' do
     expect(helper.mark_tag(nil, 'term')).to be_nil
   end


### PR DESCRIPTION
* switched to a single mark function that:
  * doesn't mark inside html tags (<...>) or the common html entities (`&amp;` e.g.)
  * does *not* mark across html boundaries
* *all* autocompletes now mark their output (though we may decide that's not what we want)
* switched to a new mark color because the previous color didn't work against the gray of OTUs:
<img width="712" height="116" alt="image" src="https://github.com/user-attachments/assets/66a56970-6b78-4ea6-add2-ba7959ad453b" />
<img width="728" height="118" alt="image" src="https://github.com/user-attachments/assets/6b5e3209-5115-4f85-b7ee-2c5265aefe29" />
<img width="728" height="118" alt="image" src="https://github.com/user-attachments/assets/5b6c163e-4994-48c1-b640-5ec289db857a" />
<img width="728" height="118" alt="image" src="https://github.com/user-attachments/assets/bf8526fb-f753-4072-8619-61f49e5c31eb" />

@jlpereira / @mjy any feedback? I'm not really tied to any of this; @jlpereira feel free to finish this one off if you want to experiment :)