### PR TITLE
4971 More unify fixes [non-dual FK cherry-picked commits]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - OTU autocomplete sometimes returns unuseful results instead of an exact match, even when an exact match exists [#4994]
 - Biological Association UUID sent to GBIF was bad data (not a UUID)
 - PDF viewer is not rendering pages [#5023]
+- Add 'Exclude' option to Tags and Confidences facets in filters (for finding objects NOT satisfying the given conditions) [#4157]
+- New BA: Forms do not reset if a citation has already been created
 
 [#4157]: https://github.com/SpeciesFileGroup/taxonworks/issues/4157
 [#4937]: https://github.com/SpeciesFileGroup/taxonworks/issues/4937

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,14 +41,14 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Unify fixes related to: Georeferences when Collecting Events are unified, matrix columns when descriptors are unified, and dynamix matrix rows/columns when dynamic data are unified [#4944]
 - Unify now preserves list order of associated data: e.g. if two Collection Objects are unified, the kept object has its original list of Taxon Determinations in the same order, followed by the Taxon Determinations of the destroyed Collection Object in their original order
 - Can't unify two Taxon Names when they have the same relationship type from/to a same third Taxon Name [#4971]
+- A "successful" unify between two Taxon Names, one of which has a synonym, can leave the synonym in an unusable state [#4971]
+- Unify of two Asserted Distributions with the "same" Citation can cause loss of annotation data from the citation that gets destroyed [#4971]
 - Monograph facilitator: Determination label is not visible in Safari browser
 - Checklist importer crashing on empty `originalNameUsageID` in some cases
 - Source and Repository autocompletes sometimes miss results, repository usage counts were sometimes wrong [#4990]
 - OTU autocomplete sometimes returns unuseful results instead of an exact match, even when an exact match exists [#4994]
 - Biological Association UUID sent to GBIF was bad data (not a UUID)
 - PDF viewer is not rendering pages [#5023]
-- Add 'Exclude' option to Tags and Confidences facets in filters (for finding objects NOT satisfying the given conditions) [#4157]
-- New BA: Forms do not reset if a citation has already been created
 
 [#4157]: https://github.com/SpeciesFileGroup/taxonworks/issues/4157
 [#4937]: https://github.com/SpeciesFileGroup/taxonworks/issues/4937

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Collecting Events with Georeferences raise an error when attempting to destroy [#4937]
 - Unify fixes related to: Georeferences when Collecting Events are unified, matrix columns when descriptors are unified, and dynamix matrix rows/columns when dynamic data are unified [#4944]
 - Unify now preserves list order of associated data: e.g. if two Collection Objects are unified, the kept object has its original list of Taxon Determinations in the same order, followed by the Taxon Determinations of the destroyed Collection Object in their original order
+- Can't unify two Taxon Names when they have the same relationship type from/to a same third Taxon Name [#4971]
 - Monograph facilitator: Determination label is not visible in Safari browser
 - Checklist importer crashing on empty `originalNameUsageID` in some cases
 - Source and Repository autocompletes sometimes miss results, repository usage counts were sometimes wrong [#4990]
@@ -61,6 +62,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 [#4994]: https://github.com/SpeciesFileGroup/taxonworks/issues/4994
 [#5017]: https://github.com/SpeciesFileGroup/taxonworks/issues/5017
 [#5023]: https://github.com/SpeciesFileGroup/taxonworks/issues/5023
+[#4971]: https://github.com/SpeciesFileGroup/taxonworks/issues/4971
 
 ## [0.63.1] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This project <em>does not yet</em> adhere to [Semantic Versioning](https://semve
 - Can't unify two Taxon Names when they have the same relationship type from/to a same third Taxon Name [#4971]
 - A "successful" unify between two Taxon Names, one of which has a synonym, can leave the synonym in an unusable state [#4971]
 - Unify of two Asserted Distributions with the "same" Citation can cause loss of annotation data from the citation that gets destroyed [#4971]
+- Unify blocked by "duplicate" is_original citations now works [#4971]
 - Monograph facilitator: Determination label is not visible in Safari browser
 - Checklist importer crashing on empty `originalNameUsageID` in some cases
 - Source and Repository autocompletes sometimes miss results, repository usage counts were sometimes wrong [#4990]

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -145,6 +145,19 @@ class Citation < ApplicationRecord
   # citation_object is itself confirmed to be the record actually being
   # destroyed (on_behalf_of) -- it's not losing its last citation, it's going
   # away entirely.
+  # TODO: ignore_citation_restriction is plain in-memory state, not covered
+  # by the transaction -- if the surrounding unify call later rolls back
+  # (preview: true always does; so could a later failure in the same merge),
+  # the DB reverts but this flag stays true on whatever in-memory
+  # citation_object instance we set it on. Only matters if a caller reuses
+  # that same instance afterward (a script/console/rake task previewing
+  # several unifies, say), not a per-request web flow. Shared::CitationRequired's
+  # own before_destroy already has the identical property for a plain
+  # (non-unify) destroy, so this isn't a new kind of gap, just a new path to
+  # it. A real fix would add a symmetric "cleanup" hook to Shared::Unify,
+  # called in an ensure right after the destroy attempt, so this flag only
+  # stays true for the duration of that attempt rather than however long
+  # the caller holds the object.
   def prepare_for_unify_destroy(on_behalf_of)
     return unless on_behalf_of == citation_object
 

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -171,10 +171,10 @@ class Citation < ApplicationRecord
     return if marked_for_destruction?
     return if citation_object && citation_object.respond_to?(:ignore_citation_restriction) && citation_object.ignore_citation_restriction
 
-    # citation_object may not be the same in-memory instance that an
-    # enclosing Shared::Unify#unify call is destroying (e.g. loaded fresh via
-    # this belongs_to rather than the instance unify holds), so this checks
-    # by identity (id/type), not object reference - see UnifyDestroyContext.
+    # Allow the destroy if citation_object itself is already committed to
+    # being destroyed by an enclosing Shared::Unify#unify call - it's not
+    # losing its last citation, it's going away entirely, so the "must have
+    # at least one citation" guard below is moot.
     return if citation_object && UnifyDestroyContext.objects_in_destroy&.include?(
       { id: citation_object.id, type: citation_object.class.base_class.name }
     )

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -140,30 +140,6 @@ class Citation < ApplicationRecord
     BiologicalAssociationIndex.where(biological_association_id: citation_object_id)
   end
 
-  # See Shared::Unify#prepare_for_unify_destroy. citation_object may require
-  # at least one citation (Shared::CitationRequired), but that's moot if
-  # citation_object is itself confirmed to be the record actually being
-  # destroyed (on_behalf_of) -- it's not losing its last citation, it's going
-  # away entirely.
-  # TODO: ignore_citation_restriction is plain in-memory state, not covered
-  # by the transaction -- if the surrounding unify call later rolls back
-  # (preview: true always does; so could a later failure in the same merge),
-  # the DB reverts but this flag stays true on whatever in-memory
-  # citation_object instance we set it on. Only matters if a caller reuses
-  # that same instance afterward (a script/console/rake task previewing
-  # several unifies, say), not a per-request web flow. Shared::CitationRequired's
-  # own before_destroy already has the identical property for a plain
-  # (non-unify) destroy, so this isn't a new kind of gap, just a new path to
-  # it. A real fix would add a symmetric "cleanup" hook to Shared::Unify,
-  # called in an ensure right after the destroy attempt, so this flag only
-  # stays true for the duration of that attempt rather than however long
-  # the caller holds the object.
-  def prepare_for_unify_destroy(on_behalf_of)
-    return unless on_behalf_of == citation_object
-
-    citation_object.ignore_citation_restriction = true if citation_object.respond_to?(:ignore_citation_restriction)
-  end
-
   protected
 
   def add_source_to_project
@@ -194,6 +170,14 @@ class Citation < ApplicationRecord
     # the parent instead, where everything 'just works'.
     return if marked_for_destruction?
     return if citation_object && citation_object.respond_to?(:ignore_citation_restriction) && citation_object.ignore_citation_restriction
+
+    # citation_object may not be the same in-memory instance that an
+    # enclosing Shared::Unify#unify call is destroying (e.g. loaded fresh via
+    # this belongs_to rather than the instance unify holds), so this checks
+    # by identity (id/type), not object reference - see UnifyDestroyContext.
+    return if citation_object && UnifyDestroyContext.objects_in_destroy&.include?(
+      { id: citation_object.id, type: citation_object.class.base_class.name }
+    )
 
     if citation_object.requires_citation? && citation_object.citations.count == 1
       errors.add(:base, 'at least one citation is required')

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -140,6 +140,17 @@ class Citation < ApplicationRecord
     BiologicalAssociationIndex.where(biological_association_id: citation_object_id)
   end
 
+  # See Shared::Unify#prepare_for_unify_destroy. citation_object may require
+  # at least one citation (Shared::CitationRequired), but that's moot if
+  # citation_object is itself confirmed to be the record actually being
+  # destroyed (on_behalf_of) -- it's not losing its last citation, it's going
+  # away entirely.
+  def prepare_for_unify_destroy(on_behalf_of)
+    return unless on_behalf_of == citation_object
+
+    citation_object.ignore_citation_restriction = true if citation_object.respond_to?(:ignore_citation_restriction)
+  end
+
   protected
 
   def add_source_to_project

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -40,6 +40,12 @@ class Citation < ApplicationRecord
 
   attr_accessor :no_cached
 
+  # unify's dedup logic resets is_original to false on a would-be duplicate
+  # before comparing it to the surviving Citation via #identical; if
+  # is_original weren't ignored here that reset would make the two look
+  # different and the duplicate would never be matched.
+  IGNORE_IDENTICAL = [:is_original].freeze
+
   polymorphic_annotates('citation_object')
 
   # belongs_to :source, inverse_of: :origin_citations

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -364,10 +364,6 @@ module Shared::Unify
         result[:details][n][:errors].push( {id: object.id, message: object.errors.full_messages.join('; ')} )
       end
     else
-      # The update succeeded outright. Do not reload: reload clears the
-      # in-memory dirty-tracking (`saved_changes`/`_previously_changed?`)
-      # that object's own deferred `after_commit` callbacks may depend on
-      # to decide whether to recompute cached values (e.g. TaxonNameRelationship).
       result[:details][n][:merged] += 1
     end
 

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -293,7 +293,7 @@ module Shared::Unify
 
     if !is_community?
       if project_id != remove_object.project_id
-        s.merge!(
+        s[:result].merge!(
           unified: false,
           message: 'Danger, objects come from different projects.')
       end

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -383,22 +383,52 @@ module Shared::Unify
   # records are re-parented, so the restore below is independent of how
   # acts_as_list repositions records during update.
   # Returns nil when the association does not use acts_as_list.
+  #
+  # Also captures each record's own acts_as_list scope column values (e.g.
+  # a TaxonDetermination's taxon_determination_object_id/_type), not just
+  # its id: existing (self's) and incoming (remove_object's) has_many
+  # members can straddle multiple *different* real acts_as_list scope
+  # groups at once - e.g. taxon determinations on different collection objects
+  # when unifying OTUs (see specs).
   def snapshot_list_order(relation, incoming)
     related_class = incoming.klass
     return nil unless related_class.respond_to?(:acts_as_list_options)
+
+    # reassigned_columns values are going to be set to self's values after a
+    # successful relation move, so *don't* scope by them when grouping
+    # acts_as_list groups (they're currently different than self! - see specs).
+    reassigned_columns = [relation.foreign_key, relation.type].compact
+    scope_columns = Array(related_class.acts_as_list_options[:scope])
+      .map { |s| resolve_acts_as_list_scope_column(related_class, s) } - reassigned_columns
+
     {
       klass: related_class,
-      existing_ids: send(relation.name).order(:position).pluck(:id),
-      incoming_ids: incoming.order(:position).pluck(:id)
+      existing: send(relation.name).order(:position).pluck(:id, *scope_columns),
+      incoming: incoming.order(:position).pluck(:id, *scope_columns)
     }
   end
 
+  # acts_as_list scope: [...] entries may be either a real column name, or
+  # a belongs_to association name that acts_as_list itself resolves to that
+  # association's foreign_key (e.g. LoanItem's `scope: [:loan, :project_id]`)
+  # - resolve the same way here so grouping in restore_list_order is keyed
+  # by the real column acts_as_list itself scopes by.
+  def resolve_acts_as_list_scope_column(klass, name)
+    return name.to_s if klass.column_names.include?(name.to_s)
+
+    r = klass.reflect_on_association(name)
+    r&.belongs_to? ? r.foreign_key : name.to_s
+  end
+
   # Re-apply the pre-merge position order captured by snapshot_list_order,
-  # appending incoming records after the surviving object's existing records.
+  # appending incoming records after the surviving object's existing
+  # records.
   def restore_list_order(state)
-    (state[:existing_ids] + state[:incoming_ids]).each_with_index do |id, idx|
-      state[:klass].where(id:).update_all(position: idx + 1)
-    end
+    (state[:existing] + state[:incoming])
+      .group_by { |row| row[1..] } # each row's own scope column values
+      .each_value do |rows|
+        rows.each_with_index { |row, idx| state[:klass].where(id: row[0]).update_all(position: idx + 1) }
+      end
   end
 
 end

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -356,35 +356,32 @@ module Shared::Unify
       object.save
     end
 
-    # One degree of seperation issue
+    # If the attempted move failed, it may be because an identical record
+    # already exists on self (a duplicate) -- try to find and merge into it.
+    # #identical won't match unless there's a genuine duplicate, so this is
+    # safe to attempt for *any* validation failure, not just the ones that
+    # look like a uniqueness conflict.
     #
-    # Here we check to see that the error is related
-    # to the object being unified, if not,
-    # we don't know how to handle this with confidence.
-    inv = relation.options[:inverse_of]
-    if error_related_to_relation?(object, inv)
-
-      # object can't be updated, move its annotations to self.
+    # !! If the attempt doesn't pan out (no identical match, or a match was
+    # found but merging into it failed), report unmerged directly -- do NOT
+    # reload object and treat "valid in its old, unmoved position" as good
+    # enough to call merged. It's tempting (object reverted to a position it
+    # was already valid in, so what's the harm), but it's wrong: it silently
+    # leaves object attached to remove_object, which is about to be
+    # destroyed, while reporting success. Whether that's later caught by a
+    # cascade delete or leaves an orphan varies per relation and isn't
+    # something to gamble on here -- the honest answer is that the requested
+    # move could not be completed, so the record needs to be reported
+    # unmerged and the failure needs to be surfaced.
+    if object.errors.any?
       dedup_result = deduplicate_update_target(object, o)
-      unless dedup_result && dedup_result[:result][:unified]
-        result[:result][:unified] = false
-        result[:details][n][:unmerged] += 1
-        result[:details][n][:errors] ||= []
-        result[:details][n][:errors].push( {id: object.id, message: object.errors.full_messages.join('; ')} )
-      else # We unified and destroyed the duplicate
+      if dedup_result && dedup_result[:result][:unified]
         result[:details][n][:deduplicated] += 1
-      end
-    elsif object.errors.any?
-      # There are unrelated errors we can not fix, ensure we have a fresh
-      # copy of the object and check for validity.
-      object.reload
-      if object.invalid?
+      else
         result[:result][:unified] = false
         result[:details][n][:unmerged] += 1
         result[:details][n][:errors] ||= []
         result[:details][n][:errors].push( {id: object.id, message: object.errors.full_messages.join('; ')} )
-      else
-        result[:details][n][:merged] += 1
       end
     else
       # The update succeeded outright. Do not reload: reload clears the
@@ -395,24 +392,6 @@ module Shared::Unify
     end
 
     result
-  end
-
-  # @return [Boolean]
-  #   true when `object`'s save failed because of the relation we just tried
-  #   to flip (`inv`/`inv_id`) -- either Rails reported the error directly on
-  #   that association/column, or a uniqueness validator *scoped by* that
-  #   association/column reported its error on a different attribute (e.g.
-  #   `validates_uniqueness_of :source_id, scope: [:citation_object_id, ...]`
-  #   reports on :source_id, not :citation_object_id, when a Citation can't
-  #   be moved onto an object that already has an identical one).
-  def error_related_to_relation?(object, inv)
-    return true if object.errors.details.keys.include?(inv) || object.errors.details.keys.include?(:"#{inv}_id")
-
-    fk = :"#{inv}_id"
-    object.class.validators.grep(ActiveRecord::Validations::UniquenessValidator).any? do |v|
-      Array(v.options[:scope]).any? { |s| s == inv || s == fk } &&
-        v.attributes.any? { |a| object.errors.details.key?(a) }
-    end
   end
 
   def stub_unify_result(result, relation_name, attempted)

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -87,6 +87,21 @@ module Shared::Unify
     []
   end
 
+  # Override to prepare an object for its own destruction by unify, e.g. to
+  # flag a validation on a still-alive parent that would otherwise block the
+  # destroy (see Citation, whose citation_object may require at least one
+  # citation -- moot once citation_object is itself confirmed to be the
+  # record actually being destroyed).
+  #
+  # @param on_behalf_of [ActiveRecord::Base, nil] the record actually being
+  #   destroyed by this destroy's ultimate cause: when this destroy is
+  #   happening inside deduplicate_update_target, that's the enclosing
+  #   #unify call's remove_object (deduplicate_update_target's remove_object
+  #   is always this level's own parent); nil for a top-level #unify call
+  #   with no enclosing dedup.
+  def prepare_for_unify_destroy(on_behalf_of)
+  end
+
   # See header.
   #
   # @return Hash
@@ -111,7 +126,11 @@ module Shared::Unify
   # @param target_project_id [Integer]
   #   required when self is_community?, scopes operations to target project only
   #
-  def unify(remove_object, only: [], except: [], preview: false, cutoff: 250, target_project_id: nil)
+  # @param on_behalf_of [ActiveRecord::Base, nil]
+  #   see Shared::Unify#prepare_for_unify_destroy; set internally by
+  #   deduplicate_update_target, not intended to be passed by other callers
+  #
+  def unify(remove_object, only: [], except: [], preview: false, cutoff: 250, target_project_id: nil, on_behalf_of: nil)
     s = {
       result: { unified: nil, total_related: 0, target_project_id:},
       details: {},
@@ -149,7 +168,7 @@ module Shared::Unify
 
           i.find_each do |j|
             j.update(r.options[:inverse_of] => self)
-            log_unify_result(j, r, s)
+            log_unify_result(j, r, s, o)
           end
 
           restore_list_order(list_state) if list_state
@@ -160,7 +179,7 @@ module Shared::Unify
             stub_unify_result(s, n, 1)
 
             i.update(r.options[:inverse_of] => self)
-            log_unify_result(i, r, s)
+            log_unify_result(i, r, s, o)
           end
         end
       end
@@ -174,6 +193,7 @@ module Shared::Unify
           o.reload # reset all in-memory has_many caches that would prevent destroy
 
           unless only.any? || except.any?
+            o.prepare_for_unify_destroy(on_behalf_of)
             o.destroy!
           end
 
@@ -285,13 +305,20 @@ module Shared::Unify
     s
   end
 
-  def deduplicate_update_target(object)
+  # @param object [ActiveRecord::Base] see log_unify_result
+  # @param o [ActiveRecord::Base] see log_unify_result -- object's real
+  #   parent, passed through as on_behalf_of (see #unify)
+  def deduplicate_update_target(object, o)
     i = object.identical
 
     # There is exactly 1 match, merge is unambiguous
     if i.size == 1
       j = i.first
-      j.unify(object.reload)
+      # object's own FK is still dirty from the failed update attempt (it
+      # points at self/KEEP, not o); reload so the nested unify below moves
+      # object's actual remaining relations, not phantom ones based on that
+      # dirty state.
+      j.unify(object.reload, on_behalf_of: o)
     else
       # Merge would be ambiguous, there are multiple matches
       return false
@@ -311,8 +338,10 @@ module Shared::Unify
   #   relation.options[:inverse_of] is the belongs_to on object's class whose FK
   #   we tried to flip
   # @param result [Hash] the running unify result accumulator
+  # @param o [ActiveRecord::Base] the remove_object of the enclosing #unify
+  #   call -- object's real parent, passed through to deduplicate_update_target
   # @return result Hash
-  def log_unify_result(object, relation, result)
+  def log_unify_result(object, relation, result, o)
     n = relation.name.to_s.humanize
 
     # Handle an edge case, preserve Citations that
@@ -336,7 +365,7 @@ module Shared::Unify
     if error_related_to_relation?(object, inv)
 
       # object can't be updated, move its annotations to self.
-      dedup_result = deduplicate_update_target(object)
+      dedup_result = deduplicate_update_target(object, o)
       unless dedup_result && dedup_result[:result][:unified]
         result[:result][:unified] = false
         result[:details][n][:unmerged] += 1

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -90,15 +90,18 @@ module Shared::Unify
   # Override to prepare an object for its own destruction by unify, e.g. to
   # flag a validation on a still-alive parent that would otherwise block the
   # destroy (see Citation, whose citation_object may require at least one
-  # citation -- moot once citation_object is itself confirmed to be the
+  # citation - moot once citation_object is itself confirmed to be the
   # record actually being destroyed).
   #
-  # @param on_behalf_of [ActiveRecord::Base, nil] the record actually being
-  #   destroyed by this destroy's ultimate cause: when this destroy is
-  #   happening inside deduplicate_update_target, that's the enclosing
-  #   #unify call's remove_object (deduplicate_update_target's remove_object
-  #   is always this level's own parent); nil for a top-level #unify call
-  #   with no enclosing dedup.
+  # @param on_behalf_of [ActiveRecord::Base, nil]
+  #   Normally nil (a plain, top-level #unify call destroys remove_object for
+  #   its own sake). Set only when this destroy is happening because
+  #   deduplicate_update_target found a duplicate and is merging it away --
+  #   in that case it's the parent (remove_object) of the #unify call that
+  #   triggered the merge. Hooks use it to recognize "the thing I'd
+  #   otherwise need to protect is about to be destroyed anyway, for an
+  #   unrelated reason" -- see Citation, which skips its at-least-one-
+  #   citation guard when its own citation_object is on_behalf_of.
   def prepare_for_unify_destroy(on_behalf_of)
   end
 
@@ -306,8 +309,7 @@ module Shared::Unify
   end
 
   # @param object [ActiveRecord::Base] see log_unify_result
-  # @param o [ActiveRecord::Base] see log_unify_result -- object's real
-  #   parent, passed through as on_behalf_of (see #unify)
+  # @param o [ActiveRecord::Base] see log_unify_result - object's real parent
   def deduplicate_update_target(object, o)
     i = object.identical
 
@@ -339,8 +341,7 @@ module Shared::Unify
   #   we tried to flip
   # @param result [Hash] the running unify result accumulator
   # @param o [ActiveRecord::Base] the remove_object of the enclosing #unify
-  #   call -- object's real parent, passed through to deduplicate_update_target
-  # @return result Hash
+  #   call - object's real parent
   def log_unify_result(object, relation, result, o)
     n = relation.name.to_s.humanize
 
@@ -356,25 +357,20 @@ module Shared::Unify
       object.save
     end
 
-    # If the attempted move failed, it may be because an identical record
-    # already exists on self (a duplicate) -- try to find and merge into it.
-    # #identical won't match unless there's a genuine duplicate, so this is
-    # safe to attempt for *any* validation failure, not just the ones that
-    # look like a uniqueness conflict.
-    #
-    # !! If the attempt doesn't pan out (no identical match, or a match was
-    # found but merging into it failed), report unmerged directly -- do NOT
-    # reload object and treat "valid in its old, unmoved position" as good
-    # enough to call merged. It's tempting (object reverted to a position it
-    # was already valid in, so what's the harm), but it's wrong: it silently
-    # leaves object attached to remove_object, which is about to be
-    # destroyed, while reporting success. Whether that's later caught by a
-    # cascade delete or leaves an orphan varies per relation and isn't
-    # something to gamble on here -- the honest answer is that the requested
-    # move could not be completed, so the record needs to be reported
-    # unmerged and the failure needs to be surfaced.
     if object.errors.any?
+      # If the attempted move failed, it may be because an identical record
+      # already exists on self (a duplicate) - try to find and merge into it.
+      # #identical won't match unless there's a genuine duplicate, so this is
+      # safe to attempt for *any* validation failure, not just the ones that
+      # look like a uniqueness conflict.
       dedup_result = deduplicate_update_target(object, o)
+      # object was never reloaded here unless deduplicate_update_target found
+      # a single identical match (in which case success/failure is decided by
+      # the nested unify's own result, not object's own validity) -- so in
+      # the "no match" case object is still exactly as invalid as it was when
+      # `object.errors.any?` was checked above. There's no state in between
+      # where it could have become valid, so there's nothing to re-check.
+      # TODO: followup on the other review recommendations
       if dedup_result && dedup_result[:result][:unified]
         result[:details][n][:deduplicated] += 1
       else

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -333,7 +333,7 @@ module Shared::Unify
     # to the object being unified, if not,
     # we don't know how to handle this with confidence.
     inv = relation.options[:inverse_of]
-    if object.errors.details.keys.include?(inv) || object.errors.details.keys.include?(:"#{inv}_id")
+    if error_related_to_relation?(object, inv)
 
       # object can't be updated, move its annotations to self.
       dedup_result = deduplicate_update_target(object)
@@ -368,6 +368,23 @@ module Shared::Unify
     result
   end
 
+  # @return [Boolean]
+  #   true when `object`'s save failed because of the relation we just tried
+  #   to flip (`inv`/`inv_id`) -- either Rails reported the error directly on
+  #   that association/column, or a uniqueness validator *scoped by* that
+  #   association/column reported its error on a different attribute (e.g.
+  #   `validates_uniqueness_of :source_id, scope: [:citation_object_id, ...]`
+  #   reports on :source_id, not :citation_object_id, when a Citation can't
+  #   be moved onto an object that already has an identical one).
+  def error_related_to_relation?(object, inv)
+    return true if object.errors.details.keys.include?(inv) || object.errors.details.keys.include?(:"#{inv}_id")
+
+    fk = :"#{inv}_id"
+    object.class.validators.grep(ActiveRecord::Validations::UniquenessValidator).any? do |v|
+      Array(v.options[:scope]).any? { |s| s == inv || s == fk } &&
+        v.attributes.any? { |a| object.errors.details.key?(a) }
+    end
+  end
 
   def stub_unify_result(result, relation_name, attempted)
     result[:details].merge!(

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -302,6 +302,15 @@ module Shared::Unify
   # objects issues by moving annotations from the
   # would-be duplicate to an identical existing record.
   #
+  # @param object [ActiveRecord::Base] a record in another table that has a FK
+  #   pointing to the remove_object (DESTROY) being unified away; the unify loop
+  #   just attempted to flip that FK to self (KEEP) and the attempted update is
+  #   reflected in object's in-memory state even if the save failed
+  # @param relation [ActiveRecord::Reflection] the has_many/has_one reflection
+  #   on self (KEEP) for the association being processed;
+  #   relation.options[:inverse_of] is the belongs_to on object's class whose FK
+  #   we tried to flip
+  # @param result [Hash] the running unify result accumulator
   # @return result Hash
   def log_unify_result(object, relation, result)
     n = relation.name.to_s.humanize
@@ -323,7 +332,8 @@ module Shared::Unify
     # Here we check to see that the error is related
     # to the object being unified, if not,
     # we don't know how to handle this with confidence.
-    if object.errors.details.keys.include?(relation.options[:inverse_of])
+    inv = relation.options[:inverse_of]
+    if object.errors.details.keys.include?(inv) || object.errors.details.keys.include?(:"#{inv}_id")
 
       # object can't be updated, move its annotations to self.
       dedup_result = deduplicate_update_target(object)
@@ -335,10 +345,9 @@ module Shared::Unify
       else # We unified and destroyed the duplicate
         result[:details][n][:deduplicated] += 1
       end
-
-      # THere are no errors we can fix, ensure we have a fresh copy
-      # of the object and check for validity.
     else
+      # There are no errors we can fix, ensure we have a fresh copy of the
+      # object and check for validity.
       object.reload
       if object.invalid?
         result[:result][:unified] = false

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -87,24 +87,6 @@ module Shared::Unify
     []
   end
 
-  # Override to prepare an object for its own destruction by unify, e.g. to
-  # flag a validation on a still-alive parent that would otherwise block the
-  # destroy (see Citation, whose citation_object may require at least one
-  # citation - moot once citation_object is itself confirmed to be the
-  # record actually being destroyed).
-  #
-  # @param on_behalf_of [ActiveRecord::Base, nil]
-  #   Normally nil (a plain, top-level #unify call destroys remove_object for
-  #   its own sake). Set only when this destroy is happening because
-  #   deduplicate_update_target found a duplicate and is merging it away --
-  #   in that case it's the parent (remove_object) of the #unify call that
-  #   triggered the merge. Hooks use it to recognize "the thing I'd
-  #   otherwise need to protect is about to be destroyed anyway, for an
-  #   unrelated reason" -- see Citation, which skips its at-least-one-
-  #   citation guard when its own citation_object is on_behalf_of.
-  def prepare_for_unify_destroy(on_behalf_of)
-  end
-
   # See header.
   #
   # @return Hash
@@ -129,11 +111,7 @@ module Shared::Unify
   # @param target_project_id [Integer]
   #   required when self is_community?, scopes operations to target project only
   #
-  # @param on_behalf_of [ActiveRecord::Base, nil]
-  #   see Shared::Unify#prepare_for_unify_destroy; set internally by
-  #   deduplicate_update_target, not intended to be passed by other callers
-  #
-  def unify(remove_object, only: [], except: [], preview: false, cutoff: 250, target_project_id: nil, on_behalf_of: nil)
+  def unify(remove_object, only: [], except: [], preview: false, cutoff: 250, target_project_id: nil)
     s = {
       result: { unified: nil, total_related: 0, target_project_id:},
       details: {},
@@ -143,89 +121,106 @@ module Shared::Unify
     return s if s[:result][:unified] == false
     pid = s[:result][:target_project_id]
 
+    # Whether this call intends to fully destroy remove_object (as opposed
+    # to only:/except: moving some data between the two objects).
+    will_destroy = only.empty? && except.empty?
+    destroy_key = { id: remove_object.id, type: remove_object.class.base_class.name }
+
     self.class.transaction do
       # before_unify # potential hooks, appear not to be required
 
-      merge_relations(only:, except:).each do |r|
-        n = relation_label(r)
-
-        case ::ApplicationEnumeration.relationship_type(r)
-
-        when :has_many
-          i = remove_object.send(r.name)
-
-          unless ::ApplicationEnumeration.relation_targets_community?(r)
-            i = i.where(project_id: pid)
-          end
-
-          next unless i.any?
-
-          t = i.size
-          stub_unify_result(s, n, t)
-
-          s[:result][:total_related] += t
-          next if s[:result][:total_related] > cutoff
-
-          list_state = snapshot_list_order(r, i)
-
-          i.find_each do |j|
-            j.update(r.options[:inverse_of] => self)
-            log_unify_result(j, r, s, remove_object)
-          end
-
-          restore_list_order(list_state) if list_state
-
-        when :has_one, :belongs_to
-          i = remove_object.send(r.name)
-          if !i.nil?
-            stub_unify_result(s, n, 1)
-
-            i.update(r.options[:inverse_of] => self)
-            log_unify_result(i, r, s, remove_object)
-          end
-        end
+      # Record remove_object as committed-to-destruction *before* any related
+      # records are touched below, so "must have at least one X" guards on
+      # those related records (e.g. Citation, TaxonDetermination) can see,
+      # for the whole duration of this call (including any nested unify a
+      # dedup triggers), that it's already slated for destruction regardless
+      # of what happens to its individual annotations.
+      if will_destroy
+        UnifyDestroyContext.objects_in_destroy ||= Set.new
+        UnifyDestroyContext.objects_in_destroy << destroy_key
       end
 
-      if cutoff_hit = s[:result][:total_related] > cutoff
-        s[:result][:unified] = false
-        s[:result][:message] = "Related cutoff threshold (> #{cutoff}) hit, unify is not yet allowed on these objects."
-      elsif s[:result][:unified] != false
+      begin
+        merge_relations(only:, except:).each do |r|
+          n = relation_label(r)
 
-        begin
-          remove_object.reload # reset all in-memory has_many caches that would prevent destroy
+          case ::ApplicationEnumeration.relationship_type(r)
 
-          unless only.any? || except.any?
-            remove_object.prepare_for_unify_destroy(on_behalf_of)
-            remove_object.destroy!
+          when :has_many
+            i = remove_object.send(r.name)
+
+            unless ::ApplicationEnumeration.relation_targets_community?(r)
+              i = i.where(project_id: pid)
+            end
+
+            next unless i.any?
+
+            t = i.size
+            stub_unify_result(s, n, t)
+
+            s[:result][:total_related] += t
+            next if s[:result][:total_related] > cutoff
+
+            list_state = snapshot_list_order(r, i)
+
+            i.find_each do |j|
+              j.update(r.options[:inverse_of] => self)
+              log_unify_result(j, r, s)
+            end
+
+            restore_list_order(list_state) if list_state
+
+          when :has_one, :belongs_to
+            i = remove_object.send(r.name)
+            if !i.nil?
+              stub_unify_result(s, n, 1)
+
+              i.update(r.options[:inverse_of] => self)
+              log_unify_result(i, r, s)
+            end
           end
-
-        rescue ActiveRecord::InvalidForeignKey => e
-          # InvalidForeignKey comes from the DB adapter, so e has no `.record`.
-          s[:result][:unified] = false
-          s[:details].merge!(
-            Object: {
-              errors: [
-                {
-                  id: remove_object.id,
-                  exception: e.class.name,
-                  message: e.message
-                }
-              ]
-            }
-          )
-          raise ActiveRecord::Rollback
-        rescue ActiveRecord::RecordNotDestroyed => e
-          s[:result][:unified] = false
-          s[:details].merge!(
-            Object: {
-              errors: [
-                { id: e.record.id, message: e.record.errors.full_messages.join('; ') }
-              ]
-            }
-          )
-
-          raise ActiveRecord::Rollback
         end
+
+        if cutoff_hit = s[:result][:total_related] > cutoff
+          s[:result][:unified] = false
+          s[:result][:message] = "Related cutoff threshold (> #{cutoff}) hit, unify is not yet allowed on these objects."
+        elsif s[:result][:unified] != false
+
+          begin
+            remove_object.reload # reset all in-memory has_many caches that would prevent destroy
+
+            remove_object.destroy! if will_destroy
+
+          rescue ActiveRecord::InvalidForeignKey => e
+            # InvalidForeignKey comes from the DB adapter, so e has no `.record`.
+            s[:result][:unified] = false
+            s[:details].merge!(
+              Object: {
+                errors: [
+                  {
+                    id: remove_object.id,
+                    exception: e.class.name,
+                    message: e.message
+                  }
+                ]
+              }
+            )
+            raise ActiveRecord::Rollback
+          rescue ActiveRecord::RecordNotDestroyed => e
+            s[:result][:unified] = false
+            s[:details].merge!(
+              Object: {
+                errors: [
+                  { id: e.record.id, message: e.record.errors.full_messages.join('; ') }
+                ]
+              }
+            )
+
+            raise ActiveRecord::Rollback
+          end
+        end
+      ensure
+        UnifyDestroyContext.objects_in_destroy&.delete(destroy_key) if will_destroy
       end
 
       # after_unify # potential hooks, appear not to be required
@@ -308,18 +303,17 @@ module Shared::Unify
   end
 
   # @param object [ActiveRecord::Base] see log_unify_result
-  # @param enclosing_remove_object [ActiveRecord::Base] see log_unify_result - object's real parent
-  def deduplicate_update_target(object, enclosing_remove_object)
+  def deduplicate_update_target(object)
     i = object.identical
 
     # There is exactly 1 match, merge is unambiguous
     if i.size == 1
       j = i.first
       # object's own FK is still dirty from the failed update attempt (it
-      # points at self/KEEP, not enclosing_remove_object); reload so the
-      # nested unify below moves object's actual remaining relations, not
+      # points at self/KEEP, not its real enclosing remove_object); reload so
+      # the nested unify below moves object's actual remaining relations, not
       # phantom ones based on that dirty state.
-      j.unify(object.reload, on_behalf_of: enclosing_remove_object)
+      j.unify(object.reload)
     else
       # Merge would be ambiguous, there are multiple matches
       return false
@@ -339,9 +333,7 @@ module Shared::Unify
   #   relation.options[:inverse_of] is the belongs_to on object's class whose FK
   #   we tried to flip
   # @param result [Hash] the running unify result accumulator
-  # @param enclosing_remove_object [ActiveRecord::Base] the remove_object of
-  #   the enclosing #unify call - object's real parent
-  def log_unify_result(object, relation, result, enclosing_remove_object)
+  def log_unify_result(object, relation, result)
     n = relation.name.to_s.humanize
 
     # Handle an edge case, preserve Citations that
@@ -362,13 +354,7 @@ module Shared::Unify
       # #identical won't match unless there's a genuine duplicate, so this is
       # safe to attempt for *any* validation failure, not just the ones that
       # look like a uniqueness conflict.
-      dedup_result = deduplicate_update_target(object, enclosing_remove_object)
-      # object was never reloaded here unless deduplicate_update_target found
-      # a single identical match (in which case success/failure is decided by
-      # the nested unify's own result, not object's own validity) -- so in
-      # the "no match" case object is still exactly as invalid as it was when
-      # `object.errors.any?` was checked above. There's no state in between
-      # where it could have become valid, so there's nothing to re-check.
+      dedup_result = deduplicate_update_target(object)
       if dedup_result && dedup_result[:result][:unified]
         result[:details][n][:deduplicated] += 1
       else

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -130,11 +130,9 @@ module Shared::Unify
       # before_unify # potential hooks, appear not to be required
 
       # Record remove_object as committed-to-destruction *before* any related
-      # records are touched below, so "must have at least one X" guards on
-      # those related records (e.g. Citation, TaxonDetermination) can see,
-      # for the whole duration of this call (including any nested unify a
-      # dedup triggers), that it's already slated for destruction regardless
-      # of what happens to its individual annotations.
+      # records are touched below, so those related records can see, for the
+      # whole duration of this call (including any nested unify a dedup
+      # triggers), that it's already slated for destruction.
       if will_destroy
         UnifyDestroyContext.objects_in_destroy ||= Set.new
         UnifyDestroyContext.objects_in_destroy << destroy_key

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -139,8 +139,7 @@ module Shared::Unify
       details: {},
     }
 
-    o = remove_object
-    pre_validate(o, s)
+    pre_validate(remove_object, s)
     return s if s[:result][:unified] == false
     pid = s[:result][:target_project_id]
 
@@ -153,7 +152,7 @@ module Shared::Unify
         case ::ApplicationEnumeration.relationship_type(r)
 
         when :has_many
-          i = o.send(r.name)
+          i = remove_object.send(r.name)
 
           unless ::ApplicationEnumeration.relation_targets_community?(r)
             i = i.where(project_id: pid)
@@ -171,18 +170,18 @@ module Shared::Unify
 
           i.find_each do |j|
             j.update(r.options[:inverse_of] => self)
-            log_unify_result(j, r, s, o)
+            log_unify_result(j, r, s, remove_object)
           end
 
           restore_list_order(list_state) if list_state
 
         when :has_one, :belongs_to
-          i = o.send(r.name)
+          i = remove_object.send(r.name)
           if !i.nil?
             stub_unify_result(s, n, 1)
 
             i.update(r.options[:inverse_of] => self)
-            log_unify_result(i, r, s, o)
+            log_unify_result(i, r, s, remove_object)
           end
         end
       end
@@ -193,11 +192,11 @@ module Shared::Unify
       elsif s[:result][:unified] != false
 
         begin
-          o.reload # reset all in-memory has_many caches that would prevent destroy
+          remove_object.reload # reset all in-memory has_many caches that would prevent destroy
 
           unless only.any? || except.any?
-            o.prepare_for_unify_destroy(on_behalf_of)
-            o.destroy!
+            remove_object.prepare_for_unify_destroy(on_behalf_of)
+            remove_object.destroy!
           end
 
         rescue ActiveRecord::InvalidForeignKey => e
@@ -207,7 +206,7 @@ module Shared::Unify
             Object: {
               errors: [
                 {
-                  id: o.id,
+                  id: remove_object.id,
                   exception: e.class.name,
                   message: e.message
                 }
@@ -309,18 +308,18 @@ module Shared::Unify
   end
 
   # @param object [ActiveRecord::Base] see log_unify_result
-  # @param o [ActiveRecord::Base] see log_unify_result - object's real parent
-  def deduplicate_update_target(object, o)
+  # @param enclosing_remove_object [ActiveRecord::Base] see log_unify_result - object's real parent
+  def deduplicate_update_target(object, enclosing_remove_object)
     i = object.identical
 
     # There is exactly 1 match, merge is unambiguous
     if i.size == 1
       j = i.first
       # object's own FK is still dirty from the failed update attempt (it
-      # points at self/KEEP, not o); reload so the nested unify below moves
-      # object's actual remaining relations, not phantom ones based on that
-      # dirty state.
-      j.unify(object.reload, on_behalf_of: o)
+      # points at self/KEEP, not enclosing_remove_object); reload so the
+      # nested unify below moves object's actual remaining relations, not
+      # phantom ones based on that dirty state.
+      j.unify(object.reload, on_behalf_of: enclosing_remove_object)
     else
       # Merge would be ambiguous, there are multiple matches
       return false
@@ -340,9 +339,9 @@ module Shared::Unify
   #   relation.options[:inverse_of] is the belongs_to on object's class whose FK
   #   we tried to flip
   # @param result [Hash] the running unify result accumulator
-  # @param o [ActiveRecord::Base] the remove_object of the enclosing #unify
-  #   call - object's real parent
-  def log_unify_result(object, relation, result, o)
+  # @param enclosing_remove_object [ActiveRecord::Base] the remove_object of
+  #   the enclosing #unify call - object's real parent
+  def log_unify_result(object, relation, result, enclosing_remove_object)
     n = relation.name.to_s.humanize
 
     # Handle an edge case, preserve Citations that
@@ -363,14 +362,13 @@ module Shared::Unify
       # #identical won't match unless there's a genuine duplicate, so this is
       # safe to attempt for *any* validation failure, not just the ones that
       # look like a uniqueness conflict.
-      dedup_result = deduplicate_update_target(object, o)
+      dedup_result = deduplicate_update_target(object, enclosing_remove_object)
       # object was never reloaded here unless deduplicate_update_target found
       # a single identical match (in which case success/failure is decided by
       # the nested unify's own result, not object's own validity) -- so in
       # the "no match" case object is still exactly as invalid as it was when
       # `object.errors.any?` was checked above. There's no state in between
       # where it could have become valid, so there's nothing to re-check.
-      # TODO: followup on the other review recommendations
       if dedup_result && dedup_result[:result][:unified]
         result[:details][n][:deduplicated] += 1
       else

--- a/app/models/concerns/shared/unify.rb
+++ b/app/models/concerns/shared/unify.rb
@@ -345,9 +345,9 @@ module Shared::Unify
       else # We unified and destroyed the duplicate
         result[:details][n][:deduplicated] += 1
       end
-    else
-      # There are no errors we can fix, ensure we have a fresh copy of the
-      # object and check for validity.
+    elsif object.errors.any?
+      # There are unrelated errors we can not fix, ensure we have a fresh
+      # copy of the object and check for validity.
       object.reload
       if object.invalid?
         result[:result][:unified] = false
@@ -357,6 +357,12 @@ module Shared::Unify
       else
         result[:details][n][:merged] += 1
       end
+    else
+      # The update succeeded outright. Do not reload: reload clears the
+      # in-memory dirty-tracking (`saved_changes`/`_previously_changed?`)
+      # that object's own deferred `after_commit` callbacks may depend on
+      # to decide whether to recompute cached values (e.g. TaxonNameRelationship).
+      result[:details][n][:merged] += 1
     end
 
     result

--- a/app/models/taxon_determination.rb
+++ b/app/models/taxon_determination.rb
@@ -165,9 +165,10 @@ class TaxonDetermination < ApplicationRecord
     return if marked_for_destruction?
     return if taxon_determination_object && taxon_determination_object.respond_to?(:ignore_taxon_determination_restriction) && taxon_determination_object.ignore_taxon_determination_restriction
 
-    # taxon_determination_object may not be the same in-memory instance that
-    # an enclosing Shared::Unify#unify call is destroying, so this checks by
-    # identity (id/type), not object reference - see UnifyDestroyContext.
+    # Allow the destroy if taxon_determination_object itself is already
+    # committed to being destroyed by an enclosing Shared::Unify#unify call -
+    # it's not losing its last determination, it's going away entirely, so
+    # the "must have at least one" guard below is moot.
     return if taxon_determination_object && UnifyDestroyContext.objects_in_destroy&.include?(
       { id: taxon_determination_object.id, type: taxon_determination_object.class.base_class.name }
     )

--- a/app/models/taxon_determination.rb
+++ b/app/models/taxon_determination.rb
@@ -165,6 +165,13 @@ class TaxonDetermination < ApplicationRecord
     return if marked_for_destruction?
     return if taxon_determination_object && taxon_determination_object.respond_to?(:ignore_taxon_determination_restriction) && taxon_determination_object.ignore_taxon_determination_restriction
 
+    # taxon_determination_object may not be the same in-memory instance that
+    # an enclosing Shared::Unify#unify call is destroying, so this checks by
+    # identity (id/type), not object reference - see UnifyDestroyContext.
+    return if taxon_determination_object && UnifyDestroyContext.objects_in_destroy&.include?(
+      { id: taxon_determination_object.id, type: taxon_determination_object.class.base_class.name }
+    )
+
     if taxon_determination_object.requires_taxon_determination? &&
         taxon_determination_object.taxon_determinations.count == 1
       addendum = case taxon_determination_object.class.base_class.name

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -60,6 +60,11 @@ class TaxonNameRelationship < ApplicationRecord
   # After commit only fires if there are changes to the record.
   after_commit :set_cached_names_for_taxon_names, unless: -> {self.no_cached }
 
+  # See #set_cached_names_for_taxon_names: latches once per instance so a
+  # later save that leaves subject/object_taxon_name_id unchanged can't hide
+  # an earlier reassignment from that deferred after_commit.
+  before_save :flag_taxon_name_reassignment, if: -> { subject_taxon_name_id_changed? || object_taxon_name_id_changed? }
+
   # TODO: remove, it's required by STI
   validates_presence_of :type, message: 'Relationship type should be specified'
 
@@ -472,12 +477,11 @@ class TaxonNameRelationship < ApplicationRecord
   # OriginalCombination has a replacement method.
   def set_cached_names_for_taxon_names
     # This is called via an unrestricted after_commit, which fires on
-    # destroy as well as create/update. _previously_changed? only reflects
-    # attribute changes from this record's own last save, and a plain
-    # destroy doesn't go through one -- without `|| destroyed?`, destroying
-    # a relationship (e.g. removing a synonym) would leave the taxon names
-    # it affected with stale cached values.
-    return true unless subject_taxon_name_id_previously_changed? || object_taxon_name_id_previously_changed? || destroyed?
+    # destroy as well as create/update, and a plain destroy doesn't touch
+    # subject/object_taxon_name_id at all -- without `|| destroyed?`,
+    # destroying a relationship (e.g. removing a synonym) would leave the
+    # taxon names it affected with stale cached values.
+    return true unless @taxon_name_id_reassigned || destroyed?
 
     return true unless is_invalidating?
 
@@ -551,6 +555,10 @@ class TaxonNameRelationship < ApplicationRecord
 
   def is_invalidating?
     TAXON_NAME_RELATIONSHIP_NAMES_INVALID.include?(type_name)
+  end
+
+  def flag_taxon_name_reassignment
+    @taxon_name_id_reassigned = true
   end
 
   def sv_validate_required_relationships

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -497,7 +497,13 @@ class TaxonNameRelationship < ApplicationRecord
       # instance rather than nil -- reload to force a fresh check (see the
       # identical fix/rationale on
       # TaxonNameRelationship::OriginalCombination#set_cached_names_for_taxon_names).
-      t.reload
+      # If the row is actually gone, reload raises RecordNotFound -- there's
+      # nothing left to update.
+      begin
+        t.reload
+      rescue ActiveRecord::RecordNotFound
+        return true
+      end
 
       if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)
         t.update_columns(
@@ -548,8 +554,6 @@ class TaxonNameRelationship < ApplicationRecord
       end
     end
 
-    true
-  rescue ActiveRecord::RecordNotFound
     true
   end
 

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -476,11 +476,6 @@ class TaxonNameRelationship < ApplicationRecord
 
   # OriginalCombination has a replacement method.
   def set_cached_names_for_taxon_names
-    # This is called via an unrestricted after_commit, which fires on
-    # destroy as well as create/update, and a plain destroy doesn't touch
-    # subject/object_taxon_name_id at all -- without `|| destroyed?`,
-    # destroying a relationship (e.g. removing a synonym) would leave the
-    # taxon names it affected with stale cached values.
     return true unless @taxon_name_id_reassigned || destroyed?
 
     return true unless is_invalidating?
@@ -494,10 +489,10 @@ class TaxonNameRelationship < ApplicationRecord
       # the duplicate being merged away) by the time this deferred
       # after_commit fires. If t was already memoized before that happened,
       # the belongs_to reader above returns a stale, no-longer-persisted
-      # instance rather than nil -- reload to force a fresh check (see the
+      # instance rather than nil - reload to force a fresh check (see the
       # identical fix/rationale on
       # TaxonNameRelationship::OriginalCombination#set_cached_names_for_taxon_names).
-      # If the row is actually gone, reload raises RecordNotFound -- there's
+      # If the row is actually gone, reload raises RecordNotFound - there's
       # nothing left to update.
       begin
         t.reload
@@ -540,7 +535,7 @@ class TaxonNameRelationship < ApplicationRecord
       # TODO: this fires per-relationship via after_commit, and each firing
       # redoes this full pass over every synonym of vn, not just the one
       # relationship that changed. Merging a TaxonName with N synonym
-      # relationships triggers N callbacks, each doing O(N) work here --
+      # relationships triggers N callbacks, each doing O(N) work here -
       # O(N^2) total for the whole merge. Would need batching/debouncing the
       # cache rebuild to a single pass after all relationship moves land.
       vn.list_of_invalid_taxon_names.each do |s|

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -471,12 +471,12 @@ class TaxonNameRelationship < ApplicationRecord
 
   # OriginalCombination has a replacement method.
   def set_cached_names_for_taxon_names
-    return true unless subject_taxon_name_id_previously_changed? || destroyed?
+    return true unless subject_taxon_name_id_previously_changed? || object_taxon_name_id_previously_changed? || destroyed?
 
     # TODO: this should completely be replaced with Taxonname logic.
     TaxonName.transaction do # Why?
       if is_invalidating?
-        t = TaxonName.find_by(id: subject_taxon_name_id)
+        t = subject_taxon_name
         return true unless t
 
         if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -471,54 +471,60 @@ class TaxonNameRelationship < ApplicationRecord
 
   # OriginalCombination has a replacement method.
   def set_cached_names_for_taxon_names
+    # This is called via an unrestricted after_commit, which fires on
+    # destroy as well as create/update. _previously_changed? only reflects
+    # attribute changes from this record's own last save, and a plain
+    # destroy doesn't go through one -- without `|| destroyed?`, destroying
+    # a relationship (e.g. removing a synonym) would leave the taxon names
+    # it affected with stale cached values.
     return true unless subject_taxon_name_id_previously_changed? || object_taxon_name_id_previously_changed? || destroyed?
+
+    return true unless is_invalidating?
 
     # TODO: this should completely be replaced with Taxonname logic.
     TaxonName.transaction do # Why?
-      if is_invalidating?
-        t = subject_taxon_name
-        return true unless t
+      t = subject_taxon_name
+      return true unless t
 
-        if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)
-          t.update_columns(
-            cached_misspelling: t.get_cached_misspelling,
-            cached_author_year: t.get_author_and_year,
-            cached_nomenclature_date: t.nomenclature_date,
-            cached_original_combination: t.get_original_combination,
-            cached_original_combination_html: t.get_original_combination_html)
-        end
-
-        if type_name =~/Misapplication/
-          t.update_columns(
-            cached_author_year: t.get_author_and_year,
-            cached_nomenclature_date: t.nomenclature_date)
-        end
-
-        vn = t.get_valid_taxon_name
-
-        # !! NO set cached should do this from TN side of things,
-        # !! Not here
-
-        n = t.get_full_name
-
+      if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)
         t.update_columns(
-          cached: n,
-          cached_html: t.get_full_name_html(n), # OK to force reload here, otherwise we need an exception in #set_cached
+          cached_misspelling: t.get_cached_misspelling,
+          cached_author_year: t.get_author_and_year,
+          cached_nomenclature_date: t.nomenclature_date,
+          cached_original_combination: t.get_original_combination,
+          cached_original_combination_html: t.get_original_combination_html)
+      end
+
+      if type_name =~/Misapplication/
+        t.update_columns(
+          cached_author_year: t.get_author_and_year,
+          cached_nomenclature_date: t.nomenclature_date)
+      end
+
+      vn = t.get_valid_taxon_name
+
+      # !! NO set cached should do this from TN side of things,
+      # !! Not here
+
+      n = t.get_full_name
+
+      t.update_columns(
+        cached: n,
+        cached_html: t.get_full_name_html(n), # OK to force reload here, otherwise we need an exception in #set_cached
+        cached_valid_taxon_name_id: vn.id,
+        cached_is_valid: !t.unavailable_or_invalid?)
+
+      t.combination_list_self.each do |c|
+        c.update_column(:cached_valid_taxon_name_id, vn.id)
+      end
+
+      vn.list_of_invalid_taxon_names.each do |s|
+        s.update_columns(
           cached_valid_taxon_name_id: vn.id,
-          cached_is_valid: !t.unavailable_or_invalid?)
+          cached_is_valid: !s.unavailable_or_invalid?)
 
-        t.combination_list_self.each do |c|
+        s.combination_list_self.each do |c|
           c.update_column(:cached_valid_taxon_name_id, vn.id)
-        end
-
-        vn.list_of_invalid_taxon_names.each do |s|
-          s.update_columns(
-            cached_valid_taxon_name_id: vn.id,
-            cached_is_valid: !s.unavailable_or_invalid?)
-
-          s.combination_list_self.each do |c|
-            c.update_column(:cached_valid_taxon_name_id, vn.id)
-          end
         end
       end
     end

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -518,6 +518,12 @@ class TaxonNameRelationship < ApplicationRecord
         c.update_column(:cached_valid_taxon_name_id, vn.id)
       end
 
+      # TODO: this fires per-relationship via after_commit, and each firing
+      # redoes this full pass over every synonym of vn, not just the one
+      # relationship that changed. Merging a TaxonName with N synonym
+      # relationships triggers N callbacks, each doing O(N) work here --
+      # O(N^2) total for the whole merge. Would need batching/debouncing the
+      # cache rebuild to a single pass after all relationship moves land.
       vn.list_of_invalid_taxon_names.each do |s|
         s.update_columns(
           cached_valid_taxon_name_id: vn.id,

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -486,6 +486,15 @@ class TaxonNameRelationship < ApplicationRecord
       t = subject_taxon_name
       return true unless t
 
+      # t may have been destroyed elsewhere in the same unify chain (e.g. as
+      # the duplicate being merged away) by the time this deferred
+      # after_commit fires. If t was already memoized before that happened,
+      # the belongs_to reader above returns a stale, no-longer-persisted
+      # instance rather than nil -- reload to force a fresh check (see the
+      # identical fix/rationale on
+      # TaxonNameRelationship::OriginalCombination#set_cached_names_for_taxon_names).
+      t.reload
+
       if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)
         t.update_columns(
           cached_misspelling: t.get_cached_misspelling,
@@ -535,6 +544,8 @@ class TaxonNameRelationship < ApplicationRecord
       end
     end
 
+    true
+  rescue ActiveRecord::RecordNotFound
     true
   end
 

--- a/app/models/taxon_name_relationship.rb
+++ b/app/models/taxon_name_relationship.rb
@@ -476,7 +476,8 @@ class TaxonNameRelationship < ApplicationRecord
     # TODO: this should completely be replaced with Taxonname logic.
     TaxonName.transaction do # Why?
       if is_invalidating?
-        t = subject_taxon_name
+        t = TaxonName.find_by(id: subject_taxon_name_id)
+        return true unless t
 
         if TAXON_NAME_RELATIONSHIP_NAMES_MISSPELLING_ONLY.include?(type_name)
           t.update_columns(

--- a/app/models/taxon_name_relationship/original_combination.rb
+++ b/app/models/taxon_name_relationship/original_combination.rb
@@ -75,12 +75,24 @@ class TaxonNameRelationship::OriginalCombination < TaxonNameRelationship
   protected
 
   def set_cached_names_for_taxon_names
-    # object_taxon_name.reload raises RecordNotFound if the taxon name it
-    # pointed to was destroyed elsewhere in the same unify chain (e.g. as the
-    # duplicate being merged away); find_by + safe navigation degrades to a
-    # no-op instead of crashing the after_commit.
-    t = TaxonName.find_by(id: object_taxon_name_id)
-    t&.update_cached_original_combinations
+    # The taxon name object_taxon_name points to may have been destroyed
+    # elsewhere in the same unify chain (e.g. as the duplicate being merged
+    # away) by the time this deferred after_commit fires. Depending on
+    # whether the association was already cached before that happened,
+    # that shows up two different ways: the belongs_to reader returns nil
+    # outright (never cached, now legitimately missing), or an
+    # already-cached instance's #reload raises RecordNotFound. Guard both
+    # into a no-op rather than crashing the after_commit. Reload (rather
+    # than a separate TaxonName.find_by) so the already-memoized
+    # object_taxon_name association is refreshed in place, not left stale
+    # for any caller that reads it off this same relationship instance
+    # afterward.
+    return if object_taxon_name.nil?
+
+    object_taxon_name.reload
+    object_taxon_name.update_cached_original_combinations
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def sv_validate_priority

--- a/app/models/taxon_name_relationship/original_combination.rb
+++ b/app/models/taxon_name_relationship/original_combination.rb
@@ -75,6 +75,10 @@ class TaxonNameRelationship::OriginalCombination < TaxonNameRelationship
   protected
 
   def set_cached_names_for_taxon_names
+    # object_taxon_name.reload raises RecordNotFound if the taxon name it
+    # pointed to was destroyed elsewhere in the same unify chain (e.g. as the
+    # duplicate being merged away); find_by + safe navigation degrades to a
+    # no-op instead of crashing the after_commit.
     t = TaxonName.find_by(id: object_taxon_name_id)
     t&.update_cached_original_combinations
   end

--- a/app/models/taxon_name_relationship/original_combination.rb
+++ b/app/models/taxon_name_relationship/original_combination.rb
@@ -89,10 +89,13 @@ class TaxonNameRelationship::OriginalCombination < TaxonNameRelationship
     # afterward.
     return if object_taxon_name.nil?
 
-    object_taxon_name.reload
+    begin
+      object_taxon_name.reload
+    rescue ActiveRecord::RecordNotFound
+      return
+    end
+
     object_taxon_name.update_cached_original_combinations
-  rescue ActiveRecord::RecordNotFound
-    nil
   end
 
   def sv_validate_priority

--- a/app/models/taxon_name_relationship/original_combination.rb
+++ b/app/models/taxon_name_relationship/original_combination.rb
@@ -75,8 +75,8 @@ class TaxonNameRelationship::OriginalCombination < TaxonNameRelationship
   protected
 
   def set_cached_names_for_taxon_names
-    object_taxon_name.reload
-    object_taxon_name.update_cached_original_combinations
+    t = TaxonName.find_by(id: object_taxon_name_id)
+    t&.update_cached_original_combinations
   end
 
   def sv_validate_priority

--- a/app/models/unify_destroy_context.rb
+++ b/app/models/unify_destroy_context.rb
@@ -1,0 +1,9 @@
+class UnifyDestroyContext < ActiveSupport::CurrentAttributes
+  # Set of {id:, type:} for objects currently being destroyed by an
+  # in-flight (possibly nested) Shared::Unify#unify call. Populated by
+  # #unify itself, before any related records are processed, so that
+  # "must have at least one X" guards (e.g. Citation, TaxonDetermination)
+  # can tell that an object they'd otherwise protect is already committed
+  # to being destroyed regardless.
+  attribute :objects_in_destroy
+end

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -1017,6 +1017,30 @@ describe 'Shared::Unify', type: :model do
     expect(TaxonNameRelationship.find_by(id: r_keep.id)).not_to be_nil
   end
 
+  # A relation move can fail validation for reasons that have nothing to do
+  # with duplication. Here, unifying moves a SourceClassifiedAs relationship
+  # onto an ICN (botanical) name, but its subject is an ICZN (zoological)
+  # name -- TaxonNameRelationship#validate_subject_and_object_share_code, a
+  # plain `validate` callback, not a uniqueness check, correctly rejects
+  # relating names from different nomenclatural codes. That must be reported
+  # unmerged (and destroy/its relationship must survive), not treated as a
+  # duplicate-worthy failure or silently merged.
+  specify 'unifying does not report merged for a relation whose move fails a non-uniqueness validation' do
+    destroy = FactoryBot.create(:relationship_family) # ICZN
+    subject_name = FactoryBot.create(:relationship_genus, parent: destroy) # ICZN, shares code with destroy
+    keep = FactoryBot.create(:icn_family) # different nomenclatural code
+
+    r = TaxonNameRelationship::SourceClassifiedAs.create!(subject_taxon_name: subject_name, object_taxon_name: destroy)
+
+    result = keep.unify(destroy)
+
+    expect(result[:result][:unified]).to be(false)
+    expect(result[:details]['Related taxon name relationships'][:unmerged]).to eq(1)
+    expect(result[:details]['Related taxon name relationships'][:merged]).to eq(0)
+    expect(destroy.reload.destroyed?).to be_falsey
+    expect(r.reload.object_taxon_name_id).to eq(destroy.id)
+  end
+
   # Aus bus (destroy) and Cus dus (keep) both exist, and some other name is
   # a Synonym *of* Aus bus (i.e. Aus bus is the *object* of that TNR, and
   # Aus bus's id is cached on the synonym's cached_valid_taxon_name_id).

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -304,6 +304,7 @@ describe 'Shared::Unify', type: :model do
 
     expect(b.destroyed?).to be_truthy
     expect(BiocurationClassification.all.reload.size).to eq(1)
+    expect(e[:details]['Biocuration classifications'][:deduplicated]).to eq(1)
   end
 
   specify 'sums BiocurationClassifications when classes differ' do
@@ -882,6 +883,57 @@ describe 'Shared::Unify', type: :model do
 
     expect(o2.destroyed?).to be_truthy
     expect(Citation.all.size).to eq(1)
+    expect(b[:details]['Asserted distributions'][:deduplicated]).to eq(1)
+  end
+
+  # log_unify_result resets a duplicate Citation's `is_original` to false
+  # *before* attempting deduplication (to clear the separate is_original
+  # uniqueness conflict). But `is_original` is not excluded from #identical's
+  # comparison, so that reset makes the duplicate look different from the
+  # surviving Citation it should be matched against -- #identical then finds
+  # no match, deduplicate_update_target gives up, and the duplicate Citation
+  # (and anything annotating it) is only removed as a side effect of ad2's
+  # own destroy cascade, silently losing whatever was attached to it.
+  specify 'would-be duplicate citations do not halt unify - preserves Notes on the removed duplicate' do
+    s = FactoryBot.create(:valid_source)
+
+    ad1 = FactoryBot.create(:valid_asserted_distribution, asserted_distribution_object: o1, source: s)
+    ad2 = FactoryBot.create(:valid_asserted_distribution, asserted_distribution_object: o2, asserted_distribution_shape: ad1.asserted_distribution_shape, source: s)
+
+    n = FactoryBot.create(:valid_note, note_object: ad2.citations.first)
+
+    o1.unify(o2)
+
+    expect(Citation.all.size).to eq(1)
+    expect(n.reload.note_object).to eq(Citation.first)
+  end
+
+  specify 'would-be duplicate citations do not halt unify - preserves Tags on the removed duplicate' do
+    s = FactoryBot.create(:valid_source)
+    k = FactoryBot.create(:valid_keyword)
+
+    ad1 = FactoryBot.create(:valid_asserted_distribution, asserted_distribution_object: o1, source: s)
+    ad2 = FactoryBot.create(:valid_asserted_distribution, asserted_distribution_object: o2, asserted_distribution_shape: ad1.asserted_distribution_shape, source: s)
+
+    t = Tag.create!(tag_object: ad2.citations.first, keyword: k)
+
+    o1.unify(o2)
+
+    expect(Citation.all.size).to eq(1)
+    expect(t.reload.tag_object).to eq(Citation.first)
+  end
+
+  specify 'would-be duplicate citations do not halt unify - records deduplication result' do
+    s = FactoryBot.create(:valid_source)
+
+    ad1 = FactoryBot.create(:valid_asserted_distribution, asserted_distribution_object: o1, source: s)
+    ad2 = FactoryBot.create(:valid_asserted_distribution, asserted_distribution_object: o2, asserted_distribution_shape: ad1.asserted_distribution_shape, source: s)
+
+    b = ad1.unify(ad2)
+
+    expect(ad2.destroyed?).to be_truthy
+    expect(Citation.all.size).to eq(1)
+    expect(b[:details]['Citations'][:deduplicated]).to eq(1)
   end
 
   specify 'unifies TaxonNames when both have the same OriginalCombination relationship type' do

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -1258,6 +1258,57 @@ describe 'Shared::Unify', type: :model do
     end
   end
 
+  # restore_list_order/snapshot_list_order (see Shared::Unify) must number
+  # each acts_as_list scope group on its own, not flatten every record a
+  # has_many touches into one combined sequence - required whenever that
+  # scope is independent of the FK unify itself reassigns, unlike the
+  # `acts_as_list positions` cases above (Identifier/Collector/Georeference,
+  # whose scope *is* the reassigned FK, so a single combined sequence is
+  # correct for them). TaxonDetermination's taxon_determination_object_id
+  # and ObservationMatrixRowItem's observation_matrix_id are both unrelated
+  # to the otu_id/observation_object_id a TaxonName or Otu unify reassigns -
+  # self and remove_object can each have their own record in a totally
+  # different, unrelated scope group.
+  context 'acts_as_list scope grouping spans multiple, unrelated scope groups' do
+    specify 'unifying two Otus leaves an unrelated TaxonDetermination scope group untouched' do
+      specimen1 = FactoryBot.create(:valid_specimen)
+      specimen2 = FactoryBot.create(:valid_specimen)
+
+      det_keep = FactoryBot.create(:valid_taxon_determination, otu: o1, taxon_determination_object: specimen1)
+      det_destroy = FactoryBot.create(:valid_taxon_determination, otu: o2, taxon_determination_object: specimen2)
+
+      o1.unify(o2)
+
+      # Each specimen has exactly one determination - the sole occupant of
+      # its own scope group - so both must remain at position 1, "current"
+      # per TaxonDetermination's `scope :current, -> { where(position: 1)
+      # }`. Flattening both into one combined sequence (the bug this guards
+      # against) would silently bump det_destroy to position 2, breaking
+      # specimen2's current determination with no error raised anywhere.
+      expect(det_keep.reload.position).to eq(1)
+      expect(det_destroy.reload.position).to eq(1)
+      expect(TaxonDetermination.current.where(id: det_destroy.id)).to exist
+    end
+
+    specify 'unifying two Otus numbers ObservationMatrixRowItem positions within each matrix separately' do
+      matrix_a = FactoryBot.create(:valid_observation_matrix)
+      matrix_b = FactoryBot.create(:valid_observation_matrix)
+
+      ri_keep = ObservationMatrixRowItem::Single.create!(observation_object: o1, observation_matrix: matrix_a)
+      ri_destroy = ObservationMatrixRowItem::Single.create!(observation_object: o2, observation_matrix: matrix_b)
+
+      o1.unify(o2)
+
+      # Neither row item collides with anything in its own matrix - each is
+      # the sole occupant there, before and after unify - so both must stay
+      # at position 1. Flattening existing+incoming into one sequence (the
+      # bug this guards against) would bump ri_destroy to position 2 even
+      # though matrix_b never had a second row item.
+      expect(ri_keep.reload.position).to eq(1)
+      expect(ri_destroy.reload.position).to eq(1)
+    end
+  end
+
   context 'Georeferences on Collecting Events' do
     let(:ce1) { FactoryBot.create(:valid_collecting_event) }
     let(:ce2) { FactoryBot.create(:valid_collecting_event) }

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -898,13 +898,13 @@ describe 'Shared::Unify', type: :model do
   end
 
   # log_unify_result resets a duplicate Citation's `is_original` to false
-  # *before* attempting deduplication (to clear the separate is_original
-  # uniqueness conflict). But `is_original` is not excluded from #identical's
-  # comparison, so that reset makes the duplicate look different from the
-  # surviving Citation it should be matched against -- #identical then finds
-  # no match, deduplicate_update_target gives up, and the duplicate Citation
-  # (and anything annotating it) is only removed as a side effect of ad2's
-  # own destroy cascade, silently losing whatever was attached to it.
+  # before attempting deduplication (to clear the separate is_original
+  # uniqueness conflict). Citation::IGNORE_IDENTICAL excludes is_original
+  # from #identical's comparison, so that reset doesn't stop the duplicate
+  # from still matching the surviving Citation - #identical finds it, and
+  # deduplicate_update_target moves its annotations (e.g. this Note) onto
+  # the survivor before destroying it, rather than losing them to ad2's own
+  # destroy cascade.
   specify 'would-be duplicate citations do not halt unify - preserves Notes on the removed duplicate' do
     s = FactoryBot.create(:valid_source)
 
@@ -953,11 +953,11 @@ describe 'Shared::Unify', type: :model do
   # instance than whatever unify holds - see UnifyDestroyContext) to decide
   # whether citation_object is already slated for destruction regardless.
   # citation1 and citation2 here are on two entirely unrelated
-  # AssertedDistributions (neither is being unified with the other, so ad2
-  # is never registered as being destroyed) that merely happen to share a
-  # source and pages. Calling Citation#unify directly must not destroy
-  # citation2 and leave ad2 -- untouched, still fully alive -- with zero
-  # citations despite requiring one.
+  # AssertedDistributions - neither ad1 nor ad2 is being unified with the
+  # other, so ad2 is never registered as being destroyed. Calling
+  # Citation#unify directly must not destroy citation2 and leave ad2 -
+  # untouched, still fully alive - with zero citations despite requiring
+  # one.
   specify 'unify does not destroy a required citation for an unrelated, untouched citation_object' do
     s = FactoryBot.create(:valid_source)
     ad1 = FactoryBot.create(:valid_asserted_distribution, source: s)
@@ -965,8 +965,6 @@ describe 'Shared::Unify', type: :model do
 
     citation1 = ad1.citations.first
     citation2 = ad2.citations.first
-    citation1.update!(pages: '5')
-    citation2.update!(pages: '5')
 
     citation1.unify(citation2)
 
@@ -1000,7 +998,7 @@ describe 'Shared::Unify', type: :model do
   # treats a nilled position as "insert at top" and always finds room by
   # shifting every other record in the scope down, so the retry always
   # succeeds. That means object.errors is always empty by the time
-  # log_unify_result would otherwise reach for deduplicate_update_target --
+  # log_unify_result would otherwise reach for deduplicate_update_target -
   # dedup is never actually exercised here, regardless of the guard fix
   # above. The "duplicate" determination is just merged in as an ordinary
   # (undeduped) second record, not destroyed and not blocked.
@@ -1021,7 +1019,7 @@ describe 'Shared::Unify', type: :model do
     expect(fo1.taxon_determinations.reload.count).to eq(2)
   end
 
-  specify 'unifies TaxonNames when both have the same OriginalCombination relationship type' do
+  specify 'unifies TaxonNames when both have an identical OriginalCombination relationship (same subject and type)' do
     genus = FactoryBot.create(:relationship_genus)
     keep = FactoryBot.create(:relationship_species)
     destroy = FactoryBot.create(:relationship_species)
@@ -1057,7 +1055,7 @@ describe 'Shared::Unify', type: :model do
     expect(result[:details]['Related taxon name relationships'][:deduplicated]).to eq(1)
   end
 
-  specify 'unifies TaxonNames when both are subjects of the same TNR to the same object' do
+  specify 'unifies TaxonNames when both are subjects of the same TaxonNameRelationship type to the same object' do
     keep = FactoryBot.create(:relationship_species)
     destroy = FactoryBot.create(:relationship_species)
     valid_name = FactoryBot.create(:relationship_species)
@@ -1079,7 +1077,7 @@ describe 'Shared::Unify', type: :model do
   # A relation move can fail validation for reasons that have nothing to do
   # with duplication. Here, unifying moves a SourceClassifiedAs relationship
   # onto an ICN (botanical) name, but its subject is an ICZN (zoological)
-  # name -- TaxonNameRelationship#validate_subject_and_object_share_code, a
+  # name - TaxonNameRelationship#validate_subject_and_object_share_code, a
   # plain `validate` callback, not a uniqueness check, correctly rejects
   # relating names from different nomenclatural codes. That must be reported
   # unmerged (and destroy/its relationship must survive), not treated as a
@@ -1105,9 +1103,10 @@ describe 'Shared::Unify', type: :model do
   # Aus bus's id is cached on the synonym's cached_valid_taxon_name_id).
   # keep.unify(destroy) moves destroy's taxon_name_relationships (including
   # the synonym TNR) over to keep, then destroys Aus bus. The synonym's
-  # cached_valid_taxon_name_id, however, still points at the now-destroyed
-  # Aus bus, so anything that resolves #valid_taxon_name off the synonym
-  # blows up trying to load a name that no longer exists.
+  # cached_valid_taxon_name_id must follow that move and end up pointing at
+  # keep, not the now-destroyed Aus bus - otherwise anything that resolves
+  # #valid_taxon_name off the synonym would blow up trying to load a name
+  # that no longer exists.
   specify 'unifies TaxonNames - synonym cached_valid_taxon_name_id follows the object of a Synonym relationship' do
     keep = FactoryBot.create(:relationship_species)    # Cus dus
     destroy = FactoryBot.create(:relationship_species) # Aus bus
@@ -1501,32 +1500,27 @@ describe 'Shared::Unify', type: :model do
       "  #{uncovered.join("\n  ")}"
   end
 
-  # log_unify_result no longer tries to guess whether a failed move "looks"
-  # relation-related before attempting dedup -- it just always tries
-  # (#identical won't match unless there's a genuine duplicate). What matters
-  # is what happens when that attempt does NOT pan out (no match, or a match
-  # was found but the nested merge failed): this must be reported as
-  # unmerged, not treated as safe to reload-and-recheck. See the georeference
-  # ("ce1 has a geographic_area that does not contain ce2s georeference") and
-  # ObservationMatrixRow ("when the nested unify inside deduplicate_update_
-  # target fails") specs above for the real scenarios this protects: the
-  # object, reverted to its old parent, is often perfectly *valid* there --
-  # but that parent is about to be destroyed, so "valid in its old spot" is
-  # not the same as "the requested move succeeded", and reporting merged
-  # would be silently wrong regardless of whether a dependent: :destroy
-  # cascade happens to clean it up afterward.
   describe 'log_unify_result reports unmerged (not merged) when a dedup attempt does not pan out' do
     let(:helper) { TestUnify.new }
-    let(:relation) { OpenStruct.new(name: :test_relation, options: { inverse_of: :integer }) }
+    let(:relation) { OpenStruct.new(name: :test_relation) }
     let(:result) { { result: { unified: nil }, details: {} } }
 
-    specify 'even though the object, reloaded, is perfectly valid on its own' do
+    specify 'trusts the error already on the object rather than reloading to recheck validity' do
       obj = TestUnifyIdenticalCapable.create!(string: 'a-value')
-      obj.errors.add(:string, :taken) # simulate: the attempted move failed, for any reason
+      # Fakes the aftermath of a failed relation move, without an actual
+      # failed .update: obj.errors now looks exactly like it would right
+      # after a failed save, but obj itself is still the one persisted,
+      # perfectly valid row - reloading it would clear this and show no
+      # error at all.
+      obj.errors.add(:string, :taken)
 
       helper.send(:stub_unify_result, result, 'Test relation', 1)
       helper.send(:log_unify_result, obj, relation, result)
 
+      # obj is the only row of its kind, so #identical (called internally
+      # by deduplicate_update_target) finds no match - there's no duplicate
+      # to merge into, so this must be reported as a failed move, not
+      # silently treated as merged-because-obj.reload-is-valid.
       expect(result[:details]['Test relation'][:unmerged]).to eq(1)
       expect(result[:details]['Test relation'][:merged]).to eq(0)
       expect(result[:result][:unified]).to be(false)
@@ -1541,7 +1535,7 @@ class TestUnify < ApplicationRecord
 end
 
 # Like TestUnify, but also includes Shared::IsData for #identical, which
-# deduplicate_update_target needs -- kept separate from TestUnify so the
+# deduplicate_update_target needs - kept separate from TestUnify so the
 # plain helper class doesn't pick up Shared::IsData's broader behavior
 # (callbacks, extra validations) just for tests that call private methods
 # via `send` without persisting anything.

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -936,6 +936,32 @@ describe 'Shared::Unify', type: :model do
     expect(b[:details]['Citations'][:deduplicated]).to eq(1)
   end
 
+  # Citation#prepare_for_unify_destroy only flags citation_object.
+  # ignore_citation_restriction when on_behalf_of equals citation_object --
+  # i.e. when citation_object is itself confirmed to be the record actually
+  # being destroyed. citation1 and citation2 here are on two entirely
+  # unrelated AssertedDistributions (neither is being unified with the
+  # other) that merely happen to share a source and pages. Calling
+  # Citation#unify directly (bypassing the deduplicate_update_target context
+  # that would supply the real on_behalf_of) must not destroy citation2 and
+  # leave ad2 -- untouched, still fully alive -- with zero citations despite
+  # requiring one.
+  specify 'unify does not destroy a required citation for an unrelated, untouched citation_object' do
+    s = FactoryBot.create(:valid_source)
+    ad1 = FactoryBot.create(:valid_asserted_distribution, source: s)
+    ad2 = FactoryBot.create(:valid_asserted_distribution, source: s)
+
+    citation1 = ad1.citations.first
+    citation2 = ad2.citations.first
+    citation1.update!(pages: '5')
+    citation2.update!(pages: '5')
+
+    citation1.unify(citation2)
+
+    expect(citation2.destroyed?).to be_falsey
+    expect(ad2.reload.citations.count).to eq(1)
+  end
+
   specify 'unifies TaxonNames when both have the same OriginalCombination relationship type' do
     genus = FactoryBot.create(:relationship_genus)
     keep = FactoryBot.create(:relationship_species)

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -287,6 +287,17 @@ describe 'Shared::Unify', type: :model do
     expect(r[:result][:message]).to include('cutoff')
   end
 
+   specify 'does not unify non-community objects from different projects' do
+    other_project = FactoryBot.create(:valid_project)
+    b = FactoryBot.create(:valid_otu, project: other_project)
+
+    r = o1.unify(b)
+
+    expect(r[:result][:unified]).to be(false)
+    expect(r[:result][:message]).to include('different project')
+    expect(b.destroyed?).to be_falsey
+  end
+
   specify 'handles BiocurationClassifications when identical' do
     a = FactoryBot.create(:valid_specimen)
     b = FactoryBot.create(:valid_specimen)

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -939,6 +939,56 @@ describe 'Shared::Unify', type: :model do
     expect(TaxonNameRelationship.find_by(id: r_keep.id)).not_to be_nil
   end
 
+  # Aus bus (destroy) and Cus dus (keep) both exist, and some other name is
+  # a Synonym *of* Aus bus (i.e. Aus bus is the *object* of that TNR, and
+  # Aus bus's id is cached on the synonym's cached_valid_taxon_name_id).
+  # keep.unify(destroy) moves destroy's taxon_name_relationships (including
+  # the synonym TNR) over to keep, then destroys Aus bus. The synonym's
+  # cached_valid_taxon_name_id, however, still points at the now-destroyed
+  # Aus bus, so anything that resolves #valid_taxon_name off the synonym
+  # blows up trying to load a name that no longer exists.
+  specify 'unifies TaxonNames - synonym cached_valid_taxon_name_id follows the object of a Synonym relationship' do
+    keep = FactoryBot.create(:relationship_species)    # Cus dus
+    destroy = FactoryBot.create(:relationship_species) # Aus bus
+    synonym = FactoryBot.create(:relationship_species)  # something else, synonym of Aus bus
+
+    FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym::Subjective',
+      subject_taxon_name: synonym, object_taxon_name: destroy)
+
+    expect(synonym.reload.cached_valid_taxon_name_id).to eq(destroy.id)
+
+    keep.unify(destroy)
+
+    expect(destroy.destroyed?).to be_truthy
+    expect(synonym.reload.cached_valid_taxon_name_id).to eq(keep.id)
+    expect(synonym.valid_taxon_name).to eq(keep)
+  end
+
+  # Same shape, opposite side of the TNR: here Aus bus (destroy) is itself the
+  # *subject* (a Synonym) of a relationship pointing to some unrelated valid
+  # name, rather than being the object another name is a synonym of.
+  # keep.unify(destroy) moves that relationship's subject_taxon_name over to
+  # Cus dus (keep), which should itself pick up destroy's cached_valid_taxon_name_id.
+  specify 'unifies TaxonNames - keep picks up cached_valid_taxon_name_id when it becomes the subject of a Synonym relationship' do
+    keep = FactoryBot.create(:relationship_species)       # Cus dus
+    destroy = FactoryBot.create(:relationship_species)    # Aus bus, a synonym
+    valid_name = FactoryBot.create(:relationship_species) # the name Aus bus is a synonym of
+
+    FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym::Subjective',
+      subject_taxon_name: destroy, object_taxon_name: valid_name)
+
+    expect(destroy.reload.cached_valid_taxon_name_id).to eq(valid_name.id)
+    expect(keep.reload.cached_valid_taxon_name_id).to eq(keep.id)
+
+    keep.unify(destroy)
+
+    expect(destroy.destroyed?).to be_truthy
+    expect(keep.reload.cached_valid_taxon_name_id).to eq(valid_name.id)
+    expect(keep.valid_taxon_name).to eq(valid_name)
+  end
+
   specify 'InvalidForeignKey error' do
     keep = FactoryBot.create(:valid_topic)
     remove = FactoryBot.create(:valid_topic)

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -884,6 +884,61 @@ describe 'Shared::Unify', type: :model do
     expect(Citation.all.size).to eq(1)
   end
 
+  specify 'unifies TaxonNames when both have the same OriginalCombination relationship type' do
+    genus = FactoryBot.create(:relationship_genus)
+    keep = FactoryBot.create(:relationship_species)
+    destroy = FactoryBot.create(:relationship_species)
+
+    r_keep = FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::OriginalCombination::OriginalGenus',
+      subject_taxon_name: genus, object_taxon_name: keep)
+    r_destroy = FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::OriginalCombination::OriginalGenus',
+      subject_taxon_name: genus, object_taxon_name: destroy)
+
+    keep.unify(destroy)
+
+    expect(destroy.destroyed?).to be_truthy
+    expect(TaxonNameRelationship.find_by(id: r_destroy.id)).to be_nil
+    expect(TaxonNameRelationship.find_by(id: r_keep.id)).not_to be_nil
+  end
+
+  specify 'unifies TaxonNames with duplicate OriginalCombination - counts as deduplicated in result' do
+    genus = FactoryBot.create(:relationship_genus)
+    keep = FactoryBot.create(:relationship_species)
+    destroy = FactoryBot.create(:relationship_species)
+
+    FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::OriginalCombination::OriginalGenus',
+      subject_taxon_name: genus, object_taxon_name: keep)
+    FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::OriginalCombination::OriginalGenus',
+      subject_taxon_name: genus, object_taxon_name: destroy)
+
+    result = keep.unify(destroy)
+
+    expect(result[:details]['Related taxon name relationships'][:deduplicated]).to eq(1)
+  end
+
+  specify 'unifies TaxonNames when both are subjects of the same TNR to the same object' do
+    keep = FactoryBot.create(:relationship_species)
+    destroy = FactoryBot.create(:relationship_species)
+    valid_name = FactoryBot.create(:relationship_species)
+
+    r_keep = FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym::Subjective',
+      subject_taxon_name: keep, object_taxon_name: valid_name)
+    r_destroy = FactoryBot.create(:taxon_name_relationship,
+      type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym::Subjective',
+      subject_taxon_name: destroy, object_taxon_name: valid_name)
+
+    keep.unify(destroy)
+
+    expect(destroy.destroyed?).to be_truthy
+    expect(TaxonNameRelationship.find_by(id: r_destroy.id)).to be_nil
+    expect(TaxonNameRelationship.find_by(id: r_keep.id)).not_to be_nil
+  end
+
   specify 'InvalidForeignKey error' do
     keep = FactoryBot.create(:valid_topic)
     remove = FactoryBot.create(:valid_topic)

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -973,6 +973,46 @@ describe 'Shared::Unify', type: :model do
     expect(ad2.reload.citations.count).to eq(1)
   end
 
+  # TaxonDetermination has the identical "must have at least one" before_destroy
+  # guard shape as Citation (Shared::TaxonDeterminationRequired's
+  # ignore_taxon_determination_restriction mirrors Shared::CitationRequired's
+  # ignore_citation_restriction, and FieldOccurrence#requires_taxon_determination?
+  # is unconditionally true, just like Citation's requirement), but only
+  # Citation was given a prepare_for_unify_destroy override in this branch.
+  # This spec sets up the *same shape* of scenario as the Citation dedup specs
+  # above (two objects, each with a matching/duplicate related record) to
+  # confirm the TaxonDetermination gap does not currently bite -- but for a
+  # different reason than "it's fixed":
+  #
+  # TaxonDetermination's only uniqueness validator is on :position, scoped by
+  # (taxon_determination_object_id/type, project_id). Unlike Citation's
+  # source/pages uniqueness, this validator can never survive
+  # log_unify_result's generic "reset position to nil and retry" fixup:
+  # acts_as_list's add_new_at: :top callback (before_update :check_scope)
+  # treats a nilled position as "insert at top" and always finds room by
+  # shifting every other record in the scope down, so the retry always
+  # succeeds. That means object.errors is always empty by the time
+  # log_unify_result would otherwise reach for deduplicate_update_target --
+  # dedup, and therefore the missing prepare_for_unify_destroy path, is never
+  # actually exercised here. The "duplicate" determination is just merged in
+  # as an ordinary (undeduped) second record, not destroyed and not blocked.
+  specify 'unify does not attempt (and so does not need to guard) dedup of a duplicate TaxonDetermination on a FieldOccurrence' do
+    fo1 = FactoryBot.create(:valid_field_occurrence)
+    fo2 = FactoryBot.create(:valid_field_occurrence)
+    otu = FactoryBot.create(:valid_otu)
+
+    fo1.taxon_determinations.first.update!(otu:)
+    fo2.taxon_determinations.first.update!(otu:)
+
+    result = fo1.unify(fo2)
+
+    expect(result[:result][:unified]).to be(true)
+    expect(result[:details]['Taxon determinations'][:merged]).to eq(1)
+    expect(result[:details]['Taxon determinations'][:deduplicated]).to eq(0)
+    expect(fo2.destroyed?).to be_truthy
+    expect(fo1.taxon_determinations.reload.count).to eq(2)
+  end
+
   specify 'unifies TaxonNames when both have the same OriginalCombination relationship type' do
     genus = FactoryBot.create(:relationship_genus)
     keep = FactoryBot.create(:relationship_species)

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -1418,9 +1418,52 @@ describe 'Shared::Unify', type: :model do
       "  #{uncovered.join("\n  ")}"
   end
 
+  # log_unify_result no longer tries to guess whether a failed move "looks"
+  # relation-related before attempting dedup -- it just always tries
+  # (#identical won't match unless there's a genuine duplicate). What matters
+  # is what happens when that attempt does NOT pan out (no match, or a match
+  # was found but the nested merge failed): this must be reported as
+  # unmerged, not treated as safe to reload-and-recheck. See the georeference
+  # ("ce1 has a geographic_area that does not contain ce2s georeference") and
+  # ObservationMatrixRow ("when the nested unify inside deduplicate_update_
+  # target fails") specs above for the real scenarios this protects: the
+  # object, reverted to its old parent, is often perfectly *valid* there --
+  # but that parent is about to be destroyed, so "valid in its old spot" is
+  # not the same as "the requested move succeeded", and reporting merged
+  # would be silently wrong regardless of whether a dependent: :destroy
+  # cascade happens to clean it up afterward.
+  describe 'log_unify_result reports unmerged (not merged) when a dedup attempt does not pan out' do
+    let(:helper) { TestUnify.new }
+    let(:relation) { OpenStruct.new(name: :test_relation, options: { inverse_of: :integer }) }
+    let(:result) { { result: { unified: nil }, details: {} } }
+
+    specify 'even though the object, reloaded, is perfectly valid on its own' do
+      obj = TestUnifyIdenticalCapable.create!(string: 'a-value')
+      obj.errors.add(:string, :taken) # simulate: the attempted move failed, for any reason
+
+      helper.send(:stub_unify_result, result, 'Test relation', 1)
+      helper.send(:log_unify_result, obj, relation, result, TestUnify.new)
+
+      expect(result[:details]['Test relation'][:unmerged]).to eq(1)
+      expect(result[:details]['Test relation'][:merged]).to eq(0)
+      expect(result[:result][:unified]).to be(false)
+    end
+  end
+
 end
 
 class TestUnify < ApplicationRecord
   include FakeTable
   include Shared::Unify
+end
+
+# Like TestUnify, but also includes Shared::IsData for #identical, which
+# deduplicate_update_target needs -- kept separate from TestUnify so the
+# plain helper class doesn't pick up Shared::IsData's broader behavior
+# (callbacks, extra validations) just for tests that call private methods
+# via `send` without persisting anything.
+class TestUnifyIdenticalCapable < ApplicationRecord
+  include FakeTable
+  include Shared::Unify
+  include Shared::IsData
 end

--- a/spec/models/concerns/shared/unify_spec.rb
+++ b/spec/models/concerns/shared/unify_spec.rb
@@ -947,16 +947,17 @@ describe 'Shared::Unify', type: :model do
     expect(b[:details]['Citations'][:deduplicated]).to eq(1)
   end
 
-  # Citation#prepare_for_unify_destroy only flags citation_object.
-  # ignore_citation_restriction when on_behalf_of equals citation_object --
-  # i.e. when citation_object is itself confirmed to be the record actually
-  # being destroyed. citation1 and citation2 here are on two entirely
-  # unrelated AssertedDistributions (neither is being unified with the
-  # other) that merely happen to share a source and pages. Calling
-  # Citation#unify directly (bypassing the deduplicate_update_target context
-  # that would supply the real on_behalf_of) must not destroy citation2 and
-  # leave ad2 -- untouched, still fully alive -- with zero citations despite
-  # requiring one.
+  # Citation#prevent_if_required consults UnifyDestroyContext.objects_in_destroy
+  # (populated by Shared::Unify#unify, keyed by {id:, type:} rather than
+  # object reference, since citation_object may be a different in-memory
+  # instance than whatever unify holds - see UnifyDestroyContext) to decide
+  # whether citation_object is already slated for destruction regardless.
+  # citation1 and citation2 here are on two entirely unrelated
+  # AssertedDistributions (neither is being unified with the other, so ad2
+  # is never registered as being destroyed) that merely happen to share a
+  # source and pages. Calling Citation#unify directly must not destroy
+  # citation2 and leave ad2 -- untouched, still fully alive -- with zero
+  # citations despite requiring one.
   specify 'unify does not destroy a required citation for an unrelated, untouched citation_object' do
     s = FactoryBot.create(:valid_source)
     ad1 = FactoryBot.create(:valid_asserted_distribution, source: s)
@@ -973,17 +974,24 @@ describe 'Shared::Unify', type: :model do
     expect(ad2.reload.citations.count).to eq(1)
   end
 
-  # TaxonDetermination has the identical "must have at least one" before_destroy
-  # guard shape as Citation (Shared::TaxonDeterminationRequired's
-  # ignore_taxon_determination_restriction mirrors Shared::CitationRequired's
-  # ignore_citation_restriction, and FieldOccurrence#requires_taxon_determination?
-  # is unconditionally true, just like Citation's requirement), but only
-  # Citation was given a prepare_for_unify_destroy override in this branch.
-  # This spec sets up the *same shape* of scenario as the Citation dedup specs
-  # above (two objects, each with a matching/duplicate related record) to
-  # confirm the TaxonDetermination gap does not currently bite -- but for a
-  # different reason than "it's fixed":
-  #
+  # Same guard, same UnifyDestroyContext mechanism, on the other model that
+  # has the identical "must have at least one" before_destroy shape
+  # (Shared::TaxonDeterminationRequired mirrors Shared::CitationRequired, and
+  # FieldOccurrence#requires_taxon_determination? is unconditionally true,
+  # just like Citation's requirement).
+  specify 'unify does not destroy a required taxon determination for an unrelated, untouched taxon_determination_object' do
+    fo1 = FactoryBot.create(:valid_field_occurrence)
+    fo2 = FactoryBot.create(:valid_field_occurrence)
+
+    td1 = fo1.taxon_determinations.first
+    td2 = fo2.taxon_determinations.first
+
+    td1.unify(td2)
+
+    expect(td2.destroyed?).to be_falsey
+    expect(fo2.reload.taxon_determinations.count).to eq(1)
+  end
+
   # TaxonDetermination's only uniqueness validator is on :position, scoped by
   # (taxon_determination_object_id/type, project_id). Unlike Citation's
   # source/pages uniqueness, this validator can never survive
@@ -993,9 +1001,9 @@ describe 'Shared::Unify', type: :model do
   # shifting every other record in the scope down, so the retry always
   # succeeds. That means object.errors is always empty by the time
   # log_unify_result would otherwise reach for deduplicate_update_target --
-  # dedup, and therefore the missing prepare_for_unify_destroy path, is never
-  # actually exercised here. The "duplicate" determination is just merged in
-  # as an ordinary (undeduped) second record, not destroyed and not blocked.
+  # dedup is never actually exercised here, regardless of the guard fix
+  # above. The "duplicate" determination is just merged in as an ordinary
+  # (undeduped) second record, not destroyed and not blocked.
   specify 'unify does not attempt (and so does not need to guard) dedup of a duplicate TaxonDetermination on a FieldOccurrence' do
     fo1 = FactoryBot.create(:valid_field_occurrence)
     fo2 = FactoryBot.create(:valid_field_occurrence)
@@ -1517,7 +1525,7 @@ describe 'Shared::Unify', type: :model do
       obj.errors.add(:string, :taken) # simulate: the attempted move failed, for any reason
 
       helper.send(:stub_unify_result, result, 'Test relation', 1)
-      helper.send(:log_unify_result, obj, relation, result, TestUnify.new)
+      helper.send(:log_unify_result, obj, relation, result)
 
       expect(result[:details]['Test relation'][:unmerged]).to eq(1)
       expect(result[:details]['Test relation'][:merged]).to eq(0)

--- a/spec/models/taxon_name_relationship_spec.rb
+++ b/spec/models/taxon_name_relationship_spec.rb
@@ -279,6 +279,18 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
         expect(s1.cached_primary_homonym).to eq('Bus aus')
       end
 
+      # OriginalCombination#set_cached_names_for_taxon_names refreshes
+      # object_taxon_name via #reload rather than a separately-fetched
+      # TaxonName instance, so the already-memoized association on the
+      # relationship itself reflects the update -- checked here through r,
+      # not a freshly-fetched s1, to catch a regression back to a separate
+      # instance the relationship's own association would never see.
+      specify 'object_taxon_name association is refreshed in place, not left stale' do
+        r = TaxonNameRelationship::OriginalCombination::OriginalGenus.create!(subject_taxon_name: g1, object_taxon_name: s1)
+        r.update!(subject_taxon_name: g2)
+        expect(r.object_taxon_name.cached_primary_homonym).to eq('Bus aus')
+      end
+
       specify 'for cached_classified_as' do
         r2 = FactoryBot.build(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: family, type: 'TaxonNameRelationship::SourceClassifiedAs')
         r2.save!

--- a/spec/models/taxon_name_relationship_spec.rb
+++ b/spec/models/taxon_name_relationship_spec.rb
@@ -28,16 +28,16 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
     perform_enqueued_jobs
 
     expect(s.dwc_occurrence.reload.scientificName).to eq(t.cached_name_and_author_year)
-    
+
     r1 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: t, object_taxon_name: species, type: 'TaxonNameRelationship::Iczn::Invalidating::Synonym')
-   
+
     perform_enqueued_jobs
-   
+
     expect(s.dwc_occurrence.reload.scientificName).to eq(species.cached_name_and_author_year)
 
     # Back the other way
     r1.destroy!
-  
+
     perform_enqueued_jobs
     expect(s.dwc_occurrence.reload.scientificName).to eq(t.cached_name_and_author_year)
   end
@@ -282,11 +282,14 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
       # OriginalCombination#set_cached_names_for_taxon_names refreshes
       # object_taxon_name via #reload rather than a separately-fetched
       # TaxonName instance, so the already-memoized association on the
-      # relationship itself reflects the update -- checked here through r,
+      # relationship itself reflects the update - checked here through r,
       # not a freshly-fetched s1, to catch a regression back to a separate
       # instance the relationship's own association would never see.
       specify 'object_taxon_name association is refreshed in place, not left stale' do
         r = TaxonNameRelationship::OriginalCombination::OriginalGenus.create!(subject_taxon_name: g1, object_taxon_name: s1)
+        # Reassigns the original genus itself (Aus -> Bus), which is what
+        # set_cached_names_for_taxon_names's #reload+#update_cached_
+        # original_combinations recompute on s1's cached_primary_homonym.
         r.update!(subject_taxon_name: g2)
         expect(r.object_taxon_name.cached_primary_homonym).to eq('Bus aus')
       end
@@ -325,19 +328,24 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
       end
 
       # The `|| destroyed?` in set_cached_names_for_taxon_names's guard exists
-      # for this case specifically: `_previously_changed?` only reflects
-      # attribute changes from the record's *own* last save, and a plain
-      # destroy doesn't go through an update. Right after .create! that flag
-      # happens to still read true (left over from creation), which would
-      # mask a missing `destroyed?` guard -- reloading r1 first clears it, so
-      # this only passes if destroy on its own re-triggers the cache update.
-      specify 'for cached_valid_taxon_name_id, destroyed after previously_changed? has already reset' do
+      # for a plain destroy performed through an instance that never itself
+      # reassigned subject/object_taxon_name - e.g. destroying a
+      # freshly-loaded copy of the relationship, as an ordinary "delete this
+      # relationship" flow would. flag_taxon_name_reassignment's ivar is only
+      # ever set to true by that instance's *own* before_save, so on a fresh
+      # instance it's still nil/false; without `|| destroyed?`, the
+      # after_commit would skip the cache update entirely. Using
+      # TaxonNameRelationship.find (not r1.reload) is essential here - r1
+      # itself already flagged the ivar true back when it was created, and
+      # #reload never clears that, so destroying r1 directly would pass even
+      # without the `destroyed?` guard.
+      specify 'destroyed via a freshly-loaded instance that never reassigned itself' do
         r1 = TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: g2, object_taxon_name: g1)
-        r1.reload
-        expect(r1.subject_taxon_name_id_previously_changed?).to be_falsey
         g2.reload
         expect(g2.cached_valid_taxon_name_id).to eq(g1.id)
-        r1.destroy!
+
+        TaxonNameRelationship.find(r1.id).destroy!
+
         g2.reload
         expect(g2.cached_valid_taxon_name_id).to eq(g2.id)
         expect(g2.cached_is_valid).to be_truthy
@@ -347,7 +355,7 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
       # can run after subject_taxon_name was destroyed elsewhere in the same
       # unify chain. If subject_taxon_name was already memoized on r1 before
       # that happened, the belongs_to reader returns the stale,
-      # no-longer-persisted instance rather than nil -- reproduced here by
+      # no-longer-persisted instance rather than nil - reproduced here by
       # memoizing g2 on r1, destroying r1 itself (satisfying the FK on
       # taxon_name_relationships.subject_taxon_name_id) and then g2, and
       # invoking the callback again as the deferred after_commit would.
@@ -355,17 +363,22 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
       # TaxonNameRelationship::OriginalCombination#set_cached_names_for_taxon_names.
       specify 'does not raise when subject_taxon_name is memoized but its row is gone by the time the callback runs' do
         r1 = TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: g2, object_taxon_name: g1)
+        # Without this, the belongs_to reader would just re-query and return
+        # nil directly once g2 is gone below, short-circuiting at `return
+        # true unless t` before ever reaching the #reload this test targets.
         r1.subject_taxon_name # memoize g2 on r1's association cache
 
         r1.destroy! # satisfies the FK, fires the callback once normally (g2 still exists here)
-        g2.destroy!
+        g2.destroy! # g2's row is gone, but r1 still holds the stale memoized instance
 
+        # t.reload (on the stale memoized g2) raises RecordNotFound here -
+        # confirms it's rescued rather than propagating.
         expect { r1.send(:set_cached_names_for_taxon_names) }.not_to raise_error
       end
 
       # set_cached_names_for_taxon_names relies on
       # TaxonNameRelationship#flag_taxon_name_reassignment's ivar, not
-      # _previously_changed?, to notice a reassignment -- because #reload
+      # _previously_changed?, to notice a reassignment - because #reload
       # resets ordinary AR dirty-tracking back to whatever's in the DB, but
       # leaves plain instance variables untouched. Reassign object_taxon_name,
       # then reload that very same r1 instance (as unify's own dedup path
@@ -379,7 +392,11 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
         expect(g2.reload.cached_valid_taxon_name_id).to eq(g1.id)
 
         TaxonNameRelationship.transaction do
+          # object_taxon_name_id_changed? on this save sets the ivar true.
           r1.update(object_taxon_name: g3)
+          # Wipes AR's own dirty-tracking (_previously_changed?) back to
+          # matching the just-saved row, but leaves the ivar untouched -
+          # that's the gap flag_taxon_name_reassignment exists to cover.
           r1.reload
         end
 

--- a/spec/models/taxon_name_relationship_spec.rb
+++ b/spec/models/taxon_name_relationship_spec.rb
@@ -312,6 +312,25 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
         expect(g2.cached_is_valid).to be_truthy
       end
 
+      # The `|| destroyed?` in set_cached_names_for_taxon_names's guard exists
+      # for this case specifically: `_previously_changed?` only reflects
+      # attribute changes from the record's *own* last save, and a plain
+      # destroy doesn't go through an update. Right after .create! that flag
+      # happens to still read true (left over from creation), which would
+      # mask a missing `destroyed?` guard -- reloading r1 first clears it, so
+      # this only passes if destroy on its own re-triggers the cache update.
+      specify 'for cached_valid_taxon_name_id, destroyed after previously_changed? has already reset' do
+        r1 = TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: g2, object_taxon_name: g1)
+        r1.reload
+        expect(r1.subject_taxon_name_id_previously_changed?).to be_falsey
+        g2.reload
+        expect(g2.cached_valid_taxon_name_id).to eq(g1.id)
+        r1.destroy!
+        g2.reload
+        expect(g2.cached_valid_taxon_name_id).to eq(g2.id)
+        expect(g2.cached_is_valid).to be_truthy
+      end
+
       specify 'create misspelling relationship' do
         r3 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s2,
                                type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')

--- a/spec/models/taxon_name_relationship_spec.rb
+++ b/spec/models/taxon_name_relationship_spec.rb
@@ -343,6 +343,26 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
         expect(g2.cached_is_valid).to be_truthy
       end
 
+      # set_cached_names_for_taxon_names's after_commit is deferred, so it
+      # can run after subject_taxon_name was destroyed elsewhere in the same
+      # unify chain. If subject_taxon_name was already memoized on r1 before
+      # that happened, the belongs_to reader returns the stale,
+      # no-longer-persisted instance rather than nil -- reproduced here by
+      # memoizing g2 on r1, destroying r1 itself (satisfying the FK on
+      # taxon_name_relationships.subject_taxon_name_id) and then g2, and
+      # invoking the callback again as the deferred after_commit would.
+      # Mirrors the identical fix on
+      # TaxonNameRelationship::OriginalCombination#set_cached_names_for_taxon_names.
+      specify 'does not raise when subject_taxon_name is memoized but its row is gone by the time the callback runs' do
+        r1 = TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: g2, object_taxon_name: g1)
+        r1.subject_taxon_name # memoize g2 on r1's association cache
+
+        r1.destroy! # satisfies the FK, fires the callback once normally (g2 still exists here)
+        g2.destroy!
+
+        expect { r1.send(:set_cached_names_for_taxon_names) }.not_to raise_error
+      end
+
       specify 'create misspelling relationship' do
         r3 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s2,
                                type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')

--- a/spec/models/taxon_name_relationship_spec.rb
+++ b/spec/models/taxon_name_relationship_spec.rb
@@ -363,6 +363,29 @@ describe TaxonNameRelationship, type: :model, group: [:nomenclature] do
         expect { r1.send(:set_cached_names_for_taxon_names) }.not_to raise_error
       end
 
+      # set_cached_names_for_taxon_names relies on
+      # TaxonNameRelationship#flag_taxon_name_reassignment's ivar, not
+      # _previously_changed?, to notice a reassignment -- because #reload
+      # resets ordinary AR dirty-tracking back to whatever's in the DB, but
+      # leaves plain instance variables untouched. Reassign object_taxon_name,
+      # then reload that very same r1 instance (as unify's own dedup path
+      # does elsewhere in the same transaction) before letting the
+      # transaction close: the deferred after_commit still has to pick up
+      # the reassignment via the ivar, since _previously_changed? alone
+      # would already read false by the time it runs.
+      specify 'cached_valid_taxon_name_id updates after the reassigning instance is reloaded before commit' do
+        g3 = FactoryBot.create(:relationship_genus, name: 'Cus', parent: family)
+        r1 = TaxonNameRelationship::Iczn::Invalidating::Synonym.create!(subject_taxon_name: g2, object_taxon_name: g1)
+        expect(g2.reload.cached_valid_taxon_name_id).to eq(g1.id)
+
+        TaxonNameRelationship.transaction do
+          r1.update(object_taxon_name: g3)
+          r1.reload
+        end
+
+        expect(g2.reload.cached_valid_taxon_name_id).to eq(g3.id)
+      end
+
       specify 'create misspelling relationship' do
         r3 = FactoryBot.create(:taxon_name_relationship, subject_taxon_name: s1, object_taxon_name: s2,
                                type: 'TaxonNameRelationship::Iczn::Invalidating::Usage::Misspelling')


### PR DESCRIPTION
These are commits cherry-picked from https://github.com/SpeciesFileGroup/taxonworks/pull/5030

It contains the original fixes reviewed by @mjy plus a followup commit I had locally that fixes a bug in the initial acts_as_list restore fix.

All of the commits for issue **D** plus more I haven't submitted yet will appear in a later release.